### PR TITLE
feat: downloaded models filter in hub

### DIFF
--- a/app/model-hub.tsx
+++ b/app/model-hub.tsx
@@ -4,23 +4,20 @@ import useDefaultHeader from '../hooks/useDefaultHeader';
 import { useModelStore } from '../store/modelStore';
 import FloatingActionButton from '../components/model-hub/FloatingActionButton';
 import WithDrawerGesture from '../components/WithDrawerGesture';
-import { ScrollView } from 'react-native-gesture-handler';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import ModelManagementSheet from '../components/bottomSheets/ModelManagementSheet';
 import { fontFamily, fontSizes } from '../styles/fontStyles';
-import TextFieldInput from '../components/TextFieldInput';
-import SearchIcon from '../assets/icons/search.svg';
 import SecondaryButton from '../components/SecondaryButton';
 import QuestionIcon from '../assets/icons/question.svg';
 import AddModelSheet from '../components/bottomSheets/AddModelSheet';
 import MemoryWarningSheet from '../components/bottomSheets/MemoryWarningSheet';
-import SortingTag from '../components/model-hub/SortingTag';
 import { useTheme } from '../context/ThemeContext';
 import { Theme } from '../styles/colors';
-import useModelHubData from '../hooks/useModelHubData';
+import useModelHubData, { ModelHubFilter } from '../hooks/useModelHubData';
 import { Model } from '../database/modelRepository';
 import GroupedModelList from '../components/model-hub/GroupedModelList';
 import { CustomKeyboardAvoidingView } from '../components/CustomKeyboardAvoidingView';
