### PR TITLE
chore: stop bundling whisper model

### DIFF
--- a/scripts/download-models.js
+++ b/scripts/download-models.js
@@ -6,24 +6,12 @@ const { Readable } = require('stream');
 
 const VERSION_TAG = 'v0.8.0';
 
-const WHISPER_TINY_EN_FILES = [
-  `https://huggingface.co/software-mansion/react-native-executorch-whisper-tiny.en/resolve/${VERSION_TAG}/tokenizer.json`,
-  `https://huggingface.co/software-mansion/react-native-executorch-whisper-tiny.en/resolve/${VERSION_TAG}/xnnpack/whisper_tiny_en_xnnpack.pte`,
-];
-
 const ALL_MINI_LM_FILES = [
   `https://huggingface.co/software-mansion/react-native-executorch-all-MiniLM-L6-v2/resolve/${VERSION_TAG}/all-MiniLM-L6-v2_xnnpack.pte`,
   `https://huggingface.co/software-mansion/react-native-executorch-all-MiniLM-L6-v2/resolve/${VERSION_TAG}/tokenizer.json`,
 ];
 
 async function ensureModelAssets() {
-  const whisperDir = path.join(
-    __dirname,
-    '..',
-    'assets',
-    'models',
-    'whisper-tiny-en'
-  );
   const allMinilmDir = path.join(
     __dirname,
     '..',
@@ -31,25 +19,7 @@ async function ensureModelAssets() {
     'models',
     'all-mini-lm'
   );
-  fs.mkdirSync(whisperDir, { recursive: true });
   fs.mkdirSync(allMinilmDir, { recursive: true });
-
-  for (const url of WHISPER_TINY_EN_FILES) {
-    const name = url.split('/').pop();
-    const filePath = path.join(whisperDir, name);
-    if (fs.existsSync(filePath)) {
-      continue;
-    }
-
-    console.log(`Downloading ${url}...`);
-    const res = await fetch(url);
-    await new Promise((resolve, reject) => {
-      const fileStream = fs.createWriteStream(filePath);
-      fileStream.on('finish', resolve);
-      fileStream.on('error', reject);
-      Readable.fromWeb(res.body).pipe(fileStream);
-    });
-  }
 
   for (const url of ALL_MINI_LM_FILES) {
     const name = url.split('/').pop();

--- a/utils/modelConfig.ts
+++ b/utils/modelConfig.ts
@@ -23,20 +23,6 @@ export enum ModelSourceStrategy {
   ASSET_PACK_COPY = 'asset_pack_copy',
 }
 
-export const WHISPER_TINY_EN_MODEL: ModelDefinition = {
-  assetPackName: 'whisper-tiny-en',
-  bundledAssets: {
-    decoderSource: require('../assets/models/whisper-tiny-en/whisper_tiny_en_decoder_xnnpack.pte'),
-    encoderSource: require('../assets/models/whisper-tiny-en/whisper_tiny_en_encoder_xnnpack.pte'),
-    tokenizerSource: require('../assets/models/whisper-tiny-en/tokenizer.json'),
-  },
-  assetPackFiles: {
-    decoderSource: 'whisper_tiny_en_decoder_xnnpack.pte',
-    encoderSource: 'whisper_tiny_en_encoder_xnnpack.pte',
-    tokenizerSource: 'tokenizer.json',
-  },
-};
-
 export const ALL_MINI_LM_MODEL: ModelDefinition = {
   assetPackName: 'all-mini-lm',
   bundledAssets: {


### PR DESCRIPTION
## Summary
- Whisper is loaded at runtime via `SpeechToTextModule.fromModelName(WHISPER_TINY_EN, ...)` in [store/sttStore.ts](store/sttStore.ts), so the bundled whisper assets and their `download-models` step were unused.
- Drops `WHISPER_TINY_EN_MODEL` from [utils/modelConfig.ts](utils/modelConfig.ts) and the whisper download block from [scripts/download-models.js](scripts/download-models.js).
- `ALL_MINI_LM_MODEL` bundling is unchanged.

## Test plan
- [x] `yarn test` — 354/354 passing
- [ ] Verify STT still works on a device (whisper downloads on first use)
- [ ] Verify Android release AAB still ships the all-mini-lm asset pack via `./scripts/build-release.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)