### PR TITLE
Add support for pasting images

### DIFF
--- a/__mocks__/@react-native-clipboard/clipboard.ts
+++ b/__mocks__/@react-native-clipboard/clipboard.ts
@@ -1,6 +1,0 @@
-const Clipboard = {
-  setString: jest.fn(),
-  getString: jest.fn(() => Promise.resolve('')),
-};
-
-export default Clipboard;

--- a/__mocks__/expo-clipboard.ts
+++ b/__mocks__/expo-clipboard.ts
@@ -1,0 +1,6 @@
+export const setStringAsync = jest.fn(() => Promise.resolve());
+export const getStringAsync = jest.fn(() => Promise.resolve(''));
+export const setImageAsync = jest.fn(() => Promise.resolve());
+export const getImageAsync = jest.fn(() => Promise.resolve(null));
+export const hasStringAsync = jest.fn(() => Promise.resolve(false));
+export const hasImageAsync = jest.fn(() => Promise.resolve(false));

--- a/__mocks__/expo-paste-input.tsx
+++ b/__mocks__/expo-paste-input.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View } from 'react-native';
+
+export interface PasteEventPayload {
+  type: 'text' | 'images' | 'unsupported';
+  text?: string;
+  uris?: string[];
+}
+
+export const TextInputWrapper = ({ children, onPaste, style, ...props }: any) => {
+  return (
+    <View style={style} {...props}>
+      {children}
+    </View>
+  );
+};

