### PR TITLE
fix(chat): harden model select sheet + feature LFM 2.5 VL 450M

### DIFF
--- a/__mocks__/@gorhom/bottom-sheet.tsx
+++ b/__mocks__/@gorhom/bottom-sheet.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
-import { View } from 'react-native';
+import { View, FlatList } from 'react-native';
 
-export const BottomSheetModal = React.forwardRef((_props: any, _ref: any) => null);
+export const BottomSheetModal = React.forwardRef(
+  ({ children }: any, _ref: any) => <>{children}</>
+);
 export const BottomSheetView = ({ children, style }: any) => (
   <View style={style}>{children}</View>
 );
+export const BottomSheetFlatList = (props: any) => <FlatList {...props} />;
 export const BottomSheetBackdrop = () => null;
 export const BottomSheetModalProvider = ({ children }: any) => <>{children}</>;
+export const useBottomSheetTimingConfigs = (_config: any) => ({});
+export const useBottomSheetSpringConfigs = (_config: any) => ({});

--- a/__mocks__/react-native-executorch.ts
+++ b/__mocks__/react-native-executorch.ts
@@ -33,6 +33,7 @@ export const PHI_4_MINI_4B_QUANTIZED = makeModelConstants('phi4-mini-4b-quantize
 export const LFM2_5_1_2B_INSTRUCT = makeModelConstants('lfm2.5-1.2b-instruct');
 export const LFM2_5_1_2B_INSTRUCT_QUANTIZED = makeModelConstants('lfm2.5-1.2b-instruct-quantized');
 export const LFM2_VL_1_6B_QUANTIZED = makeModelConstants('lfm2-vl-1.6b-quantized');
+export const LFM2_VL_450M_QUANTIZED = makeModelConstants('lfm2-vl-450m-quantized');
 export const WHISPER_TINY_EN = 'whisper-tiny-en';
 
 export const LLMModule = {

--- a/__tests__/ModelSelectSheet.test.tsx
+++ b/__tests__/ModelSelectSheet.test.tsx
@@ -34,16 +34,27 @@ jest.mock('@gorhom/bottom-sheet', () => {
   const { View } = require('react-native');
   let _data: any = null;
 
-  const BottomSheetModal = React.forwardRef((props: any, _ref: any) => (
-    <View>{props.children}</View>
-  ));
+  const BottomSheetModal = React.forwardRef((props: any, _ref: any) => {
+    React.useEffect(() => {
+      props.onChange?.(0);
+    }, []);
+    return <View>{props.children}</View>;
+  });
   const BottomSheetFlatList = ({ data, renderItem }: any) => (
     <View>{data.map((item: any, i: number) => <View key={i}>{renderItem({ item })}</View>)}</View>
   );
   const BottomSheetView = ({ children, style }: any) => <View style={style}>{children}</View>;
   const BottomSheetBackdrop = () => null;
 
-  return { BottomSheetModal, BottomSheetFlatList, BottomSheetView, BottomSheetBackdrop };
+  const useBottomSheetTimingConfigs = () => ({});
+
+  return {
+    BottomSheetModal,
+    BottomSheetFlatList,
+    BottomSheetView,
+    BottomSheetBackdrop,
+    useBottomSheetTimingConfigs,
+  };
 });
 
 import ModelSelectSheet from '../components/bottomSheets/ModelSelectSheet';

--- a/components/bottomSheets/ModelSelectSheet.tsx
+++ b/components/bottomSheets/ModelSelectSheet.tsx
@@ -4,7 +4,9 @@ import {
   BottomSheetFlatList,
   BottomSheetView,
   BottomSheetBackdrop,
+  useBottomSheetTimingConfigs,
 } from '@gorhom/bottom-sheet';
+import { Easing } from 'react-native-reanimated';
 import { router } from 'expo-router';
 import { View, StyleSheet, Text, Platform } from 'react-native';
 import { useModelStore } from '../../store/modelStore';
@@ -31,6 +33,11 @@ const ModelSelectSheet = ({
   const styles = useMemo(() => createStyles(theme), [theme]);
   const { downloadedModels } = useModelStore();
   const [search, setSearch] = useState('');
+  const [isFullyOpen, setIsFullyOpen] = useState(false);
+  const animationConfigs = useBottomSheetTimingConfigs({
+    duration: 150,
+    easing: Easing.out(Easing.cubic),
+  });
 
   const filteredModels = downloadedModels.filter((model) =>
     model.modelName.toLowerCase().includes(search.toLowerCase())
@@ -55,15 +62,18 @@ const ModelSelectSheet = ({
       onChange={(index) => onSheetStateChange?.(index >= 0)}
       onDismiss={() => onSheetStateChange?.(false)}
       snapPoints={['30%', '50%']}
+      animationConfigs={animationConfigs}
       enableDynamicSizing={false}
       handleStyle={styles.handle}
       handleIndicatorStyle={styles.handleIndicator}
       backgroundStyle={styles.background}
       keyboardBehavior={Platform.OS === 'ios' ? 'interactive' : 'fillParent'}
       keyboardBlurBehavior="restore"
+      onChange={(i) => setIsFullyOpen(i >= 0)}
+      onDismiss={() => setIsFullyOpen(false)}
     >
       {downloadedModels.length > 0 ? (
-        <View style={styles.content}>
+        <View style={styles.content} pointerEvents={isFullyOpen ? 'auto' : 'none'}>
           <Text style={[styles.title, styles.horizontalInset]}>
             Select a Model
           </Text>

--- a/constants/default-models.ts
+++ b/constants/default-models.ts
@@ -29,11 +29,12 @@ import {
   LFM2_5_1_2B_INSTRUCT,
   LFM2_5_1_2B_INSTRUCT_QUANTIZED,
   LFM2_VL_1_6B_QUANTIZED,
+  LFM2_VL_450M_QUANTIZED,
 } from 'react-native-executorch';
 
 export const startingModels = [
-  'LLaMA 3.2 - 1B - SpinQuant',
-  'Qwen 3 - 0.6B - Quantized',
+  'LFM 2.5 - 1.2B - Quantized',
+  'LFM 2.5 VL - 450M - Quantized',
   'Qwen 3 - 1.7B - Quantized',
 ];
 
@@ -343,6 +344,21 @@ export const DEFAULT_MODELS: Omit<Model, 'id' | 'isDownloaded'>[] = [
     thinking: false,
     vision: true,
     labels: ['Vision'],
+    systemPrompt:
+      'You are a helpful vision assistant. When the user shares an image, analyze it carefully and provide detailed, accurate descriptions and answers about its content. When no image is provided, respond as a knowledgeable and helpful general assistant.',
+  },
+  {
+    modelName: 'LFM 2.5 VL - 450M - Quantized',
+    modelPath: LFM2_VL_450M_QUANTIZED.modelSource,
+    tokenizerPath: LFM2_VL_450M_QUANTIZED.tokenizerSource,
+    tokenizerConfigPath: LFM2_VL_450M_QUANTIZED.tokenizerConfigSource,
+    source: 'remote',
+    parameters: 0.45,
+    modelSize: 0.65,
+    featured: true,
+    thinking: false,
+    vision: true,
+    labels: ['Fast', 'Vision', 'Quantized'],
     systemPrompt:
       'You are a helpful vision assistant. When the user shares an image, analyze it carefully and provide detailed, accurate descriptions and answers about its content. When no image is provided, respond as a knowledgeable and helpful general assistant.',
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@dr.pogodin/react-native-fs": "^2.35.1",
     "@expo-google-fonts/dm-sans": "^0.4.0",
-    "@gorhom/bottom-sheet": "^5.2.8",
+    "@gorhom/bottom-sheet": "^5.2.9",
     "@op-engineering/op-sqlite": "^15.2.7",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "11.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2061,9 +2061,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gorhom/bottom-sheet@npm:^5.2.8":
-  version: 5.2.8
-  resolution: "@gorhom/bottom-sheet@npm:5.2.8"
+"@gorhom/bottom-sheet@npm:^5.2.9":
+  version: 5.2.9
+  resolution: "@gorhom/bottom-sheet@npm:5.2.9"
   dependencies:
     "@gorhom/portal": 1.0.14
     invariant: ^2.2.4
@@ -2079,7 +2079,7 @@ __metadata:
       optional: true
     "@types/react-native":
       optional: true
-  checksum: 987c07e013c423d71afc21f5a38ad02dacfc153c8eb613ac3be0fa1331a559976f0f0d02144bf80654b2fe737582c21249ff8988694cdb6d94981037a1b54001
+  checksum: 252336a263fa40241ecbab4bbd4b6647783fbad25ac59e973dc01e0f7b5dc57dc7ddff602801604822f9a9b86364860cf0d66af6184c950d0f2f64f782955ba2
   languageName: node
   linkType: hard
 
@@ -9303,7 +9303,7 @@ __metadata:
     "@babel/core": ^7.25.2
     "@dr.pogodin/react-native-fs": ^2.35.1
     "@expo-google-fonts/dm-sans": ^0.4.0
-    "@gorhom/bottom-sheet": ^5.2.8
+    "@gorhom/bottom-sheet": ^5.2.9
     "@op-engineering/op-sqlite": ^15.2.7
     "@react-native-async-storage/async-storage": 2.2.0
     "@react-native-community/netinfo": 11.5.2


### PR DESCRIPTION
Gate model card taps on sheet open state to avoid a gorhom mid-animation race where a fast tap would cause the sheet to re-appear on top of the new chat screen. Shorten the open animation to 150ms so the brief non-interactive window is imperceptible. Bump @gorhom/bottom-sheet to 5.2.9.

Also add LFM 2.5 VL 450M Quantized as a featured vision model and swap starting models to LFM 2.5 1.2B Quantized, LFM 2.5 VL 450M Quantized, and Qwen 3 1.7B Quantized.