### PR TITLE
refactor: move common button layout to a component

### DIFF
--- a/components/CircleButton.tsx
+++ b/components/CircleButton.tsx
@@ -1,13 +1,22 @@
 import React, { useMemo } from 'react';
 import { StyleSheet, TouchableOpacity } from 'react-native';
+import { SvgComponent } from '../utils/SvgComponent';
 
 interface Props {
-  icon: React.ReactNode;
+  icon: SvgComponent;
+  size?: number;
   backgroundColor: string;
+  color: string;
   onPress: () => void;
 }
 
-const CircleButton = ({ icon, backgroundColor, onPress }: Props) => {
+const CircleButton = ({
+  icon: Icon,
+  size = 20,
+  backgroundColor,
+  color,
+  onPress,
+}: Props) => {
   const styles = useMemo(
     () => createStyles(backgroundColor),
     [backgroundColor]
@@ -15,7 +24,7 @@ const CircleButton = ({ icon, backgroundColor, onPress }: Props) => {
 
   return (
     <TouchableOpacity onPress={onPress} style={styles.circle}>
-      {icon}
+      <Icon width={size} height={size} color={color} />
     </TouchableOpacity>
   );
 };

--- a/components/chat-screen/ChatBar.tsx
+++ b/components/chat-screen/ChatBar.tsx
@@ -16,6 +16,7 @@ import SendIcon from '../../assets/icons/send_icon.svg';
 import PauseIcon from '../../assets/icons/pause_icon.svg';
 import RotateLeft from '../../assets/icons/rotate_left.svg';
 import { Theme } from '../../styles/colors';
+import CircleButton from '../CircleButton';
 
 interface Props {
   chatId: number | null;
@@ -87,19 +88,22 @@ const ChatBar = ({
           />
           <View style={styles.buttonBar}>
             {userInput && !isGenerating && !isProcessingPrompt ? (
-              <TouchableOpacity style={styles.sendButton} onPress={onSend}>
-                <SendIcon width={20} height={20} style={styles.iconContrast} />
-              </TouchableOpacity>
+              <CircleButton
+                icon={SendIcon}
+                onPress={onSend}
+                backgroundColor={theme.bg.main}
+                color={theme.text.contrastPrimary}
+              />
             ) : null}
 
             {(isGenerating || isProcessingPrompt) && (
-              <TouchableOpacity style={styles.sendButton} onPress={interrupt}>
-                <PauseIcon
-                  height={13.33}
-                  width={13.33}
-                  style={styles.iconContrast}
-                />
-              </TouchableOpacity>
+              <CircleButton
+                icon={PauseIcon}
+                size={13.33}
+                onPress={interrupt}
+                backgroundColor={theme.bg.main}
+                color={theme.text.contrastPrimary}
+              />
             )}
           </View>
         </View>
@@ -160,16 +164,5 @@ const createStyles = (theme: Theme) =>
     buttonBar: {
       justifyContent: 'center',
       alignItems: 'flex-end',
-    },
-    sendButton: {
-      width: 36,
-      height: 36,
-      justifyContent: 'center',
-      alignItems: 'center',
-      borderRadius: 18,
-      backgroundColor: theme.bg.main,
-    },
-    iconContrast: {
-      color: theme.text.contrastPrimary,
     },
   });

--- a/components/model-hub/ModelCard.tsx
+++ b/components/model-hub/ModelCard.tsx
@@ -161,13 +161,9 @@ const ModelCard = ({ model, onPress, memoryWarningSheetRef, wifiWarningSheetRef 
           <CircleButton
             onPress={handlePress}
             backgroundColor={theme.bg.errorSecondary}
-            icon={
-              <CloseIcon
-                width={13.33}
-                height={13.33}
-                style={styles.iconPrimary}
-              />
-            }
+            color={theme.text.primary}
+            icon={CloseIcon}
+            size={13.33}
           />
         )}
 
@@ -175,9 +171,9 @@ const ModelCard = ({ model, onPress, memoryWarningSheetRef, wifiWarningSheetRef 
           <CircleButton
             onPress={handlePress}
             backgroundColor={theme.bg.softSecondary}
-            icon={
-              <DownloadIcon width={15} height={15} style={styles.iconPrimary} />
-            }
+            color={theme.text.primary}
+            icon={DownloadIcon}
+            size={15}
           />
         )}
       </View>
@@ -223,9 +219,6 @@ const createStyles = (theme: Theme) =>
     name: {
       fontFamily: fontFamily.medium,
       fontSize: fontSizes.md,
-      color: theme.text.primary,
-    },
-    iconPrimary: {
       color: theme.text.primary,
     },
     iconSecondary: {

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,5 +1,6 @@
 declare module '*.svg' {
-  import { SvgProps } from 'react-native-svg';
-  const content: React.FV<SvgProps>;
+  import { CustomSvgProps } from './utils/CustomSvgProps';
+
+  const content: React.FC<CustomSvgProps>;
   export default content;
 }

--- a/utils/SvgComponent.ts
+++ b/utils/SvgComponent.ts
@@ -1,0 +1,8 @@
+import { StyleProp, ViewStyle } from 'react-native';
+import { SvgProps } from 'react-native-svg';
+
+export interface CustomSvgProps extends Omit<SvgProps, 'style'> {
+  style?: StyleProp<ViewStyle & { color?: string }>;
+}
+
+export type SvgComponent = React.ComponentType<CustomSvgProps>;


### PR DESCRIPTION
Expands customization of `CircleButton` and uses it for existing buttons that match.
- change split from work on STT, which will add more of this kind of button
- fixes typo in type declaration for imports from `*.svg` files. Overrides `style` prop to allow `color` (which is the default method used in the app, but isn't included in the original `ViewStyle`)