--- a/__tests__/ChatBar.test.tsx
+++ b/__tests__/ChatBar.test.tsx
@@ -31,6 +31,7 @@ const mockUseAttachment = {
   removeAttachment: jest.fn(),
   clearAll: jest.fn(),
   openSheet: jest.fn(),
+  addPastedAttachment: jest.fn(),
 };
 
 jest.mock('../hooks/useAttachment', () => ({
@@ -432,5 +433,144 @@ describe('attachment', () => {
     expect(screen.queryByTestId('pick-library-btn')).toBeNull();
     expect(screen.queryByTestId('pick-camera-btn')).toBeNull();
     expect(screen.getByTestId('pick-document-btn')).toBeTruthy();
+  });
+});
+
+// ─── paste functionality ─────────────────────────────────────────────────────
+
+describe('paste functionality', () => {
+  it('calls addPastedAttachment when image is pasted to vision model', () => {
+    const { UNSAFE_getByType } = renderBar({ isVisionModel: true });
+    const TextInputWrapper = require('expo-paste-input').TextInputWrapper;
+    const wrapper = UNSAFE_getByType(TextInputWrapper);
+
+    // Simulate paste event with image
+    act(() => {
+      wrapper.props.onPaste({
+        type: 'images',
+        uris: ['file://test-pasted-image.jpg'],
+      });
+    });
+
+    expect(mockUseAttachment.addPastedAttachment).toHaveBeenCalledWith('file://test-pasted-image.jpg');
+  });
+
+  it('calls addPastedAttachment for multiple pasted images', () => {
+    const { UNSAFE_getByType } = renderBar({ isVisionModel: true });
+    const TextInputWrapper = require('expo-paste-input').TextInputWrapper;
+    const wrapper = UNSAFE_getByType(TextInputWrapper);
+
+    act(() => {
+      wrapper.props.onPaste({
+        type: 'images',
+        uris: ['file://image1.jpg', 'file://image2.png'],
+      });
+    });
+
+    expect(mockUseAttachment.addPastedAttachment).toHaveBeenCalledTimes(2);
+    expect(mockUseAttachment.addPastedAttachment).toHaveBeenCalledWith('file://image1.jpg');
+    expect(mockUseAttachment.addPastedAttachment).toHaveBeenCalledWith('file://image2.png');
+  });
+
+  it('does not call addPastedAttachment when text is pasted', () => {
+    const { UNSAFE_getByType } = renderBar();
+    const TextInputWrapper = require('expo-paste-input').TextInputWrapper;
+    const wrapper = UNSAFE_getByType(TextInputWrapper);
+
+    act(() => {
+      wrapper.props.onPaste({
+        type: 'text',
+        text: 'Hello world',
+      });
+    });
+
+    expect(mockUseAttachment.addPastedAttachment).not.toHaveBeenCalled();
+  });
+
+  it('shows toast when unsupported content is pasted', () => {
+    const { UNSAFE_getByType } = renderBar();
+    const TextInputWrapper = require('expo-paste-input').TextInputWrapper;
+    const wrapper = UNSAFE_getByType(TextInputWrapper);
+
+    act(() => {
+      wrapper.props.onPaste({
+        type: 'unsupported',
+      });
+    });
+
+    expect(Toast.show).toHaveBeenCalledWith(
+      expect.objectContaining({ text1: 'Unsupported clipboard content' })
+    );
+  });
+
+  it('shows error toast when paste processing fails', () => {
+    mockUseAttachment.addPastedAttachment.mockImplementation(() => {
+      throw new Error('Test error');
+    });
+
+    const { UNSAFE_getByType } = renderBar({ isVisionModel: true });
+    const TextInputWrapper = require('expo-paste-input').TextInputWrapper;
+    const wrapper = UNSAFE_getByType(TextInputWrapper);
+
+    act(() => {
+      wrapper.props.onPaste({
+        type: 'images',
+        uris: ['file://test.jpg'],
+      });
+    });
+
+    expect(Toast.show).toHaveBeenCalledWith(
+      expect.objectContaining({ text1: 'Error processing pasted content' })
+    );
+  });
+
+  it('handles empty uris array gracefully', () => {
+    const { UNSAFE_getByType } = renderBar();
+    const TextInputWrapper = require('expo-paste-input').TextInputWrapper;
+    const wrapper = UNSAFE_getByType(TextInputWrapper);
+
+    act(() => {
+      wrapper.props.onPaste({
+        type: 'images',
+        uris: [],
+      });
+    });
+
+    expect(mockUseAttachment.addPastedAttachment).not.toHaveBeenCalled();
+  });
+
+  it('blocks image paste for non-vision models', () => {
+    const { UNSAFE_getByType } = renderBar({ isVisionModel: false });
+    const TextInputWrapper = require('expo-paste-input').TextInputWrapper;
+    const wrapper = UNSAFE_getByType(TextInputWrapper);
+
+    act(() => {
+      wrapper.props.onPaste({
+        type: 'images',
+        uris: ['file://test.jpg'],
+      });
+    });
+
+    expect(mockUseAttachment.addPastedAttachment).not.toHaveBeenCalled();
+    expect(Toast.show).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text1: 'This model does not support images',
+      })
+    );
+  });
+
+  it('allows image paste for vision models', () => {
+    const { UNSAFE_getByType } = renderBar({ isVisionModel: true });
+    const TextInputWrapper = require('expo-paste-input').TextInputWrapper;
+    const wrapper = UNSAFE_getByType(TextInputWrapper);
+
+    act(() => {
+      wrapper.props.onPaste({
+        type: 'images',
+        uris: ['file://test.jpg'],
+      });
+    });
+
+    expect(mockUseAttachment.addPastedAttachment).toHaveBeenCalledWith('file://test.jpg');
   });
 });

--- a/__tests__/useAttachment.test.ts
+++ b/__tests__/useAttachment.test.ts
@@ -109,4 +109,85 @@ describe('useAttachment', () => {
     act(() => { result.current.clearAll(); });
     expect(result.current.attachments).toEqual([]);
   });
