### PR TITLE
fix: reset download status after error

### DIFF
--- a/fetchUtils/ResourceFetcherUtils.ts
+++ b/fetchUtils/ResourceFetcherUtils.ts
@@ -87,16 +87,14 @@ export namespace ResourceFetcherUtils {
             console.warn(
               `Failed to fetch HEAD for ${source}: ${response.status}`
             );
-            continue;
+          } else {
+            const contentLength = response.headers.get('content-length');
+            length = contentLength ? parseInt(contentLength, 10) : 0;
+            previousFilesTotalLength = totalLength;
+            totalLength += length;
           }
-
-          const contentLength = response.headers.get('content-length');
-          length = contentLength ? parseInt(contentLength, 10) : 0;
-          previousFilesTotalLength = totalLength;
-          totalLength += length;
         } catch (error) {
           console.warn(`Error fetching HEAD for ${source}:`, error);
-          continue;
         }
       }
       results.push({ source, type, length, previousFilesTotalLength });

--- a/store/modelStore.ts
+++ b/store/modelStore.ts
@@ -43,7 +43,7 @@ interface ModelStore {
   ) => Promise<void>;
 }
 
-const MS_PER_FRAME = 16 // ~60 fps
+const MS_PER_FRAME = 16; // ~60 fps
 
 export const useModelStore = create<ModelStore>((set, get) => ({
   db: null,
@@ -138,6 +138,11 @@ export const useModelStore = create<ModelStore>((set, get) => ({
       });
     } catch (err) {
       console.error('Failed:', err);
+      setDownloading(0, ModelState.NotStarted);
+      Toast.show({
+        type: 'defaultToast',
+        text1: "The model could not be downloaded",
+      });
     }
   },
 


### PR DESCRIPTION
If downloading a modal fails
- clean up "downloading" state so it can be retried
- show a toast with error message