### PR TITLE
fix: use react-native-keyboard-controller for keyboard handling

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,9 +1,8 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-  <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+  <style name="AppTheme" parent="Theme.EdgeToEdge">
     <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="android:statusBarColor">#ffffff</item>
-    <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:targetApi="35">true</item>
   </style>
   <style name="Theme.App.SplashScreen" parent="Theme.SplashScreen">
     <item name="windowSplashScreenBackground">@color/splashscreen_background</item>

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -58,4 +58,4 @@ expo.useLegacyPackaging=false
 expo.sqlite.enableFTS=false
 expo.sqlite.useSQLCipher=false
 # Whether the app is configured to use edge-to-edge via the app config or `react-native-edge-to-edge` plugin
-expo.edgeToEdgeEnabled=false
+expo.edgeToEdgeEnabled=true

--- a/app.json
+++ b/app.json
@@ -62,7 +62,8 @@
         "foregroundImage": "./assets/icons/icon.png",
         "backgroundColor": "#ffffff"
       },
-      "package": "com.swmansion.privatemind"
+      "package": "com.swmansion.privatemind",
+      "edgeToEdgeEnabled": true
     }
   }
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,6 +16,7 @@ import {
 import { fontFamily } from '../styles/fontStyles';
 import { ThemeProvider } from '../context/ThemeContext';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
+import { KeyboardProvider } from 'react-native-keyboard-controller';
 
 export default function Layout() {
   useFonts({
@@ -31,88 +32,90 @@ export default function Layout() {
     <GestureHandlerRootView>
       <SQLiteProvider databaseName="executorch.db" onInit={initDatabase}>
         <ThemeProvider>
-          <BottomSheetModalProvider>
-            <CustomDrawerLayout>
-              <Stack
-                screenOptions={{
-                  headerShadowVisible: false,
-                }}
-              >
-                <Stack.Screen
-                  name="model-hub"
-                  options={{
-                    title: 'Models',
-                    gestureEnabled: false,
-                    animation: 'none',
+          <KeyboardProvider>
+            <BottomSheetModalProvider>
+              <CustomDrawerLayout>
+                <Stack
+                  screenOptions={{
+                    headerShadowVisible: false,
                   }}
-                />
-                <Stack.Screen
-                  name="index"
-                  options={{
-                    title: '',
-                    animation: 'none',
-                    gestureEnabled: false,
-                  }}
-                />
-                <Stack.Screen
-                  name="benchmark"
-                  options={{
-                    title: 'Benchmark',
-                    gestureEnabled: false,
-                    animation: 'none',
-                  }}
-                />
-                <Stack.Screen
-                  name="chat/[id]"
-                  options={{ animation: 'none', gestureEnabled: false }}
-                />
-                <Stack.Screen
-                  name="chat/[id]/settings"
-                  options={{
-                    title: 'Chat Settings',
-                    presentation: 'modal',
-                    headerShown: false,
-                  }}
-                />
-                <Stack.Screen
-                  name="modal/add-local-model"
-                  options={{
-                    presentation: 'modal',
-                    title: 'Add Model',
-                    headerShown: false,
-                  }}
-                />
-                <Stack.Screen
-                  name="modal/add-remote-model"
-                  options={{
-                    presentation: 'modal',
-                    headerShown: false,
-                  }}
-                />
-                <Stack.Screen
-                  name="modal/edit-local-model/[modelId]"
-                  options={{
-                    presentation: 'modal',
-                    headerShown: false,
-                  }}
-                />
-                <Stack.Screen
-                  name="modal/edit-remote-model/[modelId]"
-                  options={{
-                    presentation: 'modal',
-                    headerShown: false,
-                  }}
-                />
-                <Stack.Screen
-                  name="modal/app-info"
-                  options={{
-                    presentation: 'modal',
-                    headerShown: false,
-                  }}
-                />
-              </Stack>
-            </CustomDrawerLayout>
-          </BottomSheetModalProvider>
+                >
+                  <Stack.Screen
+                    name="model-hub"
+                    options={{
+                      title: 'Models',
+                      gestureEnabled: false,
+                      animation: 'none',
+                    }}
+                  />
+                  <Stack.Screen
+                    name="index"
+                    options={{
+                      title: '',
+                      animation: 'none',
+                      gestureEnabled: false,
+                    }}
+                  />
+                  <Stack.Screen
+                    name="benchmark"
+                    options={{
+                      title: 'Benchmark',
+                      gestureEnabled: false,
+                      animation: 'none',
+                    }}
+                  />
+                  <Stack.Screen
+                    name="chat/[id]"
+                    options={{ animation: 'none', gestureEnabled: false }}
+                  />
+                  <Stack.Screen
+                    name="chat/[id]/settings"
+                    options={{
+                      title: 'Chat Settings',
+                      presentation: 'modal',
+                      headerShown: false,
+                    }}
+                  />
+                  <Stack.Screen
+                    name="modal/add-local-model"
+                    options={{
+                      presentation: 'modal',
+                      title: 'Add Model',
+                      headerShown: false,
+                    }}
+                  />
+                  <Stack.Screen
+                    name="modal/add-remote-model"
+                    options={{
+                      presentation: 'modal',
+                      headerShown: false,
+                    }}
+                  />
+                  <Stack.Screen
+                    name="modal/edit-local-model/[modelId]"
+                    options={{
+                      presentation: 'modal',
+                      headerShown: false,
+                    }}
+                  />
+                  <Stack.Screen
+                    name="modal/edit-remote-model/[modelId]"
+                    options={{
+                      presentation: 'modal',
+                      headerShown: false,
+                    }}
+                  />
+                  <Stack.Screen
+                    name="modal/app-info"
+                    options={{
+                      presentation: 'modal',
+                      headerShown: false,
+                    }}
+                  />
+                </Stack>
+              </CustomDrawerLayout>
+            </BottomSheetModalProvider>
+          </KeyboardProvider>
         </ThemeProvider>
       </SQLiteProvider>
     </GestureHandlerRootView>

--- a/app/benchmark.tsx
+++ b/app/benchmark.tsx
@@ -74,15 +74,17 @@ const BenchmarkScreen = () => {
     <>
       <WithDrawerGesture>
         <View style={styles.container}>
-          <ModelSelector
-            model={selectedModel}
-            setSelectedModel={setSelectedModel}
-          />
-          <PrimaryButton
-            disabled={!selectedModel || isRunning}
-            text="Run benchmark"
-            onPress={() => startBenchmark(selectedModel)}
-          />
+          <View style={styles.controls}>
+            <ModelSelector
+              model={selectedModel}
+              setSelectedModel={setSelectedModel}
+            />
+            <PrimaryButton
+              disabled={!selectedModel || isRunning}
+              text="Run benchmark"
+              onPress={() => startBenchmark(selectedModel)}
+            />
+          </View>
           <BenchmarkHistory
             modalRef={bottomSheetModalRef}
             benchmarkList={benchmarkList}
@@ -112,8 +114,11 @@ const createStyles = (theme: Theme) =>
   StyleSheet.create({
     container: {
       flex: 1,
-      padding: 16,
       gap: 16,
       backgroundColor: theme.bg.softPrimary,
+    },
+    controls: {
+      paddingHorizontal: 16,
+      gap: 16,
     },
   });

--- a/app/chat/[id]/settings.tsx
+++ b/app/chat/[id]/settings.tsx
@@ -1,13 +1,5 @@
 import React, { RefObject, useMemo, useRef } from 'react';
-import {
-  Text,
-  StyleSheet,
-  ScrollView,
-  View,
-  KeyboardAvoidingView,
-  Platform,
-  Alert,
-} from 'react-native';
+import { StyleSheet, ScrollView, View, Alert } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
 import { setChatSettings } from '../../../database/chatRepository';
 import { useSQLiteContext } from 'expo-sqlite';
@@ -18,17 +10,16 @@ import { useChatStore } from '../../../store/chatStore';
 import ModalHeader from '../../../components/ModalHeader';
 import Toast from 'react-native-toast-message';
 import { exportChatRoom } from '../../../database/exportImportRepository';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Theme } from '../../../styles/colors';
 import useChatSettings from '../../../hooks/useChatSettings';
 import ChatSettingsForm from '../../../components/settings/ChatSettingsForm';
+import { CustomKeyboardAvoidingView } from '../../../components/CustomKeyboardAvoidingView';
 
 export default function ChatSettingsScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const chatId = Number(id) || null;
 
   const scrollViewRef = useRef<ScrollView>(null);
-  const insets = useSafeAreaInsets();
   const db = useSQLiteContext();
   const { theme } = useTheme();
   const { getModelById } = useModelStore();
@@ -100,10 +91,9 @@ export default function ChatSettingsScreen() {
   };
 
   return (
-    <KeyboardAvoidingView
+    <CustomKeyboardAvoidingView
+      isModalScreen
       style={styles.keyboardAvoidingView}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      keyboardVerticalOffset={Platform.OS === 'ios' ? 16 + insets.bottom : 0}
     >
       <View style={styles.container}>
         <ModalHeader title="Chat Settings" onClose={() => router.back()} />
@@ -119,7 +109,7 @@ export default function ChatSettingsScreen() {
         />
         <PrimaryButton text="Save changes" onPress={handleSave} />
       </View>
-    </KeyboardAvoidingView>
+    </CustomKeyboardAvoidingView>
   );
 }
 
@@ -132,7 +122,7 @@ const createStyles = (theme: Theme) =>
     container: {
       flex: 1,
       padding: 16,
+      paddingBottom: theme.insets.bottom + 16,
       justifyContent: 'space-between',
-      paddingBottom: Platform.OS === 'ios' ? 24 : 0,
     },
   });

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -115,7 +115,7 @@ const createStyles = (theme: Theme) =>
     container: {
       flex: 1,
       backgroundColor: theme.bg.softPrimary,
-      paddingBottom: Platform.OS === 'android' ? 20 : 0,
+      paddingBottom: 16 + theme.insets.bottom,
     },
     emptyContainer: {
       flex: 1,

--- a/app/modal/add-local-model.tsx
+++ b/app/modal/add-local-model.tsx
@@ -1,12 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import {
-  Text,
-  StyleSheet,
-  Alert,
-  KeyboardAvoidingView,
-  Platform,
-  View,
-} from 'react-native';
+import { Text, StyleSheet, Alert, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useModelStore } from '../../store/modelStore';
 import ModalHeader from '../../components/ModalHeader';
@@ -17,6 +10,7 @@ import { ScrollView } from 'react-native-gesture-handler';
 import UploadInput from '../../components/UploadInput';
 import Toast from 'react-native-toast-message';
 import { Theme } from '../../styles/colors';
+import { CustomKeyboardAvoidingView } from '../../components/CustomKeyboardAvoidingView';
 
 type LocalFile = {
   name: string;
@@ -78,10 +72,9 @@ export default function AddLocalModelScreen() {
   };
 
   return (
-    <KeyboardAvoidingView
+    <CustomKeyboardAvoidingView
+      isModalScreen
       style={styles.keyboardAvoidingView}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      keyboardVerticalOffset={Platform.OS === 'ios' ? 50 : 0}
     >
       <View style={styles.container}>
         <ModalHeader title="Add Local Model" onClose={() => router.back()} />
@@ -118,7 +111,7 @@ export default function AddLocalModelScreen() {
         </ScrollView>
         <PrimaryButton text="Add model" onPress={handleSave} />
       </View>
-    </KeyboardAvoidingView>
+    </CustomKeyboardAvoidingView>
   );
 }
 
@@ -131,7 +124,7 @@ const createStyles = (theme: Theme) =>
     container: {
       flex: 1,
       padding: 16,
-      paddingBottom: Platform.OS === 'ios' ? 24 : 0,
+      paddingBottom: theme.insets.bottom + 16,
       justifyContent: 'space-between',
     },
     scrollViewContent: {

--- a/app/modal/add-remote-model.tsx
+++ b/app/modal/add-remote-model.tsx
@@ -1,12 +1,5 @@
 import React, { useMemo, useRef, useState } from 'react';
-import {
-  Text,
-  StyleSheet,
-  Alert,
-  KeyboardAvoidingView,
-  Platform,
-  View,
-} from 'react-native';
+import { Text, StyleSheet, Alert, Platform, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useModelStore } from '../../store/modelStore';
 import ModalHeader from '../../components/ModalHeader';
@@ -16,8 +9,8 @@ import { useTheme } from '../../context/ThemeContext';
 import PrimaryButton from '../../components/PrimaryButton';
 import { ScrollView } from 'react-native-gesture-handler';
 import Toast from 'react-native-toast-message';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Theme } from '../../styles/colors';
+import { CustomKeyboardAvoidingView } from '../../components/CustomKeyboardAvoidingView';
 
 export interface RemoteModelFormState {
   remoteModelPath: string;
@@ -31,7 +24,6 @@ export default function AddRemoteModelScreen() {
   const styles = useMemo(() => createStyles(theme), [theme]);
   const scrollViewRef = useRef<ScrollView>(null);
   const { addModelToDB } = useModelStore();
-  const insets = useSafeAreaInsets();
 
   const [
     { remoteModelPath, remoteTokenizerPath, remoteTokenizerConfigPath },
@@ -90,10 +82,9 @@ export default function AddRemoteModelScreen() {
   };
 
   return (
-    <KeyboardAvoidingView
+    <CustomKeyboardAvoidingView
+      isModalScreen
       style={styles.keyboardAvoidingView}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      keyboardVerticalOffset={Platform.OS === 'ios' ? 16 + insets.bottom : 0}
     >
       <View style={styles.container}>
         <ModalHeader title="Add External Model" onClose={() => router.back()} />
@@ -143,7 +134,7 @@ export default function AddRemoteModelScreen() {
         </ScrollView>
         <PrimaryButton text="Add model" onPress={handleSave} />
       </View>
-    </KeyboardAvoidingView>
+    </CustomKeyboardAvoidingView>
   );
 }
 
@@ -156,7 +147,7 @@ const createStyles = (theme: Theme) =>
     container: {
       flex: 1,
       padding: 16,
-      paddingBottom: Platform.OS === 'ios' ? 24 : 0,
+      paddingBottom: theme.insets.bottom + 16,
       justifyContent: 'space-between',
     },
     scrollViewContent: {

--- a/app/modal/app-info.tsx
+++ b/app/modal/app-info.tsx
@@ -10,6 +10,7 @@ import {
 import { useRouter } from 'expo-router';
 import Clipboard from '@react-native-clipboard/clipboard';
 import Toast from 'react-native-toast-message';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { fontSizes, fontFamily } from '../../styles/fontStyles';
 import { useTheme } from '../../context/ThemeContext';
 import ModalHeader from '../../components/ModalHeader';
@@ -125,10 +126,11 @@ const VersionInfo = () => {
 export default function AppInfoScreen() {
   const router = useRouter();
   const { theme } = useTheme();
+  const insets = useSafeAreaInsets();
 
   return (
     <View style={[styles.screen, { backgroundColor: theme.bg.softPrimary }]}>
-      <View style={styles.container}>
+      <View style={[styles.container, { paddingBottom: insets.bottom }]}>
         <ModalHeader title="App info" onClose={() => router.back()} />
         <AppHeader />
         <LearnMoreSection />
@@ -148,7 +150,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     padding: 16,
-    paddingBottom: Platform.OS === 'ios' ? 16 : 0,
     gap: 16,
   },
   card: {

--- a/app/modal/edit-local-model/[modelId].tsx
+++ b/app/modal/edit-local-model/[modelId].tsx
@@ -1,12 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import {
-  Text,
-  StyleSheet,
-  KeyboardAvoidingView,
-  Platform,
-  View,
-  Alert,
-} from 'react-native';
+import { Text, StyleSheet, View, Alert } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useModelStore } from '../../../store/modelStore';
 import ModalHeader from '../../../components/ModalHeader';
@@ -20,6 +13,7 @@ import TextFieldInput from '../../../components/TextFieldInput';
 import Toast from 'react-native-toast-message';
 import { Theme } from '../../../styles/colors';
 import { LocalModelFormState } from '../add-local-model';
+import { CustomKeyboardAvoidingView } from '../../../components/CustomKeyboardAvoidingView';
 
 type LocalFile = {
   name: string;
@@ -90,10 +84,9 @@ export default function EditLocalModelScreen() {
   };
 
   return (
-    <KeyboardAvoidingView
+    <CustomKeyboardAvoidingView
+      isModalScreen
       style={styles.keyboardAvoidingView}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      keyboardVerticalOffset={Platform.OS === 'ios' ? 50 : 0}
     >
       <View style={styles.container}>
         <ModalHeader title="Edit Local Model" onClose={() => router.back()} />
@@ -136,7 +129,7 @@ export default function EditLocalModelScreen() {
         </ScrollView>
         <PrimaryButton text="Save changes" onPress={handleSave} />
       </View>
-    </KeyboardAvoidingView>
+    </CustomKeyboardAvoidingView>
   );
 }
 
@@ -149,7 +142,7 @@ const createStyles = (theme: Theme) =>
     container: {
       flex: 1,
       padding: 16,
-      paddingBottom: 32,
+      paddingBottom: theme.insets.bottom + 16,
       justifyContent: 'space-between',
     },
     scrollViewContent: {

--- a/app/modal/edit-remote-model/[modelId].tsx
+++ b/app/modal/edit-remote-model/[modelId].tsx
@@ -1,12 +1,5 @@
 import React, { useMemo, useRef, useState } from 'react';
-import {
-  Text,
-  StyleSheet,
-  Alert,
-  KeyboardAvoidingView,
-  Platform,
-  View,
-} from 'react-native';
+import { Text, StyleSheet, Alert, Platform, View } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useModelStore } from '../../../store/modelStore';
 import ModalHeader from '../../../components/ModalHeader';
@@ -17,9 +10,9 @@ import PrimaryButton from '../../../components/PrimaryButton';
 import { ScrollView } from 'react-native-gesture-handler';
 import Toast from 'react-native-toast-message';
 import { InfoAlert } from '../../../components/InfoAlert';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Theme } from '../../../styles/colors';
 import { RemoteModelFormState } from '../add-remote-model';
+import { CustomKeyboardAvoidingView } from '../../../components/CustomKeyboardAvoidingView';
 
 interface EditModelFormState extends RemoteModelFormState {
   modelName: string;
@@ -28,7 +21,6 @@ interface EditModelFormState extends RemoteModelFormState {
 export default function EditRemoteModelScreen() {
   const { modelId: rawModelId } = useLocalSearchParams<{ modelId: string }>();
   const modelId = parseInt(rawModelId);
-  const insets = useSafeAreaInsets();
   const scrollViewRef = useRef<ScrollView>(null);
   const router = useRouter();
 
@@ -93,10 +85,9 @@ export default function EditRemoteModelScreen() {
   };
 
   return (
-    <KeyboardAvoidingView
+    <CustomKeyboardAvoidingView
+      isModalScreen
       style={styles.keyboardAvoidingView}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      keyboardVerticalOffset={Platform.OS === 'ios' ? 16 + insets.bottom : 0}
     >
       <View style={styles.container}>
         <ModalHeader title="Edit Remote Model" onClose={() => router.back()} />
@@ -148,7 +139,7 @@ export default function EditRemoteModelScreen() {
         </ScrollView>
         <PrimaryButton text="Save changes" onPress={handleSave} />
       </View>
-    </KeyboardAvoidingView>
+    </CustomKeyboardAvoidingView>
   );
 }
 
@@ -161,7 +152,7 @@ const createStyles = (theme: Theme) =>
     container: {
       flex: 1,
       padding: 16,
-      paddingBottom: Platform.OS === 'ios' ? 16 : 0,
+      paddingBottom: theme.insets.bottom + 16,
       justifyContent: 'space-between',
     },
     scrollViewContent: {

--- a/app/model-hub.tsx
+++ b/app/model-hub.tsx
@@ -21,6 +21,7 @@ import useModelHubData from '../hooks/useModelHubData';
 import { Model } from '../database/modelRepository';
 import GroupedModelList from '../components/model-hub/GroupedModelList';
 import StandardModelList from '../components/model-hub/StandardModelList';
+import { CustomKeyboardAvoidingView } from '../components/CustomKeyboardAvoidingView';
 
 const ModelHubScreen = () => {
   useDefaultHeader();
@@ -76,7 +77,7 @@ const ModelHubScreen = () => {
   );
 
   return (
-    <>
+    <CustomKeyboardAvoidingView style={styles.keyboardAvoidingView}>
       <WithDrawerGesture>
         <View style={styles.container}>
           <View style={styles.horizontalInset}>
@@ -146,7 +147,7 @@ const ModelHubScreen = () => {
       <ModelManagementSheet bottomSheetModalRef={modelManagementSheetRef} />
       <AddModelSheet bottomSheetModalRef={addModelSheetRef} />
       <MemoryWarningSheet bottomSheetModalRef={memoryWarningSheetRef} />
-    </>
+    </CustomKeyboardAvoidingView>
   );
 };
 
@@ -154,11 +155,14 @@ export default ModelHubScreen;
 
 const createStyles = (theme: Theme) =>
   StyleSheet.create({
+    keyboardAvoidingView: {
+      flex: 1,
+      backgroundColor: theme.bg.softPrimary,
+    },
     container: {
       flex: 1,
       gap: 24,
       paddingTop: 16,
-      backgroundColor: theme.bg.softPrimary,
     },
     horizontalInset: {
       paddingHorizontal: 16,
@@ -194,6 +198,8 @@ const createStyles = (theme: Theme) =>
     },
     modelScrollContent: {
       gap: 16,
+      // 56 is the FAB size
+      paddingBottom: theme.insets.bottom + 16 + 56,
     },
     tagContainer: {
       gap: 8,

--- a/components/CustomKeyboardAvoidingView.tsx
+++ b/components/CustomKeyboardAvoidingView.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Platform } from 'react-native';
+import {
+  KeyboardAvoidingView,
+  KeyboardAvoidingViewProps,
+} from 'react-native-keyboard-controller';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+interface Props
+  extends Omit<
+    KeyboardAvoidingViewProps,
+    'behavior' | 'contentContainerStyle'
+  > {
+  isModalScreen?: boolean;
+}
+
+const headerBarHeight = Platform.select({
+  ios: 40,
+  android: 56,
+  default: 0,
+});
+
+export const CustomKeyboardAvoidingView: React.FC<Props> = ({
+  isModalScreen,
+  ...props
+}: Props) => {
+  const insets = useSafeAreaInsets();
+
+  const topOffset = isModalScreen
+    ? // modal screens wrap the entire screen in KAV and render the header inside
+      // so we only need to account for modal screen position on iOS
+      Platform.select({ ios: insets.top + 10, default: 0 })
+    : insets.top + headerBarHeight;
+
+  return (
+    <KeyboardAvoidingView
+      behavior="padding"
+      // subtracting bottom inset makes the keyboard cover the safe are padding
+      // present on the screen
+      keyboardVerticalOffset={topOffset - insets.bottom}
+      {...props}
+    />
+  );
+};

--- a/components/ModalHeader.tsx
+++ b/components/ModalHeader.tsx
@@ -1,5 +1,11 @@
 import React, { useMemo } from 'react';
-import { View, TouchableOpacity, Text, StyleSheet } from 'react-native';
+import {
+  View,
+  TouchableOpacity,
+  Text,
+  StyleSheet,
+  Platform,
+} from 'react-native';
 import CloseIcon from '../assets/icons/close.svg';
 import { useTheme } from '../context/ThemeContext';
 import { Theme } from '../styles/colors';
@@ -36,6 +42,8 @@ const createStyles = (theme: Theme) =>
       position: 'relative',
       height: 56,
       marginBottom: 16,
+      marginTop:
+        Platform.OS === 'android' ? Math.max(0, theme.insets.top - 16) : 0,
     },
     iconWrap: {
       position: 'absolute',

--- a/components/benchmark/BenchmarkHistory.tsx
+++ b/components/benchmark/BenchmarkHistory.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { FlatList, View, StyleSheet, Text } from 'react-native';
+import { View, StyleSheet, Text } from 'react-native';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { useTheme } from '../../context/ThemeContext';
 import { useModelStore } from '../../store/modelStore';
@@ -8,6 +8,7 @@ import BenchmarkItem from './BenchmarkItem';
 import BenchmarkIcon from '../../assets/icons/benchmark.svg';
 import { fontFamily, fontSizes } from '../../styles/fontStyles';
 import { Theme } from '../../styles/colors';
+import { FlatList } from 'react-native-gesture-handler';
 
 interface Props {
   modalRef: React.RefObject<BottomSheetModal | null>;
@@ -58,9 +59,12 @@ const createStyles = (theme: Theme) =>
       fontSize: fontSizes.md,
       fontFamily: fontFamily.medium,
       color: theme.text.primary,
+      paddingHorizontal: 16,
     },
     listContent: {
       gap: 8,
+      paddingHorizontal: 16,
+      paddingBottom: theme.insets.bottom + 16,
     },
     noDataContainer: {
       alignItems: 'center',

--- a/components/benchmark/BenchmarkModal.tsx
+++ b/components/benchmark/BenchmarkModal.tsx
@@ -33,6 +33,8 @@ export const BenchmarkModal = ({
       transparent
       animationType="fade"
       onRequestClose={handleCancel}
+      statusBarTranslucent
+      navigationBarTranslucent
     >
       <View style={styles.modalOverlay}>
         {!showSuccess ? (

--- a/components/bottomSheets/AddModelSheet.tsx
+++ b/components/bottomSheets/AddModelSheet.tsx
@@ -75,7 +75,7 @@ const createStyles = (theme: Theme) =>
     sheetContent: {
       paddingVertical: 16,
       paddingHorizontal: 24,
-      paddingBottom: 36,
+      paddingBottom: theme.insets.bottom + 16,
       gap: 24,
       backgroundColor: theme.bg.softPrimary,
     },

--- a/components/bottomSheets/BenchmarkResultSheet.tsx
+++ b/components/bottomSheets/BenchmarkResultSheet.tsx
@@ -102,6 +102,7 @@ const createStyles = (theme: Theme) =>
       gap: 24,
       paddingVertical: 16,
       paddingHorizontal: 24,
+      paddingBottom: theme.insets.bottom + 16,
     },
     header: {
       fontSize: fontSizes.lg,

--- a/components/bottomSheets/MemoryWarningSheet.tsx
+++ b/components/bottomSheets/MemoryWarningSheet.tsx
@@ -79,7 +79,7 @@ const createStyles = (theme: Theme) =>
     sheet: {
       paddingVertical: 16,
       paddingHorizontal: 24,
-      paddingBottom: 36,
+      paddingBottom: theme.insets.bottom + 16,
       gap: 24,
       backgroundColor: theme.bg.softPrimary,
     },

--- a/components/bottomSheets/MessageManagementSheet.tsx
+++ b/components/bottomSheets/MessageManagementSheet.tsx
@@ -68,7 +68,7 @@ const createStyles = (theme: Theme) =>
     content: {
       paddingVertical: 16,
       paddingHorizontal: 24,
-      paddingBottom: 36,
+      paddingBottom: theme.insets.bottom + 16,
       gap: 24,
       backgroundColor: theme.bg.softPrimary,
     },

--- a/components/bottomSheets/ModelManagementSheet.tsx
+++ b/components/bottomSheets/ModelManagementSheet.tsx
@@ -201,7 +201,7 @@ const createStyles = (theme: Theme) =>
     container: {
       paddingVertical: 16,
       paddingHorizontal: 24,
-      paddingBottom: 36,
+      paddingBottom: theme.insets.bottom + 16,
       gap: 24,
       backgroundColor: theme.bg.softPrimary,
     },

--- a/components/chat-screen/ChatScreen.tsx
+++ b/components/chat-screen/ChatScreen.tsx
@@ -5,17 +5,9 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import {
-  Keyboard,
-  KeyboardAvoidingView,
-  Platform,
-  StyleSheet,
-  TextInput,
-  View,
-} from 'react-native';
+import { Keyboard, StyleSheet, TextInput, View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useModelStore } from '../../store/modelStore';
 import { useLLMStore } from '../../store/llmStore';
 import { useChatStore } from '../../store/chatStore';
@@ -27,6 +19,7 @@ import ChatBar from './ChatBar';
 import ModelSelectSheet from '../bottomSheets/ModelSelectSheet';
 import { Theme } from '../../styles/colors';
 import { useSQLiteContext } from 'expo-sqlite';
+import { CustomKeyboardAvoidingView } from '../CustomKeyboardAvoidingView';
 
 interface Props {
   chatId: number | null;
@@ -48,7 +41,6 @@ export default function ChatScreen({
 
   const { theme } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
-  const insets = useSafeAreaInsets();
 
   const { loadModels } = useModelStore();
   const { isGenerating, sendChatMessage, loadModel } = useLLMStore();
@@ -98,12 +90,7 @@ export default function ChatScreen({
   };
 
   return (
-    <KeyboardAvoidingView
-      style={styles.container}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      keyboardVerticalOffset={Platform.OS === 'ios' ? 85 + insets.bottom : 40}
-      collapsable={false}
-    >
+    <CustomKeyboardAvoidingView style={styles.container} collapsable={false}>
       <View style={styles.messagesContainer}>
         <Messages
           chatHistory={messageHistory}
@@ -113,23 +100,25 @@ export default function ChatScreen({
         />
       </View>
 
-      <ChatBar
-        chatId={chatId}
-        userInput={userInput}
-        setUserInput={setUserInput}
-        onSend={handleSendMessage}
-        onSelectModel={handlePresentModalPress}
-        inputRef={inputRef}
-        model={model}
-        scrollRef={scrollRef}
-        isAtBottom={isAtBottom}
-      />
+      <View style={styles.barContainer}>
+        <ChatBar
+          chatId={chatId}
+          userInput={userInput}
+          setUserInput={setUserInput}
+          onSend={handleSendMessage}
+          onSelectModel={handlePresentModalPress}
+          inputRef={inputRef}
+          model={model}
+          scrollRef={scrollRef}
+          isAtBottom={isAtBottom}
+        />
+      </View>
 
       <ModelSelectSheet
         bottomSheetModalRef={bottomSheetModalRef}
         selectModel={handleSelectModel}
       />
-    </KeyboardAvoidingView>
+    </CustomKeyboardAvoidingView>
   );
 }
 
@@ -138,12 +127,14 @@ const createStyles = (theme: Theme) =>
     container: {
       flex: 1,
       backgroundColor: theme.bg.softPrimary,
-      paddingBottom: Platform.OS === 'android' ? 20 : 0,
     },
     messagesContainer: {
       flex: 1,
       paddingHorizontal: 12,
       paddingVertical: 8,
       backgroundColor: theme.bg.softPrimary,
+    },
+    barContainer: {
+      paddingBottom: theme.insets.bottom + 16,
     },
   });

--- a/components/drawer/CustomDrawerLayout.tsx
+++ b/components/drawer/CustomDrawerLayout.tsx
@@ -5,13 +5,13 @@ import {
   Animated,
   Dimensions,
   Pressable,
-  StatusBar,
   Text,
-  SafeAreaView,
   TouchableOpacity,
   Keyboard,
+  Platform,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { StatusBar } from 'expo-status-bar';
 import { DrawerProvider } from '../../context/DrawerContext';
 import { useTheme } from '../../context/ThemeContext';
 import { fontSizes, fontFamily } from '../../styles/fontStyles';
@@ -92,10 +92,8 @@ const CustomDrawerLayout = ({ children }: { children: React.ReactNode }) => {
             },
           ]}
         >
-          <SafeAreaView style={styles.safeArea}>
-            <StatusBar backgroundColor={theme.bg.softPrimary} />
-            {children}
-          </SafeAreaView>
+          {Platform.OS === 'android' && <StatusBar style="auto" />}
+          {children}
         </Animated.View>
 
         {isOpen && (
@@ -135,10 +133,6 @@ export default CustomDrawerLayout;
 const createStyles = (theme: Theme) =>
   StyleSheet.create({
     container: {
-      flex: 1,
-      backgroundColor: theme.bg.softPrimary,
-    },
-    safeArea: {
       flex: 1,
       backgroundColor: theme.bg.softPrimary,
     },

--- a/components/model-hub/FloatingActionButton.tsx
+++ b/components/model-hub/FloatingActionButton.tsx
@@ -26,7 +26,7 @@ const createStyles = (theme: Theme) =>
     button: {
       position: 'absolute',
       right: 20,
-      bottom: 30,
+      bottom: 16 + theme.insets.bottom,
       width: 56,
       height: 56,
       borderRadius: 28,

--- a/components/model-hub/StandardModelList.tsx
+++ b/components/model-hub/StandardModelList.tsx
@@ -69,6 +69,5 @@ const createStyles = (theme: Theme) =>
     },
     downloadList: {
       gap: 8,
-      paddingBottom: 60,
     },
   });

--- a/context/ThemeContext.tsx
+++ b/context/ThemeContext.tsx
@@ -1,18 +1,36 @@
-import React, { createContext, useState, useEffect, useContext } from 'react';
+import React, {
+  createContext,
+  useState,
+  useEffect,
+  useContext,
+  useMemo,
+} from 'react';
 import { Appearance } from 'react-native';
 import { darkTheme, lightTheme, Theme } from '../styles/colors';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-const ThemeContext = createContext<{ theme: Theme }>({ theme: lightTheme });
+const ThemeContext = createContext<{ theme: Theme }>({
+  theme: {
+    ...lightTheme,
+    insets: { top: 0, bottom: 0, left: 0, right: 0 },
+  },
+});
 
 export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
   const colorScheme = Appearance.getColorScheme();
-  const [theme, setTheme] = useState(
+  const [themeColors, setThemeColors] = useState(
     colorScheme === 'dark' ? darkTheme : lightTheme
+  );
+  const insets = useSafeAreaInsets();
+
+  const theme = useMemo(
+    () => ({ ...themeColors, insets }),
+    [themeColors, insets]
   );
 
   useEffect(() => {
     const subscription = Appearance.addChangeListener(({ colorScheme }) => {
-      setTheme(colorScheme === 'dark' ? darkTheme : lightTheme);
+      setThemeColors(colorScheme === 'dark' ? darkTheme : lightTheme);
     });
 
     return () => subscription.remove();

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1434,6 +1434,55 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - react-native-keyboard-controller (1.18.1):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - react-native-keyboard-controller/common (= 1.18.1)
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - react-native-keyboard-controller/common (1.18.1):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - react-native-menu (1.2.3):
     - DoubleConversion
     - glog
@@ -2214,6 +2263,7 @@ DEPENDENCIES:
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
   - react-native-executorch (from `../node_modules/react-native-executorch`)
+  - react-native-keyboard-controller (from `../node_modules/react-native-keyboard-controller`)
   - "react-native-menu (from `../node_modules/@react-native-menu/menu`)"
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
@@ -2370,6 +2420,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
   react-native-executorch:
     :path: "../node_modules/react-native-executorch"
+  react-native-keyboard-controller:
+    :path: "../node_modules/react-native-keyboard-controller"
   react-native-menu:
     :path: "../node_modules/@react-native-menu/menu"
   react-native-netinfo:
@@ -2510,6 +2562,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 96a2f2a176268581733be182fa6eebab1c0193be
   React-microtasksnativemodule: bda561d2648e1e52bd9e5a87f8889836bdbde2e2
   react-native-executorch: 4ff1b81fddc6d4ddb22289436f71c67519baafb0
+  react-native-keyboard-controller: af13329b118eecdbb253ca09e30308c782cdf13f
   react-native-menu: be9bce4eb201a4d13734744763d36d56e6df8b4a
   react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
   react-native-safe-area-context: 562163222d999b79a51577eda2ea8ad2c32b4d06

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-native-device-info": "^14.0.4",
     "react-native-executorch": "0.4.7",
     "react-native-gesture-handler": "~2.24.0",
+    "react-native-keyboard-controller": "^1.18.1",
     "react-native-loading-spinner-overlay": "^3.0.1",
     "react-native-markdown-display": "^7.0.2",
     "react-native-reanimated": "~3.17.4",

--- a/styles/colors.ts
+++ b/styles/colors.ts
@@ -1,3 +1,5 @@
+import { EdgeInsets } from 'react-native-safe-area-context';
+
 export const lightTheme = {
   bg: {
     main: '#3D61D6',
@@ -44,4 +46,5 @@ export const darkTheme = {
   },
 };
 
-export type Theme = typeof lightTheme;
+export type ThemeColors = typeof lightTheme;
+export type Theme = ThemeColors & { insets: EdgeInsets };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5794,6 +5794,7 @@ __metadata:
     react-native-device-info: ^14.0.4
     react-native-executorch: 0.4.7
     react-native-gesture-handler: ~2.24.0
+    react-native-keyboard-controller: ^1.18.1
     react-native-loading-spinner-overlay: ^3.0.1
     react-native-markdown-display: ^7.0.2
     react-native-reanimated: ~3.17.4
@@ -7420,6 +7421,29 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 4cdf2b2fb5b131f2015c26d2cb7688b4a0c5f3c8474b1bf0ddfa9eabb0263df440c87262ae8f812a6ecab0d5310df0373bddad4b51f53dabb2ffee01e9ef0f44
+  languageName: node
+  linkType: hard
+
+"react-native-is-edge-to-edge@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "react-native-is-edge-to-edge@npm:1.2.1"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 8fb6d8ab7b953c7d7cec8c987cef24f1c5348a293a85cb49c7c53b54ef110c0ca746736ae730e297603c8c76020df912e93915fb17518c4f2f91143757177aba
+  languageName: node
+  linkType: hard
+
+"react-native-keyboard-controller@npm:^1.18.1":
+  version: 1.18.1
+  resolution: "react-native-keyboard-controller@npm:1.18.1"
+  dependencies:
+    react-native-is-edge-to-edge: ^1.2.1
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+    react-native-reanimated: ">=3.0.0"
+  checksum: b2f59af84ed422c2af088c9abde07be11cb88489e3aa34c26d08262fb5092f2ae1df6a2db785d506ec61c4b159b54fda4fa3dc11a6a035c7645524e0931610bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- makes screens handle safe area insets individually instead of with global `SafeAreaView` to avoid issues caused by scrolling containers and platform differences in navigator nesting
  - replaces hardcoded insets for bottom edge with real ones
  - includes safe are insets in `ThemeContext`, since they're often needed for screen styles.
- enables edge-to-edge on Android
- installs `react-native-keyboard-controller` and replaces regular 'KeyboardAvoidingView`, which
  - fixes #44 
  - fixes #53 animation for text fields and buttons above keyboard
  - works with edge-to-edge on Android
  - reuses configuration for common screen layouts
- switches to `StatusBar` from `expo-status-bar` (already installed)
- fixes benchmark history list not scrolling on Android