+
+  describe('addPastedAttachment', () => {
+    it('adds pasted image attachment for valid image URI', () => {
+      const { result } = renderHook(() => useAttachment());
+      act(() => {
+        result.current.addPastedAttachment('file://pasted-image.jpg');
+      });
+      expect(result.current.attachments).toHaveLength(1);
+      expect(result.current.attachments[0].type).toBe('image');
+      expect(result.current.attachments[0].uri).toBe('file://pasted-image.jpg');
+      expect(result.current.attachments[0].status).toBe('ready');
+    });
+
+    it('supports multiple image formats', () => {
+      const { result } = renderHook(() => useAttachment());
+      const formats = [
+        'file://image.jpg',
+        'file://image.jpeg',
+        'file://image.png',
+        'file://image.gif',
+        'file://image.webp',
+        'file://image.heic',
+      ];
+
+      formats.forEach(uri => {
+        act(() => {
+          result.current.addPastedAttachment(uri);
+        });
+      });
+
+      expect(result.current.attachments).toHaveLength(formats.length);
+      result.current.attachments.forEach(att => {
+        expect(att.type).toBe('image');
+        expect(att.status).toBe('ready');
+      });
+    });
+
+    it('shows toast and does not add attachment for non-image URI', () => {
+      const Toast = require('react-native-toast-message');
+      const { result } = renderHook(() => useAttachment());
+
+      act(() => {
+        result.current.addPastedAttachment('file://document.pdf');
+      });
+
+      expect(result.current.attachments).toHaveLength(0);
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text1: expect.stringContaining('Only images can be pasted'),
+        })
+      );
+    });
+
+    it('handles empty URI gracefully', () => {
+      const { result } = renderHook(() => useAttachment());
+      act(() => {
+        result.current.addPastedAttachment('');
+      });
+      expect(result.current.attachments).toHaveLength(0);
+    });
+
+    it('handles invalid URI type gracefully', () => {
+      const { result } = renderHook(() => useAttachment());
+      act(() => {
+        // @ts-expect-error testing invalid input
+        result.current.addPastedAttachment(null);
+      });
+      expect(result.current.attachments).toHaveLength(0);
+    });
+
+    it('generates IDs for pasted attachments', () => {
+      const { result } = renderHook(() => useAttachment());
+
+      act(() => {
+        result.current.addPastedAttachment('file://image1.jpg');
+      });
+
+      expect(result.current.attachments).toHaveLength(1);
+      expect(result.current.attachments[0].id).toMatch(/^img-\d+$/);
+    });
+  });
 });

--- a/app/(modals)/app-info.tsx
+++ b/app/(modals)/app-info.tsx
@@ -7,7 +7,7 @@ import {
   Linking,
 } from 'react-native';
 import { useRouter } from 'expo-router';
-import Clipboard from '@react-native-clipboard/clipboard';
+import * as Clipboard from 'expo-clipboard';
 import Toast from 'react-native-toast-message';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { fontSizes, fontFamily } from '../../styles/fontStyles';
