### PR TITLE
fix: avoid layout shifts when focusing text inputs

### DIFF
--- a/components/TextAreaField.tsx
+++ b/components/TextAreaField.tsx
@@ -3,6 +3,7 @@ import { TextInput, StyleSheet, View, TextInputProps } from 'react-native';
 import { useTheme } from '../context/ThemeContext';
 import { fontFamily, fontSizes } from '../styles/fontStyles';
 import { Theme } from '../styles/colors';
+import TextInputBorder from './TextInputBorder';
 
 type TextAreaFieldProps = TextInputProps & {
   value: string;
@@ -19,10 +20,11 @@ const TextAreaField: React.FC<TextAreaFieldProps> = ({
 }) => {
   const { theme } = useTheme();
   const [active, setActive] = useState(false);
-  const styles = useMemo(() => createStyles(theme, active), [theme, active]);
+  const styles = useMemo(() => createStyles(theme), [theme]);
 
   return (
     <View style={styles.inputWrapper}>
+      <TextInputBorder active={active} />
       <TextInput
         value={value}
         onChangeText={onChangeText}
@@ -44,14 +46,11 @@ const TextAreaField: React.FC<TextAreaFieldProps> = ({
 
 export default TextAreaField;
 
-const createStyles = (theme: Theme, active: boolean) =>
+const createStyles = (theme: Theme) =>
   StyleSheet.create({
     inputWrapper: {
-      borderRadius: 12,
       paddingHorizontal: 16,
       paddingVertical: 12,
-      borderWidth: active ? 2 : 1,
-      borderColor: active ? theme.bg.strongPrimary : theme.border.soft,
     },
     textArea: {
       height: 120,

--- a/components/TextFieldInput.tsx
+++ b/components/TextFieldInput.tsx
@@ -3,6 +3,7 @@ import { TextInput, StyleSheet, View, TextInputProps } from 'react-native';
 import { useTheme } from '../context/ThemeContext';
 import { fontFamily, fontSizes } from '../styles/fontStyles';
 import { Theme } from '../styles/colors';
+import TextInputBorder from './TextInputBorder';
 
 type TextFieldInputProps = TextInputProps & {
   value: string;
@@ -23,12 +24,13 @@ const TextFieldInput: React.FC<TextFieldInputProps> = ({
   const [active, setActive] = useState(false);
 
   const styles = useMemo(
-    () => createStyles(theme, active, !!icon, props.editable !== false),
-    [theme, active, icon, props.editable]
+    () => createStyles(theme, !!icon, props.editable !== false),
+    [theme, icon, props.editable]
   );
 
   return (
     <View style={styles.inputWrapper}>
+      <TextInputBorder active={active} />
       {icon}
       <TextInput
         value={value}
@@ -51,7 +53,6 @@ export default TextFieldInput;
 
 const createStyles = (
   theme: Theme,
-  active: boolean,
   hasIcon: boolean,
   isEditable: boolean = true
 ) =>
@@ -60,11 +61,8 @@ const createStyles = (
       flexDirection: 'row',
       alignItems: 'center',
       gap: 8,
-      borderRadius: 12,
       paddingHorizontal: 16,
       paddingVertical: 12,
-      borderWidth: active ? 2 : 1,
-      borderColor: active ? theme.bg.strongPrimary : theme.border.soft,
     },
     input: {
       width: hasIcon ? '90%' : '100%',

--- a/components/TextInputBorder.tsx
+++ b/components/TextInputBorder.tsx
@@ -1,0 +1,39 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Theme } from '../styles/colors';
+import { useTheme } from '../context/ThemeContext';
+
+interface TextInputBorderProps {
+  active: boolean;
+}
+
+/**
+ * Place inside a view wrapping a text input - it'll match dimensions of its parent.
+ */
+const TextInputBorder: React.FC<TextInputBorderProps> = ({ active }) => {
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <View style={[styles.common, active ? styles.active : styles.inactive]} />
+  );
+};
+
+export default TextInputBorder;
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    common: {
+      borderRadius: 12,
+      pointerEvents: 'none',
+      ...StyleSheet.absoluteFillObject,
+    },
+    inactive: {
+      borderWidth: 1,
+      borderColor: theme.border.soft,
+    },
+    active: {
+      borderWidth: 2,
+      borderColor: theme.bg.strongPrimary,
+    },
+  });

--- a/components/bottomSheets/ModelSelectSheet.tsx
+++ b/components/bottomSheets/ModelSelectSheet.tsx
@@ -16,6 +16,7 @@ import { Model } from '../../database/modelRepository';
 import ModelCard from '../model-hub/ModelCard';
 import PrimaryButton from '../PrimaryButton';
 import SearchIcon from '../../assets/icons/search.svg';
+import TextInputBorder from '../TextInputBorder';
 
 interface Props {
   bottomSheetModalRef: RefObject<BottomSheetModal | null>;
@@ -62,17 +63,8 @@ const ModelSelectSheet = ({ bottomSheetModalRef, selectModel }: Props) => {
         <View style={styles.content}>
           <Text style={styles.title}>Select a Model</Text>
           {Platform.OS === 'ios' && (
-            <View
-              style={[
-                styles.inputWrapper,
-                {
-                  borderColor: active
-                    ? theme.bg.strongPrimary
-                    : theme.border.soft,
-                  borderWidth: active ? 2 : 1,
-                },
-              ]}
-            >
+            <View style={styles.inputWrapper}>
+              <TextInputBorder active={active} />
               <SearchIcon width={20} height={20} style={styles.searchIcon} />
               <BottomSheetTextInput
                 style={styles.input}
@@ -159,7 +151,6 @@ const createStyles = (theme: Theme) =>
       color: theme.text.defaultSecondary,
     },
     inputWrapper: {
-      borderRadius: 12,
       paddingHorizontal: 16,
       paddingVertical: 12,
       flexDirection: 'row',

--- a/components/model-hub/SortingTag.tsx
+++ b/components/model-hub/SortingTag.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Text, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { useTheme } from '../../context/ThemeContext';
 import { fontSizes, fontFamily } from '../../styles/fontStyles';
 import { Theme } from '../../styles/colors';
@@ -22,6 +22,7 @@ const SortingTag = ({ text, selected, onPress }: Props) => {
     <TouchableOpacity style={styles.container} onPress={onPress}>
       <Text style={styles.text}>{text}</Text>
       {selected && <CheckIcon width={20} height={20} style={styles.icon} />}
+      <View style={styles.border} />
     </TouchableOpacity>
   );
 };
@@ -32,21 +33,28 @@ const createStyles = (theme: Theme, selected: boolean) =>
   StyleSheet.create({
     container: {
       gap: 8,
-      padding: 12,
+      paddingHorizontal: 12,
       justifyContent: 'center',
       alignItems: 'center',
       borderRadius: 9999,
-      borderWidth: selected ? 2 : 1,
-      borderColor: selected ? theme.bg.strongPrimary : theme.border.soft,
       flexDirection: 'row',
       maxHeight: 44,
+      minHeight: 20,
     },
     text: {
       fontFamily: selected ? fontFamily.medium : fontFamily.regular,
       fontSize: fontSizes.sm,
       color: theme.text.primary,
+      marginVertical: 12,
     },
     icon: {
       color: theme.text.primary,
+    },
+    border: {
+      pointerEvents: 'none',
+      ...StyleSheet.absoluteFillObject,
+      borderRadius: 9999,
+      borderWidth: selected ? 2 : 1,
+      borderColor: selected ? theme.bg.strongPrimary : theme.border.soft,
     },
   });


### PR DESCRIPTION
Fixes #49 
- applies border styles to a separate view that overlaps the text field, so border width changes don't influence layout
- extracted to a component to share the styles between `TextFieldInput`, `BottomSheetTextInput`, and `TextAreaField`

| <video src="https://github.com/user-attachments/assets/b46353ee-50c8-4835-b8d7-192bd1173e0a" /> | <video src="https://github.com/user-attachments/assets/499a84bd-a62c-4aa0-972f-ada66334f471" /> |
| --- | --- |
