### PR TITLE
fix: empty model list on first launch + touch highlight on scroll

### DIFF
--- a/components/benchmark/BenchmarkItem.tsx
+++ b/components/benchmark/BenchmarkItem.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
+import { TouchableOpacity } from 'react-native-gesture-handler';
 import { BenchmarkResult } from '../../database/benchmarkRepository';
 import BenchmarkIcon from '../../assets/icons/benchmark.svg';
 import { useTheme } from '../../context/ThemeContext';

--- a/components/chat-screen/PromptSuggestions.tsx
+++ b/components/chat-screen/PromptSuggestions.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import { ScrollView } from 'react-native-gesture-handler';
+import { View, Text, StyleSheet } from 'react-native';
+import { ScrollView, TouchableOpacity } from 'react-native-gesture-handler';
 import { useTheme } from '../../context/ThemeContext';
 import { fontFamily, fontSizes, lineHeights } from '../../styles/fontStyles';
 import { Theme } from '../../styles/colors';

--- a/components/drawer/DrawerItem.tsx
+++ b/components/drawer/DrawerItem.tsx
@@ -1,5 +1,6 @@
 import React, { memo, useMemo } from 'react';
-import { Pressable, View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
+import { Pressable } from 'react-native-gesture-handler';
 import { useTheme } from '../../context/ThemeContext';
 import { fontFamily, fontSizes } from '../../styles/fontStyles';
 import { Theme } from '../../styles/colors';

--- a/components/model-hub/FamilyCard.tsx
+++ b/components/model-hub/FamilyCard.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+import { TouchableOpacity } from 'react-native-gesture-handler';
 import { useTheme } from '../../context/ThemeContext';
 import { Theme } from '../../styles/colors';
 import { fontFamily, fontSizes } from '../../styles/fontStyles';

--- a/components/model-hub/ModelCard.tsx
+++ b/components/model-hub/ModelCard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Alert, StyleSheet, TouchableOpacity, View, Text } from 'react-native';
+import { Alert, StyleSheet, View, Text } from 'react-native';
+import { TouchableOpacity } from 'react-native-gesture-handler';
 import NetInfo from '@react-native-community/netinfo';
 import Toast from 'react-native-toast-message';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';

--- a/database/db.ts
+++ b/database/db.ts
@@ -271,8 +271,6 @@ export const initDatabase = async (db: SQLiteDatabase) => {
   useLLMStore.getState().setDB(db);
   useSourceStore.getState().setDB(db);
 
-  await useModelStore.getState().loadModels();
-
   const defaultSettings = await AsyncStorage.getItem('default_chat_settings');
   if (!defaultSettings) {
     await AsyncStorage.setItem(
@@ -315,4 +313,6 @@ export const initDatabase = async (db: SQLiteDatabase) => {
       });
     }
   });
+
+  await useModelStore.getState().loadModels();
 };

--- a/ios/PrivateMind.xcodeproj/project.pbxproj
+++ b/ios/PrivateMind.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.5;
+				MARKETING_VERSION = 1.1.6;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -450,7 +450,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.5;
+				MARKETING_VERSION = 1.1.6;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",


### PR DESCRIPTION
## Summary
- **Model Hub empty after skipping starting-model download.** `loadModels()` ran before the `DEFAULT_MODELS` insertion, so the zustand store cached an empty list on a fresh install; skipping the starting-model picker left the Hub empty until restart. Call `loadModels()` after the defaults are written.
- **Touchables flash as if tapped when scrolling.** Lists rendered inside a `react-native-gesture-handler` `ScrollView`/`FlatList` trigger the press highlight on any finger-down because core RN `TouchableOpacity`/`Pressable` don't coordinate with the GH scroll gesture. Swapped the affected touchables to their gesture-handler equivalents — `ModelCard`, `FamilyCard`, `BenchmarkItem`, `PromptSuggestions`, `DrawerItem`.
- **iOS MARKETING_VERSION** bumped to 1.1.6 to match Android.

## Test plan
- [ ] Fresh install → skip the starting-model picker → open Model Hub → list is populated.
- [ ] Model Hub: start scrolling over a card — no flash on the card.
- [ ] Model family screen: same check.
- [ ] Starting-model picker: same check.
- [ ] Drawer: scroll over chat rows — no flash.
- [ ] Benchmark history: scroll over items — no flash.
- [ ] Phantom chat empty state: scroll the prompt suggestions — no flash.
- [ ] Tapping each of the above still works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)