@@ -93,8 +93,8 @@ const LearnMoreSection = () => {
 const VersionInfo = () => {
   const { theme } = useTheme();
 
-  const handleCopyVersion = () => {
-    Clipboard.setString(APP_VERSION);
+  const handleCopyVersion = async () => {
+    await Clipboard.setStringAsync(APP_VERSION);
     Toast.show({
       type: 'defaultToast',
       text1: 'Successfully copied version to clipboard',

--- a/components/bottomSheets/MessageManagementSheet.tsx
+++ b/components/bottomSheets/MessageManagementSheet.tsx
@@ -9,7 +9,7 @@ import { Theme } from '../../styles/colors';
 import { useTheme } from '../../context/ThemeContext';
 import EntryButton from '../EntryButton';
 import CopyIcon from '../../assets/icons/copy.svg';
-import Clipboard from '@react-native-clipboard/clipboard';
+import * as Clipboard from 'expo-clipboard';
 import Toast from 'react-native-toast-message';
 
 interface Props {
@@ -46,8 +46,8 @@ const MessageManagementSheet = ({ bottomSheetModalRef }: Props) => {
           <EntryButton
             text="Copy to clipboard"
             icon={<CopyIcon width={19} height={20} style={styles.icon} />}
-            onPress={() => {
-              Clipboard.setString(props.data);
+            onPress={async () => {
+              await Clipboard.setStringAsync(props.data);
               Toast.show({
                 type: 'defaultToast',
                 text1: 'Message copied to clipboard',

--- a/components/chat-screen/ChatBar.tsx
+++ b/components/chat-screen/ChatBar.tsx
@@ -8,12 +8,13 @@ import React, {
 } from 'react';
 import {
   View,
-  TextInput,
+  TextInput as RNTextInput,
   TouchableOpacity,
   Text,
   StyleSheet,
   Keyboard,
 } from 'react-native';
+import { type PasteEventPayload, TextInputWrapper } from 'expo-paste-input';
 import AttachmentSheet from '../bottomSheets/AttachmentSheet';
 import { useAttachment, Attachment } from '../../hooks/useAttachment';
 import { Model } from '../../database/modelRepository';
@@ -33,7 +34,11 @@ import Toast from 'react-native-toast-message';
 
 interface Props {
   chatId: number | null;
-  onSend: (userInput: string, imagePath?: string, attachments?: Attachment[]) => void;
+  onSend: (
+    userInput: string,
+    imagePath?: string,
+    attachments?: Attachment[]
+  ) => void;
   onSelectModel: () => void;
   onSelectPrompt: (prompt: string) => void;
   ref: Ref<{
@@ -76,12 +81,16 @@ const ChatBar = ({
     removeAttachment,
     clearAll,
     openSheet,
+    addPastedAttachment,
   } = useAttachment();
 
   useImperativeHandle(
     ref,
     () => ({
-      clear: () => { setUserInput(''); clearAll(); },
+      clear: () => {
+        setUserInput('');
+        clearAll();
+      },
       setInput: (text: string) => setUserInput(text),
     }),
     [clearAll]
@@ -113,7 +122,42 @@ const ChatBar = ({
     if (hasLoadingAttachment) return;
     onSend(userInput, imageAttachment?.uri, attachments);
     clearAll();
-  }, [onSend, userInput, imageAttachment, attachments, clearAll, hasLoadingAttachment]);
+  }, [
+    onSend,
+    userInput,
+    imageAttachment,
+    attachments,
+    clearAll,
+    hasLoadingAttachment,
+  ]);
+
+  const onPaste = useCallback(
+    (payload: PasteEventPayload) => {
+      try {
+        if (payload.type === 'text') {
+          return;
+        }
+
+        if (payload.type === 'images' && payload.uris?.length > 0) {
+          payload.uris.forEach((uri) => addPastedAttachment(uri));
+          return;
+        }
+
+        if (payload.type === 'unsupported') {
+          Toast.show({
+            type: 'defaultToast',
+            text1: 'Unsupported clipboard content',
+          });
+        }
+      } catch {
+        Toast.show({
+          type: 'defaultToast',
+          text1: 'Error processing pasted content',
+        });
+      }
+    },
+    [addPastedAttachment]
+  );
 
   const [showSpeechInput, setShowSpeechInput] = React.useState(false);
 
@@ -190,22 +234,27 @@ const ChatBar = ({
               </>
             )}
             <View style={styles.content}>
-              <TextInput
-                style={styles.input}
-                multiline
-                onFocus={async () => {
-                  if (!isAtBottom) return;
-                  await loadSelectedModel();
-                  setTimeout(() => {
-                    scrollRef.current?.scrollToEnd({ animated: true });
-                  }, 25);
-                }}
-                placeholder="Ask about anything..."
-                placeholderTextColor={theme.text.contrastTertiary}
-                value={userInput}
-                onChangeText={setUserInput}
-                numberOfLines={3}
-              />
+              <TextInputWrapper
+                onPaste={onPaste}
+                style={styles.textInputWrapper}
+              >
+                <RNTextInput
+                  style={styles.input}
+                  multiline
+                  onFocus={async () => {
+                    if (!isAtBottom) return;
+                    await loadSelectedModel();
+                    setTimeout(() => {
+                      scrollRef.current?.scrollToEnd({ animated: true });
+                    }, 25);
+                  }}
+                  placeholder="Ask about anything..."
+                  placeholderTextColor={theme.text.contrastTertiary}
+                  value={userInput}
+                  onChangeText={setUserInput}
+                  numberOfLines={3}
+                />
+              </TextInputWrapper>
             </View>
             <ChatBarActions
               onAttach={handleAttach}
@@ -274,13 +323,18 @@ const createStyles = (theme: Theme) =>
       gap: 8,
       justifyContent: 'center',
     },
+    textInputWrapper: {
+      flex: 1,
+      minHeight: 40,
+    },
     input: {
       flex: 1,
-      fontSize: fontSizes.md,
-      lineHeight: lineHeights.md,
+      fontSize: fontSizes.lg,
+      lineHeight: lineHeights.lg,
       fontFamily: fontFamily.regular,
       textAlignVertical: 'center',
       color: theme.text.contrastPrimary,
+      minHeight: 40,
     },
     previewRow: {
       flexDirection: 'row',

--- a/components/chat-screen/ChatBar.tsx
+++ b/components/chat-screen/ChatBar.tsx
@@ -139,6 +139,13 @@ const ChatBar = ({
         }
 
         if (payload.type === 'images' && payload.uris?.length > 0) {
+          if (!isVisionModel) {
+            Toast.show({
+              type: 'defaultToast',
+              text1: 'This model does not support images',
+            });
+            return;
+          }
           payload.uris.forEach((uri) => addPastedAttachment(uri));
           return;
         }
@@ -156,7 +163,7 @@ const ChatBar = ({
         });
       }
     },
-    [addPastedAttachment]
+    [addPastedAttachment, isVisionModel]
   );
 
   const [showSpeechInput, setShowSpeechInput] = React.useState(false);

--- a/hooks/useAttachment.ts
+++ b/hooks/useAttachment.ts
@@ -31,6 +31,12 @@ const requestAndroidGalleryPermission = async (): Promise<boolean> => {
   return result === PermissionsAndroid.RESULTS.GRANTED;
 };
 
+const isImageUri = (uri: string): boolean => {
+  const imageExtensions = ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp', '.heic', '.heif'];
+  const lowerUri = uri.toLowerCase();
+  return imageExtensions.some((ext) => lowerUri.includes(ext));
+};
+
 export const useAttachment = () => {
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const sheetRef = useRef<BottomSheetModal>(null);
@@ -163,6 +169,28 @@ export const useAttachment = () => {
     sheetRef.current?.present();
   }, []);
 
+  const addPastedAttachment = useCallback(
+    (uri: string) => {
+      if (!uri || typeof uri !== 'string') {
+        return;
+      }
+
+      if (!isImageUri(uri)) {
+        Toast.show({
+          type: 'defaultToast',
+          text1: 'Only images can be pasted. Use the + button for documents.',
+        });
+        return;
+      }
+
+      setAttachments((prev) => [
+        ...prev,
+        { id: `img-${Date.now()}`, type: 'image', uri, status: 'ready' },
+      ]);
+    },
+    []
+  );
+
   return {
     attachments,
     sheetRef,
@@ -172,5 +200,6 @@ export const useAttachment = () => {
     removeAttachment,
     clearAll,
     openSheet,
+    addPastedAttachment,
   };
 };

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1564,7 +1564,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - react-native-executorch (0.8.1):
+  - react-native-executorch (0.9.0):
     - hermes-engine
     - opencv-rne (~> 4.11.0)
     - RCTRequired
@@ -3011,7 +3011,6 @@ SPEC CHECKSUMS:
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   op-sqlite: d9827bbb015ca71c44763d6b447afe2c12d20261
   opencv-rne: 2305807573b6e29c8c87e3416ab096d09047a7a0
-<<<<<<< HEAD
   Pdfium: 4a0412b69bb0172892aaed9254b430289a99f1c8
   RCTDeprecation: 5045f20b2cc1239bf422764004338c720684a22f
   RCTRequired: b6b9724225dd780ac2989d2e575d5513c50fe04b
@@ -3050,7 +3049,6 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 274cb203819492f7fb594bbb3a1f3f5061fa794d
   React-microtasksnativemodule: 563b4dcc8b8570814d6de4fc1196f48d2944acd4
   react-native-executorch: 41b4bc927366039f280b696a972c4a832cceae08
-=======
   Pdfium: 98523f87c89566d777ffc3ca0a787b990d51064c
   RCTDeprecation: 943572d4be82d480a48f4884f670135ae30bf990
   RCTRequired: 8f3cfc90cc25cf6e420ddb3e7caaaabc57df6043
@@ -3086,7 +3084,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 9050ee10c19f4f7fca8963d0211b2854d624973e
   React-microtasksnativemodule: f775db9e991c6f3b8ccbc02bfcde22770f96e23b
   react-native-executorch: c02a5a1a66609ca24e9eaf86b15c83b7af4425cc
->>>>>>> 985af21 (deps: update Podfile.lock)
+  react-native-executorch: 6b939cfa959b26138c13b171797919d57a05be90
   react-native-image-picker: 48d850454b4a389753053e1d7378b624d3b47d77
   react-native-keyboard-controller: c872321fc580f8d815e9e2ad5558b24c26c18b4f
   react-native-netinfo: f852c868bf5175e46165c7e4db48a204a95c3800

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react-native-audio-api": "0.12.0-nightly-f7c925b-20260402",
     "react-native-device-info": "^15.0.1",
     "react-native-enriched-markdown": "^0.4.1",
-    "react-native-executorch": "^0.8.1",
+    "react-native-executorch": "./react-native-executorch-0.9.0.tgz",
     "react-native-executorch-expo-resource-fetcher": "^0.8.0",
     "react-native-gesture-handler": "~2.30.0",
     "react-native-image-picker": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
       "^react-native-toast-message$": "<rootDir>/__mocks__/react-native-toast-message.ts",
       "^react-native-reanimated$": "<rootDir>/__mocks__/react-native-reanimated.ts",
       "^react-native-audio-api$": "<rootDir>/__mocks__/react-native-audio-api.ts",
+      "^expo-clipboard$": "<rootDir>/__mocks__/expo-clipboard.ts",
+      "^expo-paste-input$": "<rootDir>/__mocks__/expo-paste-input.tsx",
       "^@gorhom/bottom-sheet$": "<rootDir>/__mocks__/@gorhom/bottom-sheet.tsx",
       "^react-native-safe-area-context$": "<rootDir>/__mocks__/react-native-safe-area-context.ts",
       "^expo-store-review$": "<rootDir>/__mocks__/expo-store-review.ts"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
       "^react-native-toast-message$": "<rootDir>/__mocks__/react-native-toast-message.ts",
       "^react-native-reanimated$": "<rootDir>/__mocks__/react-native-reanimated.ts",
       "^react-native-audio-api$": "<rootDir>/__mocks__/react-native-audio-api.ts",
-      "^@react-native-clipboard/clipboard$": "<rootDir>/__mocks__/@react-native-clipboard/clipboard.ts",
       "^@gorhom/bottom-sheet$": "<rootDir>/__mocks__/@gorhom/bottom-sheet.tsx",
       "^react-native-safe-area-context$": "<rootDir>/__mocks__/react-native-safe-area-context.ts",
       "^expo-store-review$": "<rootDir>/__mocks__/expo-store-review.ts"
@@ -49,7 +48,6 @@
     "@gorhom/bottom-sheet": "^5.2.8",
     "@op-engineering/op-sqlite": "^15.2.7",
     "@react-native-async-storage/async-storage": "2.2.0",
-    "@react-native-clipboard/clipboard": "^1.16.2",
     "@react-native-community/netinfo": "11.5.2",
     "@react-native-rag/executorch": "^0.8.0",
     "@react-native-rag/op-sqlite": "^0.8.0",
@@ -67,6 +65,7 @@
     "expo-haptics": "~55.0.13",
     "expo-linking": "~55.0.11",
     "expo-localization": "~55.0.12",
+    "expo-paste-input": "^0.1.15",
     "expo-router": "~55.0.11",
     "expo-sharing": "~55.0.17",
     "expo-splash-screen": "~55.0.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2891,23 +2891,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-clipboard/clipboard@npm:^1.16.2":
-  version: 1.16.2
-  resolution: "@react-native-clipboard/clipboard@npm:1.16.2"
-  peerDependencies:
-    react: ">= 16.9.0"
-    react-native: ">= 0.61.5"
-    react-native-macos: ">= 0.61.0"
-    react-native-windows: ">= 0.61.0"
-  peerDependenciesMeta:
-    react-native-macos:
-      optional: true
-    react-native-windows:
-      optional: true
-  checksum: 4b5b2d9cdd3f1540af6cd8d1596a2e4acc85cb6bcad5778dd1b1eeb78265e326aec1f624efc8e1113cf36293902a84c5c6afa155a1e1434916c79eef6d09da3d
-  languageName: node
-  linkType: hard
-
 "@react-native-community/netinfo@npm:11.5.2":
   version: 11.5.2
   resolution: "@react-native-community/netinfo@npm:11.5.2"
@@ -5670,6 +5653,17 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 3f1dc12d9dde206e11e5ae2ddb944016ad5f8c25a5b2672d98cf38ee925099cafc5202c1d9c0e8c922c88ec32277acca2aa0798f7f498ef1371dade468bfc365
+  languageName: node
+  linkType: hard
+
+"expo-paste-input@npm:^0.1.15":
+  version: 0.1.15
+  resolution: "expo-paste-input@npm:0.1.15"
+  peerDependencies:
+    expo: "*"
+    react: "*"
+    react-native: "*"
+  checksum: 2a116c8f2cd63d0b9e8e3d4f34ab250a7ff6e56e0dcab0db94dec7e1c236e68d7daa02d3947611aaf7ce6e8232a5e988f50344aac24eea921ac913fd123478e5
   languageName: node
   linkType: hard
 
@@ -9217,7 +9211,6 @@ __metadata:
     "@gorhom/bottom-sheet": ^5.2.8
     "@op-engineering/op-sqlite": ^15.2.7
     "@react-native-async-storage/async-storage": 2.2.0
-    "@react-native-clipboard/clipboard": ^1.16.2
     "@react-native-community/netinfo": 11.5.2
     "@react-native-rag/executorch": ^0.8.0
     "@react-native-rag/op-sqlite": ^0.8.0
@@ -9239,6 +9232,7 @@ __metadata:
     expo-haptics: ~55.0.13
     expo-linking: ~55.0.11
     expo-localization: ~55.0.12
+    expo-paste-input: ^0.1.15
     expo-router: ~55.0.11
     expo-sharing: ~55.0.17
     expo-splash-screen: ~55.0.16

--- a/yarn.lock
+++ b/yarn.lock
@@ -9253,7 +9253,7 @@ __metadata:
     react-native-audio-api: 0.12.0-nightly-f7c925b-20260402
     react-native-device-info: ^15.0.1
     react-native-enriched-markdown: ^0.4.1
-    react-native-executorch: ^0.8.1
+    react-native-executorch: ./react-native-executorch-0.9.0.tgz
     react-native-executorch-expo-resource-fetcher: ^0.8.0
     react-native-gesture-handler: ~2.30.0
     react-native-image-picker: ^8.2.1
@@ -9502,9 +9502,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-executorch@npm:^0.8.1":
-  version: 0.8.1
-  resolution: "react-native-executorch@npm:0.8.1"
+"react-native-executorch@file:./react-native-executorch-0.9.0.tgz::locator=private-mind%40workspace%3A.":
+  version: 0.9.0
+  resolution: "react-native-executorch@file:./react-native-executorch-0.9.0.tgz::locator=private-mind%40workspace%3A."
   dependencies:
     "@huggingface/jinja": ^0.5.0
     jsonrepair: ^3.12.0
@@ -9514,7 +9514,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 426ef62f638374c443fc3697244f7ffb163c74a92eb70116351ba358a6a9ace2058eff42ad577a750b2dab231be59bdae55fd046e9834f4d150a57b5fff9686f
+  checksum: 3ee30a525cb9c588ede6385cc9cd924b62666a9a17ebdec557723fad60c1ec3ae103486950da585c36b225646a614490cd648d4946db0c5817e451802245ae40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds image paste functionality to the chat input and migrates clipboard handling from `@react-native-clipboard/clipboard` to Expo modules.

## Changes

### Features
- **Image pasting**: Users can paste images directly into chat input.
- Pasted images appear as attachment thumbnails alongside camera/library uploads
- Text pasting continues to work normally

## Test Plan

### Image Pasting
- [x] Copy image from Photos, paste into chat input → appears as thumbnail
- [x] Remove pasted image with × button → removed from attachments
- [x] Paste multiple images → all appear as thumbnails
- [x] Send message with pasted image → includes image in message

### Text Pasting
- [x] Copy text, paste into chat input → text appears in input field
- [x] Paste with cursor mid-text → inserts at cursor position
- [x] Paste multi-line text → preserves formatting
- [x] Paste emoji/special characters → works correctly

### Copy to Clipboard
- [x] App Info: tap copy version → shows toast, can paste elsewhere


### Edge Cases
- [ ] Paste unsupported content → shows "Unsupported clipboard content" toast
- [x] Paste while attachments exist → appends to existing
- [x] Paste empty clipboard → no errors

### Regression
- [x] Camera/library image picker still works
- [x] Document picker still works
- [x] Message sending with attachments works
- [x] Attachment removal works

## Notes

PDF/document pasting is not supported (library limitation). Documents must use the + button.
