### PR TITLE
fix: remove global bottom padding

### DIFF
--- a/components/drawer/CustomDrawerLayout.tsx
+++ b/components/drawer/CustomDrawerLayout.tsx
@@ -109,7 +109,6 @@ const createStyles = (theme: Theme) =>
     container: {
       flex: 1,
       backgroundColor: theme.bg.softPrimary,
-      paddingBottom: theme.insets.bottom === 0 ? 16 : 0,
     },
     content: {
       flex: 1,


### PR DESCRIPTION
Removes a global bottom padding that was applied on devices with no safe area bottom inset. The extra padding is no longer necessary, since screens were modified to handle the bottom spacing on their own after edge-to-edge was enabled.