### PR TITLE
chore: bump version to 1.1.5

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -92,8 +92,8 @@ android {
         applicationId 'com.swmansion.privatemind'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.1.4"
+        versionCode 61
+        versionName "1.1.5"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "scheme": "private-mind",
     "name": "Private Mind",
     "slug": "private-mind",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "orientation": "portrait",
     "icon": "./assets/icons/icon.png",
     "userInterfaceStyle": "automatic",

--- a/app/(modals)/app-info.tsx
+++ b/app/(modals)/app-info.tsx
@@ -19,7 +19,7 @@ import GithubIcon from '../../assets/icons/github.svg';
 import CopyIcon from '../../assets/icons/copy.svg';
 import FooterIcon from '../../assets/icons/footer.svg';
 
-const APP_VERSION = 'v.1.1.4';
+const APP_VERSION = 'v.1.1.5';
 
 const GITHUB_LINKS: { text: string; url: string }[] = [
   {

--- a/ios/PrivateMind/Info.plist
+++ b/ios/PrivateMind/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.4</string>
+	<string>1.1.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -33,7 +33,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>12.0</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "private-mind",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Summary
- Bump app version to 1.1.5 across [package.json](package.json), [app.json](app.json), [android/app/build.gradle](android/app/build.gradle), and [ios/PrivateMind/Info.plist](ios/PrivateMind/Info.plist).
- Android `versionCode`: 1 → 61 (continuing from the last real release at 60).
- iOS `CFBundleVersion`: 2 → 3.

## Test plan
- [ ] Android: CI produces an AAB with `versionName 1.1.5` / `versionCode 61`
- [ ] iOS: Xcode archive shows `1.1.5 (3)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)