### PR TITLE
Fix paddings in model lists

### DIFF
--- a/app/model-hub.tsx
+++ b/app/model-hub.tsx
@@ -79,22 +79,27 @@ const ModelHubScreen = () => {
     <>
       <WithDrawerGesture>
         <View style={styles.container}>
-          <TextFieldInput
-            value={search}
-            onChangeText={setSearch}
-            placeholder="Search Models..."
-            icon={
-              <SearchIcon
-                width={20}
-                height={20}
-                style={{ color: theme.text.primary }}
-              />
-            }
-          />
+          <View style={styles.horizontalInset}>
+            <TextFieldInput
+              value={search}
+              onChangeText={setSearch}
+              placeholder="Search Models..."
+              icon={
+                <SearchIcon
+                  width={20}
+                  height={20}
+                  style={{ color: theme.text.primary }}
+                />
+              }
+            />
+          </View>
           <View>
             <ScrollView
               horizontal
-              contentContainerStyle={styles.tagContainer}
+              contentContainerStyle={[
+                styles.tagContainer,
+                styles.horizontalInset,
+              ]}
               showsHorizontalScrollIndicator={false}
             >
               <SortingTag
@@ -112,7 +117,12 @@ const ModelHubScreen = () => {
           {isEmpty ? (
             renderEmptyState()
           ) : (
-            <ScrollView contentContainerStyle={styles.modelScrollContent}>
+            <ScrollView
+              contentContainerStyle={[
+                styles.modelScrollContent,
+                styles.horizontalInset,
+              ]}
+            >
               {groupByModel && groupedModels ? (
                 <GroupedModelList
                   groupedModels={groupedModels}
@@ -146,15 +156,19 @@ const createStyles = (theme: Theme) =>
   StyleSheet.create({
     container: {
       flex: 1,
-      gap: 16,
-      padding: 16,
+      gap: 24,
+      paddingTop: 16,
       backgroundColor: theme.bg.softPrimary,
+    },
+    horizontalInset: {
+      paddingHorizontal: 16,
     },
     noModelsContainer: {
       flex: 1,
       justifyContent: 'center',
       alignItems: 'center',
       gap: 24,
+      padding: 16,
     },
     emptyIconWrapper: {
       backgroundColor: theme.bg.softSecondary,
@@ -184,7 +198,5 @@ const createStyles = (theme: Theme) =>
     tagContainer: {
       gap: 8,
       alignItems: 'center',
-      paddingVertical: 8,
-      paddingRight: 8,
     },
   });

--- a/components/bottomSheets/ModelSelectSheet.tsx
+++ b/components/bottomSheets/ModelSelectSheet.tsx
@@ -8,6 +8,7 @@ import {
 } from '@gorhom/bottom-sheet';
 import { router } from 'expo-router';
 import { View, StyleSheet, Text, Platform } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useModelStore } from '../../store/modelStore';
 import { useTheme } from '../../context/ThemeContext';
 import { fontFamily, fontSizes } from '../../styles/fontStyles';
@@ -45,6 +46,8 @@ const ModelSelectSheet = ({ bottomSheetModalRef, selectModel }: Props) => {
     [styles.backdrop]
   );
 
+  const insets = useSafeAreaInsets();
+
   return (
     <BottomSheetModal
       ref={bottomSheetModalRef}
@@ -60,36 +63,48 @@ const ModelSelectSheet = ({ bottomSheetModalRef, selectModel }: Props) => {
     >
       {downloadedModels.length > 0 ? (
         <View style={styles.content}>
-          <Text style={styles.title}>Select a Model</Text>
+          <Text style={[styles.title, styles.horizontalInset]}>
+            Select a Model
+          </Text>
           {Platform.OS === 'ios' && (
-            <View
-              style={[
-                styles.inputWrapper,
-                {
-                  borderColor: active
-                    ? theme.bg.strongPrimary
-                    : theme.border.soft,
-                  borderWidth: active ? 2 : 1,
-                },
-              ]}
-            >
-              <SearchIcon width={20} height={20} style={styles.searchIcon} />
-              <BottomSheetTextInput
-                style={styles.input}
-                value={search}
-                onChangeText={setSearch}
-                placeholder="Search Models..."
-                placeholderTextColor={theme.text.defaultTertiary}
-                onFocus={() => setActive(true)}
-                onBlur={() => setActive(false)}
-              />
+            <View style={styles.horizontalInset}>
+              <View
+                style={[
+                  styles.inputWrapper,
+                  {
+                    borderColor: active
+                      ? theme.bg.strongPrimary
+                      : theme.border.soft,
+                    borderWidth: active ? 2 : 1,
+                  },
+                ]}
+              >
+                <SearchIcon width={20} height={20} style={styles.searchIcon} />
+                <BottomSheetTextInput
+                  style={styles.input}
+                  value={search}
+                  onChangeText={setSearch}
+                  placeholder="Search Models..."
+                  placeholderTextColor={theme.text.defaultTertiary}
+                  onFocus={() => setActive(true)}
+                  onBlur={() => setActive(false)}
+                />
+              </View>
             </View>
           )}
 
           <BottomSheetFlatList
             data={filteredModels}
             keyExtractor={(item) => item.id.toString()}
-            contentContainerStyle={styles.modelList}
+            // only frist two styles appear to be forwarded, so the array is
+            // nested to make all styles be part of the first item
+            contentContainerStyle={[
+              [
+                styles.modelList,
+                styles.horizontalInset,
+                { paddingBottom: insets.bottom + 16 },
+              ],
+            ]}
             renderItem={({ item }) => (
               <ModelCard
                 model={item}
@@ -102,7 +117,7 @@ const ModelSelectSheet = ({ bottomSheetModalRef, selectModel }: Props) => {
           />
         </View>
       ) : (
-        <BottomSheetView style={styles.content}>
+        <BottomSheetView style={[styles.content, styles.horizontalInset]}>
           <Text style={styles.title}>You have no available models yet</Text>
           <Text style={styles.subText}>
             To use Private Mind you need to have at least one model downloaded
@@ -144,9 +159,12 @@ const createStyles = (theme: Theme) =>
       backgroundColor: theme.bg.overlay,
     },
     content: {
-      paddingVertical: 16,
-      paddingHorizontal: 24,
+      flex: 1,
+      paddingTop: 16,
       gap: 24,
+    },
+    horizontalInset: {
+      paddingHorizontal: 24,
     },
     title: {
       fontSize: fontSizes.lg,
@@ -178,6 +196,5 @@ const createStyles = (theme: Theme) =>
     },
     modelList: {
       gap: 8,
-      paddingBottom: 120,
     },
   });


### PR DESCRIPTION
- moves scroll indicator to screen edge in model select bottom sheet and models screen
  - Fixes #47 
- models bottom sheet:
  - fixes the list being placed past bottom screen edge
  - applies inset to push last item into safe area — Fixes #50 

<details>
<summary>screenshot (indicator position)</summary>
<img width="1184" height="1280" alt="image" src="https://github.com/user-attachments/assets/a1d6616f-89f2-494f-abae-14a72be9dc50" />
</details>
