### PR TITLE
feat: Detour SDK integration improvement

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -27,6 +27,12 @@
         <category android:name="android.intent.category.BROWSABLE"/>
         <data android:scheme="private-mind"/>
       </intent-filter>
+      <intent-filter android:autoVerify="true" data-generated="true">
+        <action android:name="android.intent.action.VIEW"/>
+        <data android:scheme="https" android:host="privatemind.godetour.link" android:pathPrefix="/SneWQjYDGD"/>
+        <category android:name="android.intent.category.BROWSABLE"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+      </intent-filter>
     </activity>
   </application>
 </manifest>

--- a/app.json
+++ b/app.json
@@ -79,7 +79,8 @@
           "data": [
             {
               "scheme": "https",
-              "host": "privatemind.godetour.link"
+              "host": "privatemind.godetour.link",
+              "pathPrefix": "/SneWQjYDGD"
             }
           ],
           "category": ["BROWSABLE", "DEFAULT"]

--- a/app/(drawer)/index.tsx
+++ b/app/(drawer)/index.tsx
@@ -21,7 +21,6 @@ import { useModelStore } from '../../store/modelStore';
 import { useSourceStore } from '../../store/sourceStore';
 import { useLLMStore } from '../../store/llmStore';
 import useOnboardingRedirect from '../../hooks/useOnboardingRedirect';
