### PR TITLE
deps: upgrade react-native-executorch to 0.5.1

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -86,7 +86,7 @@ PODS:
   - hermes-engine (0.79.5):
     - hermes-engine/Pre-built (= 0.79.5)
   - hermes-engine/Pre-built (0.79.5)
-  - opencv-rne (0.1.0)
+  - opencv-rne (4.11.0)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -1411,11 +1411,11 @@ PODS:
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
-  - react-native-executorch (0.4.7):
+  - react-native-executorch (0.5.1):
     - DoubleConversion
     - glog
     - hermes-engine
-    - opencv-rne (~> 0.1.0)
+    - opencv-rne (~> 4.11.0)
     - RCT-Folly (= 2024.11.18.00)
     - RCTRequired
     - RCTTypeSafety
@@ -1435,6 +1435,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
+    - sqlite3
     - Yoga
   - react-native-keyboard-controller (1.18.1):
     - DoubleConversion
@@ -2207,6 +2208,9 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - SocketRocket (0.7.1)
+  - sqlite3 (3.50.4):
+    - sqlite3/common (= 3.50.4)
+  - sqlite3/common (3.50.4)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2314,6 +2318,7 @@ SPEC REPOS:
   trunk:
     - opencv-rne
     - SocketRocket
+    - sqlite3
 
 EXTERNAL SOURCES:
   boost:
@@ -2535,7 +2540,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: f03b0e06d3882d71e67e45b073bb827da1a21aae
-  opencv-rne: 63e933ae2373fc91351f9a348dc46c3f523c2d3f
+  opencv-rne: 2305807573b6e29c8c87e3416ab096d09047a7a0
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 5f638f65935e273753b1f31a365db6a8d6dc53b5
   RCTRequired: 8b46a520ea9071e2bc47d474aa9ca31b4a935bd8
@@ -2567,7 +2572,7 @@ SPEC CHECKSUMS:
   React-logger: 85fa3509931497c72ccd2547fcc91e7299d8591e
   React-Mapbuffer: 96a2f2a176268581733be182fa6eebab1c0193be
   React-microtasksnativemodule: bda561d2648e1e52bd9e5a87f8889836bdbde2e2
-  react-native-executorch: 4ff1b81fddc6d4ddb22289436f71c67519baafb0
+  react-native-executorch: c8842c76917ed86e372526869f76a2b686afcf0e
   react-native-keyboard-controller: af13329b118eecdbb253ca09e30308c782cdf13f
   react-native-menu: be9bce4eb201a4d13734744763d36d56e6df8b4a
   react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
@@ -2611,6 +2616,7 @@ SPEC CHECKSUMS:
   RNScreens: 482e9707f9826230810c92e765751af53826d509
   RNSVG: 794f269526df9ddc1f79b3d1a202b619df0368e3
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
+  sqlite3: 73513155ec6979715d3904ef53a8d68892d4032b
   Yoga: adb397651e1c00672c12e9495babca70777e411e
 
 PODFILE CHECKSUM: 3f3c7b364a560775124a1d731bac02497263761d

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react": "19.0.0",
     "react-native": "0.79.5",
     "react-native-device-info": "^14.0.4",
-    "react-native-executorch": "0.4.7",
+    "react-native-executorch": "0.5.1",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-keyboard-controller": "^1.18.1",
     "react-native-loading-spinner-overlay": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5647,6 +5647,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsonrepair@npm:^3.12.0":
+  version: 3.13.0
+  resolution: "jsonrepair@npm:3.13.0"
+  bin:
+    jsonrepair: bin/cli.js
+  checksum: 509a9d9341e941d97ba4577a5877e4fe405e624857ed4c82d877557af99e8869c945139a8d0c2ccbf5fb835419daad4f908cba28ee95b707e02703e1634192f3
+  languageName: node
+  linkType: hard
+
+"jsonschema@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "jsonschema@npm:1.5.0"
+  checksum: 170b9c375967bc135f4d029fedc31f5686f2c3bb07e7472cebddbb907b5369bf75a1a50287d6af9c31f61c76fe0b7786e78044c188aaddd329b77d856475e6db
+  languageName: node
+  linkType: hard
+
 "kind-of@npm:^6.0.2":
   version: 6.0.3
   resolution: "kind-of@npm:6.0.3"
@@ -5843,7 +5859,7 @@ __metadata:
     react: 19.0.0
     react-native: 0.79.5
     react-native-device-info: ^14.0.4
-    react-native-executorch: 0.4.7
+    react-native-executorch: 0.5.1
     react-native-gesture-handler: ~2.24.0
     react-native-keyboard-controller: ^1.18.1
     react-native-loading-spinner-overlay: ^3.0.1
@@ -7440,19 +7456,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-executorch@npm:0.4.7":
-  version: 0.4.7
-  resolution: "react-native-executorch@npm:0.4.7"
+"react-native-executorch@npm:0.5.1":
+  version: 0.5.1
+  resolution: "react-native-executorch@npm:0.5.1"
   dependencies:
     "@huggingface/jinja": ^0.5.0
     expo: ^53.0.7
     expo-asset: ~11.1.5
     expo-file-system: ~18.1.10
-    react-native-live-audio-stream: ^1.1.1
+    jsonrepair: ^3.12.0
+    jsonschema: ^1.5.0
+    zod: ^3.25.0
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 8fcc8e7382e2a545faafa8c45cb42a97c6669d595d5b42d3a4d31871fdb4e6e0055b7e8aa362da859497c7eb6439ed7a4251a97b5abe37d48772d9c93ff75132
+  checksum: 63bac8781d71b5488512a35cd96c7ff4cb63e4018bd49ce9e47a5a00f6b735269e0d09e5fe6b6207c9931cb0b667082bf769b22e859b0c069afb3b10e58f29a4
   languageName: node
   linkType: hard
 
@@ -7509,13 +7527,6 @@ __metadata:
     react-native: "*"
     react-native-reanimated: ">=3.0.0"
   checksum: b2f59af84ed422c2af088c9abde07be11cb88489e3aa34c26d08262fb5092f2ae1df6a2db785d506ec61c4b159b54fda4fa3dc11a6a035c7645524e0931610bb
-  languageName: node
-  linkType: hard
-
-"react-native-live-audio-stream@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "react-native-live-audio-stream@npm:1.1.1"
-  checksum: 1503fb1d9e2df58bf31bfa9ee3cf5167802a659ec64e3a6ca8ba2401b6388af158f9e04895699152e91eec66bcc949a3f35ae38fb63435ae28959b5be56bbd2e
   languageName: node
   linkType: hard
 
@@ -9080,6 +9091,13 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25.0":
+  version: 3.25.76
+  resolution: "zod@npm:3.25.76"
+  checksum: c9a403a62b329188a5f6bd24d5d935d2bba345f7ab8151d1baa1505b5da9f227fb139354b043711490c798e91f3df75991395e40142e6510a4b16409f302b849
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- installs react-native-executorch 0.5.1
- switches from `responseCallback` to `tokenCallback` when loading LLM