+import ModelListFilters from '../components/model-hub/ModelListFilters';
 
 const ModelHubScreen = () => {
   useDefaultHeader();
@@ -32,8 +29,8 @@ const ModelHubScreen = () => {
   const memoryWarningSheetRef = useRef<BottomSheetModal<Model> | null>(null);
   const { models } = useModelStore();
   const [search, setSearch] = useState('');
-  const [activeFilters, setActiveFilters] = useState<Set<string>>(
-    new Set(['featured'])
+  const [activeFilters, setActiveFilters] = useState<Set<ModelHubFilter>>(
+    new Set([ModelHubFilter.Featured])
   );
   const [groupByModel, setGroupByModel] = useState(false);
 
@@ -43,12 +40,6 @@ const ModelHubScreen = () => {
     activeFilters,
     groupByModel,
   });
-
-  const toggleFilter = (filter: string) => {
-    const newFilters = new Set(activeFilters);
-    newFilters.has(filter) ? newFilters.delete(filter) : newFilters.add(filter);
-    setActiveFilters(newFilters);
-  };
 
   const handleModelPress = useCallback((model: Model) => {
     modelManagementSheetRef.current?.present(model);
@@ -77,41 +68,14 @@ const ModelHubScreen = () => {
     <CustomKeyboardAvoidingView style={styles.keyboardAvoidingView}>
       <WithDrawerGesture>
         <View style={styles.container}>
-          <View style={styles.horizontalInset}>
-            <TextFieldInput
-              value={search}
-              onChangeText={setSearch}
-              placeholder="Search Models..."
-              icon={
-                <SearchIcon
-                  width={20}
-                  height={20}
-                  style={{ color: theme.text.primary }}
-                />
-              }
-            />
-          </View>
-          <View>
-            <ScrollView
-              horizontal
-              contentContainerStyle={[
-                styles.tagContainer,
-                styles.horizontalInset,
-              ]}
-              showsHorizontalScrollIndicator={false}
-            >
-              <SortingTag
-                text="Featured"
-                selected={activeFilters.has('featured')}
-                onPress={() => toggleFilter('featured')}
-              />
-              <SortingTag
-                text="Group by model"
-                selected={groupByModel}
-                onPress={() => setGroupByModel(!groupByModel)}
-              />
-            </ScrollView>
-          </View>
+          <ModelListFilters
+            search={search}
+            onSearchChange={setSearch}
+            activeFilters={activeFilters}
+            onFiltersChange={setActiveFilters}
+            groupByModel={groupByModel}
+            onGroupByModelChange={setGroupByModel}
+          />
           {isEmpty ? (
             renderEmptyState()
           ) : (
@@ -185,9 +149,5 @@ const createStyles = (theme: Theme) =>
     modelScrollContent: {
       // 56 is the FAB size
       paddingBottom: theme.insets.bottom + 16 + 56,
-    },
-    tagContainer: {
-      gap: 8,
-      alignItems: 'center',
     },
   });

--- a/components/model-hub/ModelListFilters.tsx
+++ b/components/model-hub/ModelListFilters.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { View, ScrollView, StyleSheet } from 'react-native';
+import TextFieldInput from '../TextFieldInput';
+import SortingTag from './SortingTag';
+import { useTheme } from '../../context/ThemeContext';
+import { useMemo } from 'react';
+import { Theme } from '../../styles/colors';
+import SearchIcon from '../../assets/icons/search.svg';
+import { ModelHubFilter } from '../../hooks/useModelHubData';
+
+interface Props {
+  search: string;
+  onSearchChange: (search: string) => void;
+  activeFilters: Set<ModelHubFilter>;
+  onFiltersChange: (filters: Set<ModelHubFilter>) => void;
+  groupByModel: boolean;
+  onGroupByModelChange: (groupByModel: boolean) => void;
+}
+
+const ModelListFilters: React.FC<Props> = ({
+  search,
+  onSearchChange,
+  activeFilters,
+  onFiltersChange,
+  groupByModel,
+  onGroupByModelChange,
+}) => {
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const toggleFilter = (filter: ModelHubFilter) => {
+    onFiltersChange(toggleSetElement(new Set(activeFilters), filter));
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.horizontalInset}>
+        <TextFieldInput
+          value={search}
+          onChangeText={onSearchChange}
+          placeholder="Search Models..."
+          icon={
+            <SearchIcon
+              width={20}
+              height={20}
+              style={{ color: theme.text.primary }}
+            />
+          }
+        />
+      </View>
+
+      <ScrollView
+        horizontal
+        contentContainerStyle={[styles.tagContainer, styles.horizontalInset]}
+        showsHorizontalScrollIndicator={false}
+      >
+        <SortingTag
+          text="Featured"
+          selected={activeFilters.has(ModelHubFilter.Featured)}
+          onPress={() => toggleFilter(ModelHubFilter.Featured)}
+        />
+        <SortingTag
+          text="Group by model"
+          selected={groupByModel}
+          onPress={() => onGroupByModelChange(!groupByModel)}
+        />
+      </ScrollView>
+    </View>
+  );
+};
+
+function toggleSetElement<T>(s: Set<T>, value: T) {
+  if (s.has(value)) {
+    s.delete(value);
+  } else {
+    s.add(value);
+  }
+
+  return s;
+}
+
+export default ModelListFilters;
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    container: {
+      gap: 24,
+    },
+    horizontalInset: {
+      paddingHorizontal: 16,
+    },
+    tagContainer: {
+      gap: 8,
+      alignItems: 'center',
+    },
+  });

--- a/components/model-hub/ModelListFilters.tsx
+++ b/components/model-hub/ModelListFilters.tsx
@@ -64,6 +64,11 @@ const ModelListFilters: React.FC<Props> = ({
           selected={groupByModel}
           onPress={() => onGroupByModelChange(!groupByModel)}
         />
+        <SortingTag
+          text="Ready to use"
+          selected={activeFilters.has(ModelHubFilter.Downloaded)}
+          onPress={() => toggleFilter(ModelHubFilter.Downloaded)}
+        />
       </ScrollView>
     </View>
   );

--- a/hooks/useModelHubData.tsx
+++ b/hooks/useModelHubData.tsx
@@ -4,6 +4,7 @@ import { Model } from '../database/modelRepository';
 
 export enum ModelHubFilter {
   Featured = 'featured',
+  Downloaded = 'downloaded',
 }
 
 interface UseModelHubDataParams {
@@ -35,9 +36,16 @@ export default function useModelHubData({
         .includes(search.toLowerCase());
       if (!matchesSearch) return false;
 
-      if (activeFilters.has(ModelHubFilter.Featured) && model.source === 'built-in') {
-        return model.featured;
-      }
+      const matchesFeatured =
+        model.featured ||
+        model.source !== 'built-in' ||
+        !activeFilters.has(ModelHubFilter.Featured);
+      if (!matchesFeatured) return false;
+
+      const matchesDownloaded =
+        model.isDownloaded || !activeFilters.has(ModelHubFilter.Downloaded);
+      if (!matchesDownloaded) return false;
+
       return true;
     });
   }, [models, search, activeFilters]);

--- a/hooks/useModelHubData.tsx
+++ b/hooks/useModelHubData.tsx
@@ -2,10 +2,14 @@ import { useMemo } from 'react';
 import { ModelState } from '../store/modelStore';
 import { Model } from '../database/modelRepository';
 
+export enum ModelHubFilter {
+  Featured = 'featured',
+}
+
 interface UseModelHubDataParams {
   models: Model[];
   search: string;
-  activeFilters: Set<string>;
+  activeFilters: Set<ModelHubFilter>;
   groupByModel: boolean;
 }
 
@@ -31,7 +35,7 @@ export default function useModelHubData({
         .includes(search.toLowerCase());
       if (!matchesSearch) return false;
 
-      if (activeFilters.has('featured') && model.source === 'built-in') {
+      if (activeFilters.has(ModelHubFilter.Featured) && model.source === 'built-in') {
         return model.featured;
       }
       return true;


### PR DESCRIPTION
Suggested in https://github.com/software-mansion-labs/private-mind/pull/61#issuecomment-3135700344

- moves the search and filter part of model hub screen to a separate file
- adds a filter for showing only downloaded models

https://github.com/user-attachments/assets/f56f9315-2997-4b91-aeb0-2448fa2e14b5