-import { useDetourContext } from '@swmansion/react-native-detour';
 
 export default function App() {
   useOnboardingRedirect();
@@ -40,11 +39,6 @@ export default function App() {
   configureReanimatedLogger({
     strict: false,
   });
-
-  const detourContext = useDetourContext();
-  useEffect(() => {
-    console.log('Detour context: ', detourContext);
-  }, [detourContext]);
 
   const handleSetModel = async (model: Model) => {
     const nextChatId = await getNextChatId(db);

--- a/app/(modals)/detour-demo.tsx
+++ b/app/(modals)/detour-demo.tsx
@@ -1,0 +1,202 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { StyleSheet, View, Text, ScrollView, Animated } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useTheme } from '../../context/ThemeContext';
+import { fontSizes, fontFamily, lineHeights } from '../../styles/fontStyles';
+import { useDetourContext } from '@swmansion/react-native-detour';
+import PrimaryButton from '../../components/PrimaryButton';
+
+// Demo chat screen shown when navigated via specific Detour link
+export default function DetourDemoChat() {
+  const router = useRouter();
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const { deferredLink } = useDetourContext();
+  const [fadeAnim] = useState(new Animated.Value(0));
+  const [slideAnim] = useState(new Animated.Value(50));
+
+  useEffect(() => {
+    Animated.parallel([
+      Animated.timing(fadeAnim, {
+        toValue: 1,
+        duration: 800,
+        useNativeDriver: true,
+      }),
+      Animated.timing(slideAnim, {
+        toValue: 0,
+        duration: 600,
+        useNativeDriver: true,
+      }),
+    ]).start();
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <ScrollView showsVerticalScrollIndicator={false}>
+        <Animated.View
+          style={[
+            styles.scrollContent,
+            {
+              opacity: fadeAnim,
+              transform: [{ translateY: slideAnim }],
+            },
+          ]}
+        >
+          {/* Hero Section */}
+          <View style={styles.hero}>
+            <Text style={styles.emoji}>🚀</Text>
+            <Text style={styles.heroTitle}>Detour link success!</Text>
+            <Text style={styles.subtitle}>
+              You've been seamlessly redirected to this chat.
+            </Text>
+            <Text style={styles.subtitle}>
+              This is a special showcase screen that demonstrates Detour's
+              deferred deep linking.
+            </Text>
+          </View>
+
+          {/* Technical Details */}
+          {deferredLink && (
+            <View style={[styles.card, styles.techCard]}>
+              <Text style={styles.cardTitle}>🔗 Link details</Text>
+              <Text style={styles.techText}>
+                Original link:{'\n'}
+                <Text style={styles.linkText}>{deferredLink.toString()}</Text>
+              </Text>
+              <Text style={styles.techText}>
+                Route: <Text style={styles.linkText}>/chat/detour-demo</Text>
+              </Text>
+            </View>
+          )}
+
+          {/* Powered By */}
+          <View style={styles.poweredBy}>
+            <Text style={styles.poweredByText}>Powered by</Text>
+            <Text style={styles.detourBrand}>Detour SDK</Text>
+            <Text style={styles.poweredBySubtext}>by Software Mansion</Text>
+          </View>
+        </Animated.View>
+
+        <View style={styles.footer}>
+          <PrimaryButton
+            text="Explore PrivateMind"
+            onPress={() => router.back()}
+          />
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const createStyles = (theme: any) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      padding: 16,
+      paddingBottom: theme.insets.bottom,
+      backgroundColor: theme.bg.softPrimary,
+    },
+    content: {
+      flex: 1,
+      gap: 24,
+      paddingTop: 24,
+    },
+    header: {
+      gap: 12,
+      paddingHorizontal: 20,
+    },
+    title: {
+      fontFamily: fontFamily.medium,
+      fontSize: fontSizes.xl,
+      textAlign: 'center',
+      color: theme.text.primary,
+    },
+    description: {
+      fontSize: fontSizes.sm,
+      fontFamily: fontFamily.regular,
+      color: theme.text.defaultSecondary,
+      textAlign: 'center',
+    },
+    scrollContent: {
+      paddingBottom: 20,
+    },
+    hero: {
+      alignItems: 'center',
+      marginBottom: 16,
+      paddingVertical: 20,
+    },
+    emoji: {
+      fontSize: 64,
+      marginBottom: 16,
+    },
+    heroTitle: {
+      fontSize: fontSizes.xxl,
+      fontFamily: fontFamily.bold,
+      color: theme.text.primary,
+      textAlign: 'center',
+      marginBottom: 8,
+    },
+    subtitle: {
+      fontSize: fontSizes.md,
+      fontFamily: fontFamily.regular,
+      color: theme.text.defaultSecondary,
+      textAlign: 'center',
+      lineHeight: lineHeights.md,
+    },
+    card: {
+      backgroundColor: theme.bg.softSecondary,
+      borderRadius: 16,
+      padding: 20,
+      marginBottom: 16,
+      borderWidth: 1,
+      borderColor: theme.border.soft,
+    },
+    techCard: {
+      backgroundColor: theme.bg.softSecondary,
+    },
+    cardTitle: {
+      fontSize: fontSizes.lg,
+      fontFamily: fontFamily.bold,
+      color: theme.text.primary,
+      marginBottom: 12,
+    },
+    techText: {
+      fontSize: fontSizes.sm,
+      fontFamily: fontFamily.regular,
+      color: theme.text.defaultSecondary,
+      lineHeight: lineHeights.md,
+    },
+    linkText: {
+      fontFamily: fontFamily.medium,
+      color: theme.bg.main,
+    },
+    poweredBy: {
+      alignItems: 'center',
+      marginTop: 20,
+      marginBottom: 20,
+    },
+    poweredByText: {
+      fontSize: fontSizes.sm,
+      fontFamily: fontFamily.regular,
+      color: theme.text.defaultSecondary,
+      marginBottom: 4,
+    },
+    detourBrand: {
+      fontSize: fontSizes.xl,
+      fontFamily: fontFamily.bold,
+      color: theme.text.primary,
+      marginBottom: 2,
+    },
+    poweredBySubtext: {
+      fontSize: fontSizes.xs,
+      fontFamily: fontFamily.regular,
+      color: theme.text.defaultSecondary,
+    },
+    footer: {
+      gap: 10,
+      backgroundColor: theme.bg.softPrimary,
+      justifyContent: 'center',
+      alignItems: 'center',
+      paddingTop: 10,
+    },
+  });

--- a/app/[...unmatched].tsx
+++ b/app/[...unmatched].tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Redirect } from 'expo-router';
+
+// Expo catches Universal/App Links before Detour
+// This redirects to home so Detour SDK can process the link properly
+export default function UnmatchedRoute() {
+  return <Redirect href="/" />;
+}

--- a/ios/PrivateMind.xcodeproj/project.pbxproj
+++ b/ios/PrivateMind.xcodeproj/project.pbxproj
@@ -377,7 +377,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = PrivateMind/PrivateMind.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = J5FM626PE2;
+				DEVELOPMENT_TEAM = B357MU264T;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -419,7 +419,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = PrivateMind/PrivateMind.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = J5FM626PE2;
+				DEVELOPMENT_TEAM = B357MU264T;
 				INFOPLIST_FILE = PrivateMind/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Private Mind";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";

--- a/ios/PrivateMind/PrivateMind.entitlements
+++ b/ios/PrivateMind/PrivateMind.entitlements
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.developer.kernel.increased-memory-limit</key>
-	<true/>
-</dict>
+  <dict>
+    <key>com.apple.developer.associated-domains</key>
+    <array>
+      <string>applinks:privatemind.godetour.link</string>
+    </array>
+  </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@react-native-rag/op-sqlite": "file:./react-native-rag-op-sqlite-0.1.2.tgz",
     "@react-native/metro-config": "^0.76.3",
     "@react-navigation/drawer": "^7.5.6",
-    "@swmansion/react-native-detour": "^0.3.0",
+    "@swmansion/react-native-detour": "^0.4.0",
     "expo": "53.0.19",
     "expo-application": "^7.0.8",
     "expo-clipboard": "^8.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2902,9 +2902,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swmansion/react-native-detour@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@swmansion/react-native-detour@npm:0.3.0"
+"@swmansion/react-native-detour@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@swmansion/react-native-detour@npm:0.4.0"
   peerDependencies:
     "@react-native-async-storage/async-storage": ">=2.0.0"
     expo-application: ">=6.1.5"
@@ -2913,7 +2913,10 @@ __metadata:
     react: ">=18"
     react-native: ">=0.72"
     react-native-device-info: ">=14.0.0"
-  checksum: 47e8b1a51ec2864f246a5368c4b0e6a2e1a7a783f45b62b832fe7b08fc1756df47357192f3866b42520d7a29c70a03c2e7a311a19fb19679f28c53790b0fa581
+  peerDependenciesMeta:
+    "@react-native-async-storage/async-storage":
+      optional: true
+  checksum: 0b72643336a600c4dc03a4b6b69289e5e9114d4ea9d20dc1003fd46fcc919e79588de94231a5d8098434e63f3491eef8016ae91d94988920cf9fe309aa1b9611
   languageName: node
   linkType: hard
 
@@ -6066,7 +6069,7 @@ __metadata:
     "@react-native-rag/op-sqlite": "file:./react-native-rag-op-sqlite-0.1.2.tgz"
     "@react-native/metro-config": ^0.76.3
     "@react-navigation/drawer": ^7.5.6
-    "@swmansion/react-native-detour": ^0.3.0
+    "@swmansion/react-native-detour": ^0.4.0
     "@types/react": ~19.0.10
     expo: 53.0.19
     expo-application: ^7.0.8


### PR DESCRIPTION
### Summary

Integrates Detour SDK v0.4.0 for deferred deep linking and adds a dedicated demo modal to test the integration.

### Changes

- Bumped @swmansion/react-native-detour to 0.4.0.
- Added Universal Link support in Android Manifest and iOS Entitlements.
- Added `detour-demo.tsx` as a showcase modal for successful deep links (only for specific link).
- Added listening for Detour links and redirect to the demo modal.

### Testing

Trigger the demo route via this `https://privatemind.godetour.link/SneWQjYDGD/chat/detour` URL

---

<img width="343" height="747" alt="image" src="https://github.com/user-attachments/assets/4ae07f41-18c6-4b91-936c-1f14d0aec359" />


