### PR TITLE
fix: reduce message touch feedback when scrolling

### DIFF
--- a/components/chat-screen/MessageItem.tsx
+++ b/components/chat-screen/MessageItem.tsx
@@ -84,6 +84,8 @@ const MessageItem = memo(
                 onLongPress={() => {
                   messageManagementSheetRef.current?.present(content);
                 }}
+                delayPressIn={50}
+                activeOpacity={0.4}
               >
                 <MarkdownComponent text={contentParts.normalContent} />
               </TouchableOpacity>


### PR DESCRIPTION
- delays message's reaction to touches so the screen is less likely to fade out when scrolling
- adjusts opacity to make the flicker less severe if it happens

Fixes #52 