### PR TITLE
deps: upgrade react-native-executorch to 0.5.2

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1461,7 +1461,7 @@ PODS:
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
-  - react-native-executorch (0.5.1):
+  - react-native-executorch (0.5.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2675,7 +2675,7 @@ SPEC CHECKSUMS:
   hermes-engine: f03b0e06d3882d71e67e45b073bb827da1a21aae
   op-sqlite: 6826f241267eca7963134db588b4bbb3a7a6b97d
   opencv-rne: 2305807573b6e29c8c87e3416ab096d09047a7a0
-  Pdfium: d8e07101b135cbec0d6a23b144929125be7fbb29
+  Pdfium: f15a6cca3c5f4341e51ab3aefd66ac01372f41ce
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 5f638f65935e273753b1f31a365db6a8d6dc53b5
   RCTRequired: 8b46a520ea9071e2bc47d474aa9ca31b4a935bd8
@@ -2707,7 +2707,7 @@ SPEC CHECKSUMS:
   React-logger: 85fa3509931497c72ccd2547fcc91e7299d8591e
   React-Mapbuffer: 96a2f2a176268581733be182fa6eebab1c0193be
   React-microtasksnativemodule: bda561d2648e1e52bd9e5a87f8889836bdbde2e2
-  react-native-executorch: c8842c76917ed86e372526869f76a2b686afcf0e
+  react-native-executorch: 7d61d976183cf8613b0e227f7f1269d364d347a7
   react-native-keyboard-controller: af13329b118eecdbb253ca09e30308c782cdf13f
   react-native-menu: be9bce4eb201a4d13734744763d36d56e6df8b4a
   react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-native": "0.79.5",
     "react-native-audio-api": "^0.7.1",
     "react-native-device-info": "^14.0.4",
-    "react-native-executorch": "0.5.1",
+    "react-native-executorch": "0.5.2",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-keyboard-controller": "^1.18.1",
     "react-native-loading-spinner-overlay": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6006,7 +6006,7 @@ __metadata:
     react-native: 0.79.5
     react-native-audio-api: ^0.7.1
     react-native-device-info: ^14.0.4
-    react-native-executorch: 0.5.1
+    react-native-executorch: 0.5.2
     react-native-gesture-handler: ~2.24.0
     react-native-keyboard-controller: ^1.18.1
     react-native-loading-spinner-overlay: ^3.0.1
@@ -7662,9 +7662,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-executorch@npm:0.5.1":
-  version: 0.5.1
-  resolution: "react-native-executorch@npm:0.5.1"
+"react-native-executorch@npm:0.5.2":
+  version: 0.5.2
+  resolution: "react-native-executorch@npm:0.5.2"
   dependencies:
     "@huggingface/jinja": ^0.5.0
     expo: ^53.0.7
@@ -7676,7 +7676,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 63bac8781d71b5488512a35cd96c7ff4cb63e4018bd49ce9e47a5a00f6b735269e0d09e5fe6b6207c9931cb0b667082bf769b22e859b0c069afb3b10e58f29a4
+  checksum: 2fb32f670e6a3ca0c2233d8b7c1029f850891695118d9ba3c9301592bd184059a7fa26cb26043227cf168cd6d410857eb6ccd371dd5a10cc20a5e0c4bd6a494f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #113 