### PR TITLE
fix: sidebar labels cut off too early

### DIFF
--- a/components/drawer/DrawerItem.tsx
+++ b/components/drawer/DrawerItem.tsx
@@ -51,5 +51,6 @@ const createStyles = (theme: Theme) =>
       fontSize: fontSizes.md,
       fontFamily: fontFamily.medium,
       color: theme.text.primary,
+      flex: 1,
     },
   });


### PR DESCRIPTION
Sometimes labels in the drawer menu are shortened with ellipsis even when there's enough space:

<img width="592" height="472" alt="image" src="https://github.com/user-attachments/assets/cbb9d043-b391-44a4-a035-089f5cc59381" />
