### PR TITLE
fix(chat): persist VLM image attachments to document directory

### DIFF
--- a/components/chat-screen/ChatScreen.tsx
+++ b/components/chat-screen/ChatScreen.tsx
@@ -27,6 +27,7 @@ import { filterAndFormatContext, formatFirstChunks } from '../../utils/contextUt
 import { useSourceStore } from '../../store/sourceStore';
 import useChatSettings from '../../hooks/useChatSettings';
 import Toast from 'react-native-toast-message';
+import { persistImage } from '../../utils/persistImage';
 
 interface Props {
   chatId: number;
@@ -120,6 +121,20 @@ export default function ChatScreen({
       await addChat(newChatTitle, model!.id);
     }
 
+    let persistedImagePath: string | undefined = imagePath;
+    if (imagePath) {
+      try {
+        persistedImagePath = await persistImage(imagePath);
+      } catch (error) {
+        console.error('Failed to persist image attachment:', error);
+        Toast.show({
+          type: 'defaultToast',
+          text1: 'Failed to save image attachment.',
+        });
+        return;
+      }
+    }
+
     inputRef.current?.clear();
     Keyboard.dismiss();
     updateLastUsed(chatId!);
@@ -170,7 +185,7 @@ export default function ChatScreen({
     const docAttachments = attachments?.filter((a) => a.type === 'document') || [];
     const docName = docAttachments.map((a) => a.name).filter(Boolean).join(', ') || undefined;
     await sendChatMessage(
-      userInput, chatId!, context, settings, imagePath,
+      userInput, chatId!, context, settings, persistedImagePath,
       docName
     );
   };

--- a/utils/persistImage.ts
+++ b/utils/persistImage.ts
@@ -1,0 +1,27 @@
+import { Directory, File, Paths } from 'expo-file-system';
+
+const CHAT_IMAGES_DIR = 'chat-images';
+
+export async function persistImage(sourceUri: string): Promise<string> {
+  const dir = new Directory(Paths.document, CHAT_IMAGES_DIR);
+  dir.create({ idempotent: true, intermediates: true });
+
+  const ext = extractExtension(sourceUri);
+  const filename = `img-${Date.now()}-${Math.random().toString(36).slice(2, 8)}${ext}`;
+  const destination = new File(Paths.document, CHAT_IMAGES_DIR, filename);
+
+  const source = new File(sourceUri);
+  source.copy(destination);
+
+  return destination.uri;
+}
+
+function extractExtension(uri: string): string {
+  const pathPart = uri.split('?')[0].split('#')[0];
+  const lastSegment = pathPart.split('/').pop() ?? '';
+  const dotIndex = lastSegment.lastIndexOf('.');
+  if (dotIndex <= 0 || dotIndex === lastSegment.length - 1) {
+    return '.jpg';
+  }
+  return lastSegment.slice(dotIndex).toLowerCase();
+}


### PR DESCRIPTION
## Summary
- Image picker hands back URIs in the OS cache directory (iOS `tmp/`, Android picker cache). Storing those in the chat DB means historic messages point at files the OS can wipe any time.
- On send, copy the picked image into `\${Paths.document}/chat-images/` via `expo-file-system` and store that stable path in the DB instead.
- Persist-on-send (not on pick) so cancelled/cleared attachments don't leave orphaned files.

## Test plan
- [x] `yarn test` — 354/354 passing
- [ ] Send an image in a new chat, force-kill the app, reopen — image still renders in the conversation
- [ ] Pick an image, remove it before sending — verify no orphan file in `chat-images/`
- [ ] Error path: simulate copy failure — verify toast shows and send is aborted

🤖 Generated with [Claude Code](https://claude.com/claude-code)