### PR TITLE
fix: do not keep screens on stack after navigating away via the drawer

### DIFF
--- a/components/drawer/DrawerMenu.tsx
+++ b/components/drawer/DrawerMenu.tsx
@@ -61,13 +61,8 @@ const DrawerMenu = ({ onNavigate }: { onNavigate: () => void }) => {
     [...chats].sort((a, b) => b.lastUsed - a.lastUsed)
   );
 
-  const history = useRef<string[]>(['/']);
-
   const navigate = (path: string) => {
     interrupt();
-    if (history.current.at(-1) !== pathname) {
-      history.current.push(pathname);
-    }
 
     // If <DrawerMenu> is visible and there is more than one route in the stack, some
     // screens were opened not via the menu. Flatten the stack again if that happens.
@@ -81,15 +76,16 @@ const DrawerMenu = ({ onNavigate }: { onNavigate: () => void }) => {
     onNavigate();
   };
 
-  // handles back button on Android to mimic the older implementation, which was
-  // pushing routes on the stack when switching screens
+  // pass this check via a ref so the BackHandler callback does not have to be
+  // unnecessarily recreated on navigation, which could interfere with more specific
+  // listeners added later.
+  const isAtIndexRef = useRef(false);
+  isAtIndexRef.current = pathname === '/';
+
   useEffect(() => {
     const handleBackPress = () => {
-      const lastHistoryItem = history.current.at(-1);
-
-      if (!router.canGoBack() && lastHistoryItem !== undefined) {
-        router.replace(lastHistoryItem);
-        history.current.pop();
+      if (!router.canGoBack() && !isAtIndexRef.current) {
+        router.replace('/');
         return true;
       } else {
         return false;


### PR DESCRIPTION
Previously, selecting an item from the drawer would push a new screen on the stack. This commit changes the drawer to replace the screen instead.
- ~the history of visited screens is recorded to make the Android back button behave the same as before~
    simplified to always go back to index route ([default option](https://reactnavigation.org/docs/drawer-navigator#backbehavior) for React Navigation drawer navigator)
~- navigating to drawer screens from somewhere else can cause gaps in history, but currently it happens only when creating a new chat, which is done on the initial screen.~ 

Fixes #64 