### PR TITLE
fix: correct labels in local model forms

### DIFF
--- a/app/modal/add-local-model.tsx
+++ b/app/modal/add-local-model.tsx
@@ -86,21 +86,21 @@ export default function AddLocalModelScreen() {
             Add a model using an existing files in your phone storage.
           </Text>
           <View style={styles.textFieldSection}>
-            <Text style={styles.label}>Model URL</Text>
+            <Text style={styles.label}>Model file</Text>
             <UploadInput
               fileInfo={localModelPath}
               onChange={(file) => setFormField('localModelPath', file)}
             />
           </View>
           <View style={styles.textFieldSection}>
-            <Text style={styles.label}>Tokenizer URL</Text>
+            <Text style={styles.label}>Tokenizer file</Text>
             <UploadInput
               fileInfo={localTokenizerPath}
               onChange={(file) => setFormField('localTokenizerPath', file)}
             />
           </View>
           <View style={styles.textFieldSection}>
-            <Text style={styles.label}>Tokenizer Config URL</Text>
+            <Text style={styles.label}>Tokenizer Config file</Text>
             <UploadInput
               fileInfo={localTokenizerConfigPath}
               onChange={(file) =>

--- a/app/modal/edit-local-model/[modelId].tsx
+++ b/app/modal/edit-local-model/[modelId].tsx
@@ -102,7 +102,7 @@ export default function EditLocalModelScreen() {
             />
           </View>
           <View style={styles.textFieldSection}>
-            <Text style={styles.label}>Model URL</Text>
+            <Text style={styles.label}>Model file</Text>
             <UploadInput
               fileInfo={localModelPath}
               onChange={(file) => setFormField('localModelPath', file)}
@@ -111,14 +111,14 @@ export default function EditLocalModelScreen() {
             <InfoAlert text="Model file is permanently linked to this model and cannot be changed" />
           </View>
           <View style={styles.textFieldSection}>
-            <Text style={styles.label}>Tokenizer URL</Text>
+            <Text style={styles.label}>Tokenizer file</Text>
             <UploadInput
               fileInfo={localTokenizerPath}
               onChange={(file) => setFormField('localTokenizerPath', file)}
             />
           </View>
           <View style={styles.textFieldSection}>
-            <Text style={styles.label}>Tokenizer Config URL</Text>
+            <Text style={styles.label}>Tokenizer Config file</Text>
             <UploadInput
               fileInfo={localTokenizerConfigPath}
               onChange={(file) =>


### PR DESCRIPTION
Changes labels on add and edit local model screens to use "file" instead of "URL"

Fixes #67 