### PR TITLE
fix: don't show negative download progress

### DIFF
--- a/fetchUtils/ResourceFetcher.ts
+++ b/fetchUtils/ResourceFetcher.ts
@@ -376,7 +376,11 @@ export class ResourceFetcher {
       sourceExtended.cacheFileUri,
       { sessionType: FileSystemSessionType.BACKGROUND },
       ({ totalBytesWritten, totalBytesExpectedToWrite }) => {
-        sourceExtended.callback!(totalBytesWritten / totalBytesExpectedToWrite);
+        if (totalBytesExpectedToWrite !== -1) {
+          sourceExtended.callback!(
+            totalBytesWritten / totalBytesExpectedToWrite
+          );
+        }
       }
     );
     //create value for the this.download Map


### PR DESCRIPTION
When the total size of the file being fetched is not available, it's given as `-1` (see https://docs.expo.dev/versions/latest/sdk/filesystem/#downloadprogressdata), which causes the download progress to show a negative number. Do not report the progress update in that case.