### PR TITLE
fix: codebase audit bug sweep + model file lifecycle

### DIFF
--- a/__mocks__/react-native-executorch-expo-resource-fetcher.ts
+++ b/__mocks__/react-native-executorch-expo-resource-fetcher.ts
@@ -1,3 +1,4 @@
 export const ExpoResourceFetcher = {
   cancelFetching: jest.fn(),
+  deleteResources: jest.fn(),
 };

--- a/__mocks__/react-native-executorch.ts
+++ b/__mocks__/react-native-executorch.ts
@@ -56,6 +56,12 @@ export const LFM2_VL_1_6B_QUANTIZED = makeModelConstants(
 export const LFM2_VL_450M_QUANTIZED = makeModelConstants(
   'lfm2-vl-450m-quantized'
 );
+export const LFM2_5_VL_1_6B_QUANTIZED = makeModelConstants(
+  'lfm2.5-vl-1.6b-quantized'
+);
+export const LFM2_5_VL_450M_QUANTIZED = makeModelConstants(
+  'lfm2.5-vl-450m-quantized'
+);
 export const WHISPER_TINY_EN = 'whisper-tiny-en';
 
 export const LLMModule = {

--- a/__tests__/modelStore.test.ts
+++ b/__tests__/modelStore.test.ts
@@ -1,15 +1,14 @@
 import { useModelStore, ModelState } from '../store/modelStore';
 import * as modelRepository from '../database/modelRepository';
 import { ResourceFetcher } from 'react-native-executorch';
-import { exists, unlink } from '@dr.pogodin/react-native-fs';
+import { ExpoResourceFetcher } from 'react-native-executorch-expo-resource-fetcher';
 import Toast from 'react-native-toast-message';
 
 jest.mock('../database/modelRepository');
 
 const mockDb = {} as any;
 const mockFetch = ResourceFetcher.fetch as jest.Mock;
-const mockExists = exists as jest.Mock;
-const mockUnlink = unlink as jest.Mock;
+const mockDeleteResources = ExpoResourceFetcher.deleteResources as jest.Mock;
 const mockGetAllModels = modelRepository.getAllModels as jest.Mock;
 const mockUpdateModelDownloaded =
   modelRepository.updateModelDownloaded as jest.Mock;
@@ -184,7 +183,7 @@ describe('cancelDownload', () => {
 });
 
 describe('removeModel', () => {
-  it('skips file deletion for local/built-in models', async () => {
+  it('skips file deletion for local models but still removes the DB row', async () => {
     const localModel = {
       ...baseModel,
       source: 'local' as const,
@@ -195,36 +194,24 @@ describe('removeModel', () => {
 
     await useModelStore.getState().removeModel(localModel.id);
 
-    expect(mockUnlink).not.toHaveBeenCalled();
-    expect(mockUpdateModelDownloaded).not.toHaveBeenCalled();
+    expect(mockDeleteResources).not.toHaveBeenCalled();
+    expect(mockRemoveModelFiles).toHaveBeenCalledWith(mockDb, localModel.id);
   });
 
-  it('deletes local files and marks not-downloaded for remote models', async () => {
+  it('deletes downloaded resources and marks not-downloaded for remote models', async () => {
     const remoteModel = { ...baseModel, isDownloaded: true };
-    mockExists.mockResolvedValue(true);
-    mockUnlink.mockResolvedValue(undefined);
+    mockDeleteResources.mockResolvedValue(undefined);
     mockUpdateModelDownloaded.mockResolvedValue(undefined);
     mockRemoveModelFiles.mockResolvedValue(undefined);
 
-    // First: download so the module-level downloadedPaths Map is populated
-    mockFetch.mockResolvedValue(['/local/model.pte', '/local/tokenizer.json']);
-    useModelStore.setState({ models: [remoteModel], db: mockDb });
-    await useModelStore.getState().downloadModel(remoteModel);
-
-    // Reset mocks so we can assert cleanly on the removeModel call
-    jest.clearAllMocks();
-    mockExists.mockResolvedValue(true);
-    mockUnlink.mockResolvedValue(undefined);
-    mockUpdateModelDownloaded.mockResolvedValue(undefined);
-    mockRemoveModelFiles.mockResolvedValue(undefined);
-    mockGetAllModels.mockResolvedValue([]);
-
-    // Still have the model in state
     useModelStore.setState({ models: [remoteModel], db: mockDb });
     await useModelStore.getState().removeModel(remoteModel.id);
 
-    expect(mockUnlink).toHaveBeenCalledWith('/local/model.pte');
-    expect(mockUnlink).toHaveBeenCalledWith('/local/tokenizer.json');
+    expect(mockDeleteResources).toHaveBeenCalledWith(
+      remoteModel.modelPath,
+      remoteModel.tokenizerPath,
+      remoteModel.tokenizerConfigPath
+    );
     expect(mockUpdateModelDownloaded).toHaveBeenCalledWith(
       mockDb,
       remoteModel.id,
@@ -240,7 +227,7 @@ describe('removeModel', () => {
         [remoteModel.id]: { progress: 1, status: ModelState.Downloaded },
       },
     });
-    mockExists.mockResolvedValue(false);
+    mockDeleteResources.mockResolvedValue(undefined);
     mockUpdateModelDownloaded.mockResolvedValue(undefined);
     mockRemoveModelFiles.mockResolvedValue(undefined);
 
@@ -262,12 +249,11 @@ describe('removeModelFiles vs removeModel', () => {
   it('removeModelFiles does not call removeModelFiles DB function (only marks not downloaded)', async () => {
     const remoteModel = { ...baseModel, isDownloaded: true };
     useModelStore.setState({ models: [remoteModel] });
-    mockExists.mockResolvedValue(false);
+    mockDeleteResources.mockResolvedValue(undefined);
     mockUpdateModelDownloaded.mockResolvedValue(undefined);
 
     await useModelStore.getState().removeModelFiles(remoteModel.id);
 
-    // updateModelDownloaded called but removeModelFiles (DB) NOT called
     expect(mockUpdateModelDownloaded).toHaveBeenCalledWith(
       mockDb,
       remoteModel.id,
@@ -279,7 +265,7 @@ describe('removeModelFiles vs removeModel', () => {
   it('removeModel calls removeModelFiles (DB) to fully delete the record', async () => {
     const remoteModel = { ...baseModel, isDownloaded: true };
     useModelStore.setState({ models: [remoteModel] });
-    mockExists.mockResolvedValue(false);
+    mockDeleteResources.mockResolvedValue(undefined);
     mockUpdateModelDownloaded.mockResolvedValue(undefined);
     mockRemoveModelFiles.mockResolvedValue(undefined);
 

--- a/__tests__/modelStore.test.ts
+++ b/__tests__/modelStore.test.ts
@@ -219,6 +219,26 @@ describe('removeModel', () => {
     );
   });
 
+  it('also deletes downloaded resources for built-in models', async () => {
+    const builtInModel = {
+      ...baseModel,
+      source: 'built-in' as const,
+      isDownloaded: true,
+    };
+    mockDeleteResources.mockResolvedValue(undefined);
+    mockUpdateModelDownloaded.mockResolvedValue(undefined);
+    mockRemoveModelFiles.mockResolvedValue(undefined);
+
+    useModelStore.setState({ models: [builtInModel], db: mockDb });
+    await useModelStore.getState().removeModel(builtInModel.id);
+
+    expect(mockDeleteResources).toHaveBeenCalledWith(
+      builtInModel.modelPath,
+      builtInModel.tokenizerPath,
+      builtInModel.tokenizerConfigPath
+    );
+  });
+
   it('removes download state entry after removal', async () => {
     const remoteModel = { ...baseModel, isDownloaded: true };
     useModelStore.setState({

--- a/app/(drawer)/benchmark.tsx
+++ b/app/(drawer)/benchmark.tsx
@@ -49,7 +49,7 @@ const BenchmarkScreen = () => {
       if (newResult) {
         bottomSheetModalRef.current?.present({
           ...newResult,
-          model: await getModelById(newResult.modelId!),
+          model: getModelById(newResult.modelId!),
         });
       }
     },

--- a/app/(drawer)/chat/[id].tsx
+++ b/app/(drawer)/chat/[id].tsx
@@ -76,10 +76,10 @@ function ChatScreenInner() {
     }, [chatId, isPhantom])
   );
 
-  const handleSetModel = async (model: Model) => {
-    setChatModel(chatId, model.id);
+  const handleSetModel = async (newModel: Model) => {
+    setChatModel(chatId, newModel.id);
     loadChats();
-    setModel(model);
+    setModel(newModel);
   };
 
   return (

--- a/app/(drawer)/index.tsx
+++ b/app/(drawer)/index.tsx
@@ -29,6 +29,10 @@ import useOnboardingRedirect from '../../hooks/useOnboardingRedirect';
 import WhatsNewCard from '../../components/WhatsNewCard';
 import { setLastUsedModelId } from '../../utils/lastUsedModel';
 
+configureReanimatedLogger({
+  strict: false,
+});
+
 export default function App() {
   useOnboardingRedirect();
 
@@ -48,10 +52,6 @@ export default function App() {
   const { theme } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const { addChat } = useChatStore();
-
-  configureReanimatedLogger({
-    strict: false,
-  });
 
   const handleSetModel = async (model: Model, replace = false) => {
     bottomSheetModalRef.current?.dismiss();

--- a/app/(modals)/app-info.tsx
+++ b/app/(modals)/app-info.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import * as Clipboard from 'expo-clipboard';
+import * as Application from 'expo-application';
 import Toast from 'react-native-toast-message';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { fontSizes, fontFamily } from '../../styles/fontStyles';
@@ -19,7 +20,7 @@ import GithubIcon from '../../assets/icons/github.svg';
 import CopyIcon from '../../assets/icons/copy.svg';
 import FooterIcon from '../../assets/icons/footer.svg';
 
-const APP_VERSION = 'v.1.1.6';
+const APP_VERSION = `v.${Application.nativeApplicationVersion ?? ''}`;
 
 const GITHUB_LINKS: { text: string; url: string }[] = [
   {

--- a/app/(modals)/select-starting-model.tsx
+++ b/app/(modals)/select-starting-model.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { StyleSheet, View, Text, ScrollView } from 'react-native';
 import { useRouter } from 'expo-router';
 import { fontSizes, fontFamily } from '../../styles/fontStyles';
@@ -12,6 +12,7 @@ import { useChatStore } from '../../store/chatStore';
 import { useLLMStore } from '../../store/llmStore';
 import { useSQLiteContext } from 'expo-sqlite';
 import { getStartingModels, Model } from '../../database/modelRepository';
+import { Theme } from '../../styles/colors';
 
 function SelectStartingModelScreen() {
   const router = useRouter();
@@ -32,16 +33,22 @@ function SelectStartingModelScreen() {
     if (downloadedModels.length > 0) setSelectedModel(downloadedModels[0]);
   }, [downloadedModels]);
 
+  const isContinuingRef = useRef(false);
   const handleContinue = async () => {
-    if (!selectedModel) return;
+    if (!selectedModel || isContinuingRef.current) return;
+    isContinuingRef.current = true;
 
-    const nextChatId = await getNextChatId(db);
-    await initPhantomChat(nextChatId);
-    await setActiveChatId(null);
-    router.replace({
-      pathname: `/chat/${nextChatId}`,
-      params: { modelId: selectedModel.id },
-    });
+    try {
+      const nextChatId = await getNextChatId(db);
+      await initPhantomChat(nextChatId);
+      await setActiveChatId(null);
+      router.replace({
+        pathname: `/chat/${nextChatId}`,
+        params: { modelId: String(selectedModel.id) },
+      });
+    } finally {
+      isContinuingRef.current = false;
+    }
   };
 
   const handleSkip = () => {
@@ -97,7 +104,7 @@ function SelectStartingModelScreen() {
 
 export default SelectStartingModelScreen;
 
-const createStyles = (theme: any) =>
+const createStyles = (theme: Theme) =>
   StyleSheet.create({
     container: {
       flex: 1,

--- a/components/CircleButton.tsx
+++ b/components/CircleButton.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
-import { StyleSheet, TouchableOpacity } from 'react-native';
+import { StyleSheet } from 'react-native';
+import { TouchableOpacity } from 'react-native-gesture-handler';
 import { SvgComponent } from '../utils/SvgComponent';
 
 interface Props {
@@ -50,5 +51,8 @@ const createStyles = (backgroundColor: string) =>
       justifyContent: 'center',
       alignItems: 'center',
       backgroundColor,
+    },
+    pressed: {
+      opacity: 0.6,
     },
   });

--- a/components/EntryButton.tsx
+++ b/components/EntryButton.tsx
@@ -6,7 +6,6 @@ import {
   ViewStyle,
   TextStyle,
   GestureResponderEvent,
-  View,
 } from 'react-native';
 import { useTheme } from '../context/ThemeContext';
 import { fontFamily, fontSizes } from '../styles/fontStyles';
@@ -38,7 +37,7 @@ const EntryButton = ({
       disabled={disabled}
       style={[styles.button, style]}
     >
-      {icon && <View>{icon}</View>}
+      {icon}
       <Text style={[styles.text, textStyle]}>{text}</Text>
     </TouchableOpacity>
   );

--- a/components/SplashScreenAnimation.tsx
+++ b/components/SplashScreenAnimation.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Dimensions, StyleSheet } from 'react-native';
 import { useTheme } from '../context/ThemeContext';
 import { lightTheme, Theme } from '../styles/colors';
@@ -16,17 +16,13 @@ function SplashScreenAnimation() {
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   const rippleProgress = useSharedValue(0);
-  const [done, setDone] = React.useState(false);
+  const [done, setDone] = useState(false);
 
   useEffect(() => {
-    const startAnimation = async () => {
-      SplashScreen.hide();
-      rippleProgress.value = withTiming(1, { duration: 800 }, () => {
-        runOnJS(setDone)(true);
-      });
-    };
-
-    startAnimation();
+    SplashScreen.hide();
+    rippleProgress.value = withTiming(1, { duration: 800 }, () => {
+      runOnJS(setDone)(true);
+    });
   }, []);
 
   const rippleStyle = useAnimatedStyle(() => ({

--- a/components/benchmark/BenchmarkHistory.tsx
+++ b/components/benchmark/BenchmarkHistory.tsx
@@ -30,9 +30,9 @@ const BenchmarkHistory = ({ modalRef, benchmarkList }: Props) => {
         renderItem={({ item }) => (
           <BenchmarkItem
             entry={item}
-            onPress={async () => {
+            onPress={() => {
               const model = item.modelId
-                ? await getModelById(item.modelId)
+                ? getModelById(item.modelId)
                 : undefined;
               modalRef.current?.present({ ...item, model });
             }}

--- a/components/bottomSheets/AttachmentSheet.tsx
+++ b/components/bottomSheets/AttachmentSheet.tsx
@@ -11,6 +11,7 @@ import { fontFamily, fontSizes, lineHeights } from '../../styles/fontStyles';
 import CameraIcon from '../../assets/icons/camera.svg';
 import ImageIcon from '../../assets/icons/image.svg';
 import AttachmentIcon from '../../assets/icons/attachment.svg';
+import { SvgComponent } from '../../utils/SvgComponent';
 
 interface Props {
   bottomSheetModalRef: RefObject<BottomSheetModal | null>;
@@ -20,6 +21,31 @@ interface Props {
   onPickDocument: () => void;
   onSheetStateChange?: (isOpen: boolean) => void;
 }
+
+interface OptionProps {
+  icon: SvgComponent;
+  iconColor: string;
+  label: string;
+  onPress: () => void;
+  testID: string;
+  styles: ReturnType<typeof createStyles>;
+}
+
+const AttachmentOption = ({
+  icon: Icon,
+  iconColor,
+  label,
+  onPress,
+  testID,
+  styles,
+}: OptionProps) => (
+  <TouchableOpacity style={styles.option} onPress={onPress} testID={testID}>
+    <View style={styles.iconWrapper}>
+      <Icon width={24} height={24} style={{ color: iconColor }} />
+    </View>
+    <Text style={styles.optionText}>{label}</Text>
+  </TouchableOpacity>
+);
 
 const AttachmentSheet = ({
   bottomSheetModalRef,
@@ -56,50 +82,32 @@ const AttachmentSheet = ({
       <BottomSheetView style={styles.container}>
         {isVisionModel && (
           <>
-            <TouchableOpacity
-              style={styles.option}
+            <AttachmentOption
+              icon={CameraIcon}
+              iconColor={theme.text.primary}
+              label="Camera"
               onPress={() => handleOption(onPickFromCamera)}
               testID="attachment-camera"
-            >
-              <View style={styles.iconWrapper}>
-                <CameraIcon
-                  width={24}
-                  height={24}
-                  style={{ color: theme.text.primary }}
-                />
-              </View>
-              <Text style={styles.optionText}>Camera</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={styles.option}
+              styles={styles}
+            />
+            <AttachmentOption
+              icon={ImageIcon}
+              iconColor={theme.text.primary}
+              label="Photo Library"
               onPress={() => handleOption(onPickFromLibrary)}
               testID="attachment-library"
-            >
-              <View style={styles.iconWrapper}>
-                <ImageIcon
-                  width={24}
-                  height={24}
-                  style={{ color: theme.text.primary }}
-                />
-              </View>
-              <Text style={styles.optionText}>Photo Library</Text>
-            </TouchableOpacity>
+              styles={styles}
+            />
           </>
         )}
-        <TouchableOpacity
-          style={styles.option}
+        <AttachmentOption
+          icon={AttachmentIcon}
+          iconColor={theme.text.primary}
+          label="Document"
           onPress={() => handleOption(onPickDocument)}
           testID="attachment-document"
-        >
-          <View style={styles.iconWrapper}>
-            <AttachmentIcon
-              width={24}
-              height={24}
-              style={{ color: theme.text.primary }}
-            />
-          </View>
-          <Text style={styles.optionText}>Document</Text>
-        </TouchableOpacity>
+          styles={styles}
+        />
       </BottomSheetView>
     </BottomSheetModal>
   );

--- a/components/bottomSheets/ModelManagementSheet.tsx
+++ b/components/bottomSheets/ModelManagementSheet.tsx
@@ -217,7 +217,10 @@ const ModelManagementSheet = ({ bottomSheetModalRef }: Props) => {
       ref={bottomSheetModalRef}
       backdropComponent={renderBackdrop}
       enableDynamicSizing
-      onChange={() => setStage(ModalStage.Initial)}
+      onChange={() => {
+        setStage(ModalStage.Initial);
+        setIsProcessing(false);
+      }}
       handleStyle={styles.handle}
       handleIndicatorStyle={styles.handleIndicator}
       backgroundStyle={styles.background}

--- a/components/bottomSheets/ModelManagementSheet.tsx
+++ b/components/bottomSheets/ModelManagementSheet.tsx
@@ -177,8 +177,9 @@ const ModelManagementSheet = ({ bottomSheetModalRef }: Props) => {
               Are you sure you want permanently remove this model from the app?
             </Text>
             <Text style={styles.subText}>
-              It will delete the model files and stored external URLs. You can
-              always add this model again manually.
+              {model.source === 'local'
+                ? 'This will remove the model from the app. The original files on your device will not be touched. You can always add this model again manually.'
+                : 'It will delete the model files and stored external URLs. You can always add this model again manually.'}
             </Text>
             <View style={styles.buttonGroup}>
               <PrimaryButton

--- a/components/chat-screen/ChatBar.tsx
+++ b/components/chat-screen/ChatBar.tsx
@@ -215,7 +215,7 @@ const ChatBar = ({
     [addPastedAttachment, isVisionModel]
   );
 
-  const [showSpeechInput, setShowSpeechInput] = React.useState(false);
+  const [showSpeechInput, setShowSpeechInput] = useState(false);
 
   const openSpeechInput = async () => {
     const permissionStatus = await AudioManager.requestRecordingPermissions();
@@ -298,9 +298,7 @@ const ChatBar = ({
                   style={styles.input}
                   multiline
                   numberOfLines={3}
-                  onFocus={async () => {
-                    await loadSelectedModel();
-                  }}
+                  onFocus={() => loadSelectedModel()}
                   placeholder="Ask about anything..."
                   placeholderTextColor={theme.text.onChatBarMuted}
                   value={userInput}
@@ -392,22 +390,5 @@ const createStyles = (theme: Theme) =>
     previewRow: {
       flexDirection: 'row',
       gap: 8,
-    },
-    divider: {
-      height: 1,
-      backgroundColor: theme.border.soft,
-    },
-    buttonBar: {
-      justifyContent: 'center',
-      alignItems: 'flex-end',
-    },
-    barButton: {
-      width: 36,
-      height: 36,
-      justifyContent: 'center',
-      alignItems: 'center',
-    },
-    iconContrast: {
-      color: theme.text.onChatBar,
     },
   });

--- a/components/chat-screen/ChatScreen.tsx
+++ b/components/chat-screen/ChatScreen.tsx
@@ -272,12 +272,14 @@ export default function ChatScreen({
       return;
     }
 
+    const previous = chatSettings?.thinkingEnabled;
+    const next = !previous;
     const newSettings: ChatSettings = {
       systemPrompt: chatSettings?.systemPrompt || '',
-      thinkingEnabled: !chatSettings?.thinkingEnabled,
+      thinkingEnabled: next,
     };
 
-    setSetting('thinkingEnabled', !chatSettings?.thinkingEnabled);
+    setSetting('thinkingEnabled', next);
 
     try {
       if (phantomChat?.id === chatId) {
@@ -286,7 +288,7 @@ export default function ChatScreen({
         await setChatSettings(db, chatId, newSettings);
       }
     } catch (error) {
-      setSetting('thinkingEnabled', !chatSettings?.thinkingEnabled);
+      setSetting('thinkingEnabled', previous ?? false);
       console.error('Failed to update thinking setting:', error);
     }
   };
@@ -295,7 +297,8 @@ export default function ChatScreen({
     async (prompt: string) => {
       inputRef.current?.setInput(prompt);
 
-      const currentModel = model || (chatId ? getModelById(chatId) : undefined);
+      const currentModel =
+        model || (chat?.modelId ? getModelById(chat.modelId) : undefined);
       if (currentModel?.isDownloaded && loadedModel?.id !== currentModel.id) {
         try {
           await loadModel(currentModel);
@@ -304,7 +307,7 @@ export default function ChatScreen({
         }
       }
     },
-    [model, loadedModel, loadModel, getModelById, chatId]
+    [model, loadedModel, loadModel, getModelById, chat?.modelId]
   );
 
   const isEmpty = !isLoading && messageHistory.length === 0;

--- a/components/chat-screen/ChatSpeechInput.tsx
+++ b/components/chat-screen/ChatSpeechInput.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useLayoutEffect, useMemo } from 'react';
+import React, {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { Theme } from '../../styles/colors';
 import { useTheme } from '../../context/ThemeContext';
@@ -32,18 +38,18 @@ const ChatSpeechInput: React.FC<Props> = ({
   const { theme } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
-  const recordingAttemptedRef = React.useRef(false);
-  const recordingStartTimeRef = React.useRef(0);
+  const recordingAttemptedRef = useRef(false);
+  const recordingStartTimeRef = useRef(0);
   /** in seconds */
-  const [recordingDuration, setRecordingDuration] = React.useState(0);
-  const [transcription, setTranscription] = React.useState<{
+  const [recordingDuration, setRecordingDuration] = useState(0);
+  const [transcription, setTranscription] = useState<{
     committed: string;
     nonCommitted: string;
   }>({ committed: '', nonCommitted: '' });
 
   const animationRef =
-    React.useRef<React.ComponentRef<typeof RecordingAnimation>>(null);
-  const exitStateRef = React.useRef<null | 'pending_submit' | 'exited'>(null);
+    useRef<React.ComponentRef<typeof RecordingAnimation>>(null);
+  const exitStateRef = useRef<null | 'pending_submit' | 'exited'>(null);
 
   const onSubmit = useStableCallback((result: string) => {
     if (exitStateRef.current === 'exited') return;
@@ -65,24 +71,30 @@ const ChatSpeechInput: React.FC<Props> = ({
     },
   });
 
+  const unmountedRef = useRef(false);
+  const stopRef = useRef(stop);
+  stopRef.current = stop;
   useEffect(() => {
     const startListening = async () => {
       try {
         const streamGenerator = await start();
         if (!streamGenerator) {
-          onCancel();
+          if (!unmountedRef.current) onCancel();
           return;
         }
 
         recordingStartTimeRef.current = Date.now();
         let text = '';
         for await (const { committed, nonCommitted } of streamGenerator) {
+          if (unmountedRef.current) break;
           text = text + committed.text;
           setTranscription({
             committed: text,
             nonCommitted: nonCommitted.text,
           });
         }
+
+        if (unmountedRef.current) return;
 
         if (exitStateRef.current === 'pending_submit') {
           if (text) {
@@ -91,7 +103,8 @@ const ChatSpeechInput: React.FC<Props> = ({
             onCancel();
           }
         }
-      } catch (error) {
+      } catch {
+        if (unmountedRef.current) return;
         Toast.show({
           type: 'defaultToast',
           text1: 'Could not start live transcript',
@@ -105,10 +118,17 @@ const ChatSpeechInput: React.FC<Props> = ({
       recordingAttemptedRef.current = true;
       startListening();
     }
-  }, [onCancel, onSubmit]);
 
-  const animationWrapperRef = React.useRef<View | null>(null);
-  const [animationWidth, setAnimationWidth] = React.useState(0);
+    return () => {
+      unmountedRef.current = true;
+      stopRef.current();
+    };
+    // onCancel/onSubmit are stable via useStableCallback; stop is captured via ref.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const animationWrapperRef = useRef<View | null>(null);
+  const [animationWidth, setAnimationWidth] = useState(0);
 
   useLayoutEffect(() => {
     if (animationWrapperRef.current) {
@@ -138,7 +158,7 @@ const ChatSpeechInput: React.FC<Props> = ({
     setTimeout(onCancel, CANCEL_ANIMATION_DURATION);
   };
 
-  const handleSend = async () => {
+  const handleSend = () => {
     exitStateRef.current = 'pending_submit';
     stop();
   };

--- a/components/chat-screen/ChatTitleMenuSheet.tsx
+++ b/components/chat-screen/ChatTitleMenuSheet.tsx
@@ -11,6 +11,7 @@ import { fontFamily, fontSizes, lineHeights } from '../../styles/fontStyles';
 import EditIcon from '../../assets/icons/edit.svg';
 import UploadIcon from '../../assets/icons/upload.svg';
 import TrashIcon from '../../assets/icons/trash.svg';
+import { SvgComponent } from '../../utils/SvgComponent';
 
 interface Props {
   bottomSheetModalRef: RefObject<BottomSheetModal | null>;
@@ -18,6 +19,35 @@ interface Props {
   onExport: () => void;
   onDelete: () => void;
 }
+
+interface OptionProps {
+  icon: SvgComponent;
+  iconColor: string;
+  label: string;
+  labelColor?: string;
+  onPress: () => void;
+  styles: ReturnType<typeof createStyles>;
+}
+
+const MenuOption = ({
+  icon: Icon,
+  iconColor,
+  label,
+  labelColor,
+  onPress,
+  styles,
+}: OptionProps) => (
+  <TouchableOpacity style={styles.option} onPress={onPress}>
+    <View style={styles.iconWrapper}>
+      <Icon width={24} height={24} style={{ color: iconColor }} />
+    </View>
+    <Text
+      style={[styles.optionText, labelColor ? { color: labelColor } : null]}
+    >
+      {label}
+    </Text>
+  </TouchableOpacity>
+);
 
 const ChatTitleMenuSheet = ({
   bottomSheetModalRef,
@@ -48,47 +78,28 @@ const ChatTitleMenuSheet = ({
       handleIndicatorStyle={{ backgroundColor: theme.border.soft }}
     >
       <BottomSheetView style={styles.container}>
-        <TouchableOpacity
-          style={styles.option}
+        <MenuOption
+          icon={EditIcon}
+          iconColor={theme.text.primary}
+          label="Rename"
           onPress={() => handleOption(onRename)}
-        >
-          <View style={styles.iconWrapper}>
-            <EditIcon
-              width={24}
-              height={24}
-              style={{ color: theme.text.primary }}
-            />
-          </View>
-          <Text style={styles.optionText}>Rename</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={styles.option}
+          styles={styles}
+        />
+        <MenuOption
+          icon={UploadIcon}
+          iconColor={theme.text.primary}
+          label="Export Chat"
           onPress={() => handleOption(onExport)}
-        >
-          <View style={styles.iconWrapper}>
-            <UploadIcon
-              width={24}
-              height={24}
-              style={{ color: theme.text.primary }}
-            />
-          </View>
-          <Text style={styles.optionText}>Export Chat</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={styles.option}
+          styles={styles}
+        />
+        <MenuOption
+          icon={TrashIcon}
+          iconColor={theme.text.error}
+          label="Delete Chat"
+          labelColor={theme.text.error}
           onPress={() => handleOption(onDelete)}
-        >
-          <View style={styles.iconWrapper}>
-            <TrashIcon
-              width={24}
-              height={24}
-              style={{ color: theme.text.error }}
-            />
-          </View>
-          <Text style={[styles.optionText, { color: theme.text.error }]}>
-            Delete Chat
-          </Text>
-        </TouchableOpacity>
+          styles={styles}
+        />
       </BottomSheetView>
     </BottomSheetModal>
   );

--- a/components/chat-screen/MessageItem.tsx
+++ b/components/chat-screen/MessageItem.tsx
@@ -21,6 +21,38 @@ interface MessageItemProps {
   documentName?: string;
 }
 
+const THINK_OPEN = '<think>';
+const THINK_CLOSE = '</think>';
+
+const parseThinkingContent = (text: string) => {
+  const thinkStartIndex = text.indexOf(THINK_OPEN);
+  if (thinkStartIndex === -1) {
+    return { normalContent: text, thinkingContent: null, hasThinking: false };
+  }
+
+  const thinkEndIndex = text.indexOf(THINK_CLOSE);
+  const normalBeforeThink = text.slice(0, thinkStartIndex);
+  const contentStart = thinkStartIndex + THINK_OPEN.length;
+
+  if (thinkEndIndex === -1) {
+    return {
+      normalContent: normalBeforeThink,
+      thinkingContent: text.slice(contentStart),
+      hasThinking: true,
+      isThinkingComplete: false,
+      normalAfterThink: '',
+    };
+  }
+
+  return {
+    normalContent: normalBeforeThink,
+    thinkingContent: text.slice(contentStart, thinkEndIndex),
+    hasThinking: true,
+    isThinkingComplete: true,
+    normalAfterThink: text.slice(thinkEndIndex + THINK_CLOSE.length),
+  };
+};
+
 const MessageItem = memo(
   ({
     content,
@@ -36,45 +68,6 @@ const MessageItem = memo(
     const styles = useMemo(() => createStyles(theme), [theme]);
     const { isGenerating, isProcessingPrompt } = useLLMStore();
     const [lightboxVisible, setLightboxVisible] = useState(false);
-
-    const parseThinkingContent = (text: string) => {
-      const thinkStartIndex = text.indexOf('<think>');
-
-      if (thinkStartIndex === -1) {
-        // No thinking block, return all as normal content
-        return {
-          normalContent: text,
-          thinkingContent: null,
-          hasThinking: false,
-        };
-      }
-
-      const thinkEndIndex = text.indexOf('</think>');
-      const normalBeforeThink = text.slice(0, thinkStartIndex);
-
-      if (thinkEndIndex === -1) {
-        // Incomplete thinking block (still streaming)
-        const thinkingContent = text.slice(thinkStartIndex + 7); // +7 for '<think>'
-        return {
-          normalContent: normalBeforeThink,
-          thinkingContent,
-          hasThinking: true,
-          isThinkingComplete: false,
-          normalAfterThink: '',
-        };
-      } else {
-        // Complete thinking block
-        const thinkingContent = text.slice(thinkStartIndex + 7, thinkEndIndex);
-        const normalAfterThink = text.slice(thinkEndIndex + 8); // +8 for '</think>'
-        return {
-          normalContent: normalBeforeThink,
-          thinkingContent,
-          hasThinking: true,
-          isThinkingComplete: true,
-          normalAfterThink,
-        };
-      }
-    };
 
     const contentParts = parseThinkingContent(content);
 
@@ -136,48 +129,46 @@ const MessageItem = memo(
             )}
           </View>
         ) : (
-          <>
-            <View style={styles.aiMessage}>
-              <View style={styles.bubbleContent}>
-                {content.trim() ? (
-                  <Text style={styles.modelName}>{modelName}</Text>
-                ) : isLastMessage && isProcessingPrompt ? (
-                  <AnimatedChatLoading />
-                ) : null}
-                {contentParts.normalContent.trim() && (
+          <View style={styles.aiMessage}>
+            <View style={styles.bubbleContent}>
+              {content.trim() ? (
+                <Text style={styles.modelName}>{modelName}</Text>
+              ) : isLastMessage && isProcessingPrompt ? (
+                <AnimatedChatLoading />
+              ) : null}
+              {contentParts.normalContent.trim() && (
+                <MarkdownComponent
+                  text={contentParts.normalContent}
+                  streaming={isLastMessage && isGenerating}
+                />
+              )}
+              {contentParts.hasThinking &&
+                contentParts.thinkingContent?.trim() && (
+                  <ThinkingBlock
+                    content={contentParts.thinkingContent || ''}
+                    isComplete={contentParts.isThinkingComplete}
+                    inProgress={
+                      isLastMessage &&
+                      isGenerating &&
+                      !contentParts.isThinkingComplete
+                    }
+                  />
+                )}
+              {contentParts.normalAfterThink &&
+                contentParts.normalAfterThink.trim() && (
                   <MarkdownComponent
-                    text={contentParts.normalContent}
+                    text={contentParts.normalAfterThink}
                     streaming={isLastMessage && isGenerating}
                   />
                 )}
-                {contentParts.hasThinking &&
-                  contentParts.thinkingContent?.trim() && (
-                    <ThinkingBlock
-                      content={contentParts.thinkingContent || ''}
-                      isComplete={contentParts.isThinkingComplete}
-                      inProgress={
-                        isLastMessage &&
-                        isGenerating &&
-                        !contentParts.isThinkingComplete
-                      }
-                    />
-                  )}
-                {contentParts.normalAfterThink &&
-                  contentParts.normalAfterThink.trim() && (
-                    <MarkdownComponent
-                      text={contentParts.normalAfterThink}
-                      streaming={isLastMessage && isGenerating}
-                    />
-                  )}
-                {tokensPerSecond !== undefined && tokensPerSecond !== 0 && (
-                  <Text style={styles.metadata}>
-                    ttft: {timeToFirstToken?.toFixed()} ms, tps:{' '}
-                    {tokensPerSecond?.toFixed(2)} tok/s
-                  </Text>
-                )}
-              </View>
+              {tokensPerSecond !== undefined && tokensPerSecond !== 0 && (
+                <Text style={styles.metadata}>
+                  ttft: {timeToFirstToken?.toFixed()} ms, tps:{' '}
+                  {tokensPerSecond?.toFixed(2)} tok/s
+                </Text>
+              )}
             </View>
-          </>
+          </View>
         )}
       </>
     );

--- a/components/chat-screen/Messages.tsx
+++ b/components/chat-screen/Messages.tsx
@@ -157,8 +157,7 @@ const Messages = ({
       lastUserHeight.current -
       lastAssistantHeight.current -
       CONTAINER_PADDING;
-    const next = raw < 50 ? 0 : raw;
-    blankSpace.value = next;
+    blankSpace.value = Math.max(0, raw);
   }, [blankSpace]);
 
   useImperativeHandle(
@@ -287,11 +286,13 @@ const Messages = ({
       // so the scroll-to-bottom button can appear without the user
       // needing to scroll manually. Use the last known scroll offset
       // (0 if user never scrolled) and the container height as a proxy
-      // for the visible area.
+      // for the visible area. Exclude blankSpace — it's an inflated
+      // inset that keeps the new row pinned, not real content, so
+      // including it would light up the button before any tokens have
+      // actually arrived.
       if (containerHeight.current > 0) {
         const layoutH = lastLayoutHeight.current || containerHeight.current;
-        const distFromBottom =
-          h + blankSpace.value - (lastScrollOffset.current + layoutH);
+        const distFromBottom = h - (lastScrollOffset.current + layoutH);
         const atBottom = distFromBottom < 100;
         if (atBottom !== isAtBottomRef.current) {
           isAtBottomRef.current = atBottom;

--- a/components/drawer/DrawerItem.tsx
+++ b/components/drawer/DrawerItem.tsx
@@ -25,7 +25,7 @@ export const DrawerItem = memo(({ label, active, onPress, icon }: Props) => {
       ]}
     >
       <View style={styles.content}>
-        {icon && icon}
+        {icon}
         <Text numberOfLines={1} style={styles.label}>
           {label}
         </Text>

--- a/components/drawer/DrawerMenu.tsx
+++ b/components/drawer/DrawerMenu.tsx
@@ -62,8 +62,9 @@ const DrawerMenu = () => {
   const isOnPhantomChat =
     phantomChat != null && pathname === `/chat/${phantomChat.id}`;
 
-  const groupedChats = groupChatsByDate(
-    [...chats].sort((a, b) => b.lastUsed - a.lastUsed)
+  const groupedChats = useMemo(
+    () => groupChatsByDate([...chats].sort((a, b) => b.lastUsed - a.lastUsed)),
+    [chats]
   );
 
   const navigate = (path: string) => {

--- a/constants/default-models.ts
+++ b/constants/default-models.ts
@@ -10,8 +10,8 @@ import {
   QWEN2_5_1_5B_QUANTIZED,
   QWEN2_5_3B_QUANTIZED,
   LFM2_5_1_2B_INSTRUCT_QUANTIZED,
-  LFM2_VL_1_6B_QUANTIZED,
-  LFM2_VL_450M_QUANTIZED,
+  LFM2_5_VL_1_6B_QUANTIZED,
+  LFM2_5_VL_450M_QUANTIZED,
 } from 'react-native-executorch';
 
 export const startingModels = [
@@ -19,6 +19,33 @@ export const startingModels = [
   'LFM 2.5 VL - 450M',
   'Qwen 3 - 1.7B',
 ];
+
+const RNE_MODELS = [
+  QWEN3_0_6B_QUANTIZED,
+  QWEN3_1_7B_QUANTIZED,
+  LLAMA3_2_1B_QLORA,
+  LLAMA3_2_1B_SPINQUANT,
+  LLAMA3_2_3B_QLORA,
+  LLAMA3_2_3B_SPINQUANT,
+  QWEN2_5_0_5B_QUANTIZED,
+  QWEN2_5_1_5B_QUANTIZED,
+  QWEN2_5_3B_QUANTIZED,
+  LFM2_5_1_2B_INSTRUCT_QUANTIZED,
+  LFM2_5_VL_1_6B_QUANTIZED,
+  LFM2_5_VL_450M_QUANTIZED,
+];
+
+const GENERATION_CONFIG_BY_MODEL_PATH: Record<string, object> =
+  Object.fromEntries(
+    RNE_MODELS.flatMap((m) =>
+      m && 'generationConfig' in m && m.generationConfig
+        ? [[m.modelSource, m.generationConfig]]
+        : []
+    )
+  );
+
+export const getGenerationConfigForModel = (modelPath: string) =>
+  GENERATION_CONFIG_BY_MODEL_PATH[modelPath];
 
 export const DEFAULT_MODELS: Omit<Model, 'id' | 'isDownloaded'>[] = [
   {
@@ -146,9 +173,9 @@ export const DEFAULT_MODELS: Omit<Model, 'id' | 'isDownloaded'>[] = [
   {
     modelName: 'LFM 2.5 VL - 1.6B',
     family: 'LFM 2.5',
-    modelPath: LFM2_VL_1_6B_QUANTIZED.modelSource,
-    tokenizerPath: LFM2_VL_1_6B_QUANTIZED.tokenizerSource,
-    tokenizerConfigPath: LFM2_VL_1_6B_QUANTIZED.tokenizerConfigSource,
+    modelPath: LFM2_5_VL_1_6B_QUANTIZED.modelSource,
+    tokenizerPath: LFM2_5_VL_1_6B_QUANTIZED.tokenizerSource,
+    tokenizerConfigPath: LFM2_5_VL_1_6B_QUANTIZED.tokenizerConfigSource,
     source: 'remote',
     parameters: 1.6,
     modelSize: 2.43,
@@ -162,9 +189,9 @@ export const DEFAULT_MODELS: Omit<Model, 'id' | 'isDownloaded'>[] = [
   {
     modelName: 'LFM 2.5 VL - 450M',
     family: 'LFM 2.5',
-    modelPath: LFM2_VL_450M_QUANTIZED.modelSource,
-    tokenizerPath: LFM2_VL_450M_QUANTIZED.tokenizerSource,
-    tokenizerConfigPath: LFM2_VL_450M_QUANTIZED.tokenizerConfigSource,
+    modelPath: LFM2_5_VL_450M_QUANTIZED.modelSource,
+    tokenizerPath: LFM2_5_VL_450M_QUANTIZED.tokenizerSource,
+    tokenizerConfigPath: LFM2_5_VL_450M_QUANTIZED.tokenizerConfigSource,
     source: 'remote',
     parameters: 0.45,
     modelSize: 0.65,

--- a/database/chatRepository.ts
+++ b/database/chatRepository.ts
@@ -1,6 +1,25 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { SQLiteDatabase } from 'expo-sqlite';
 
+const DEFAULT_CHAT_SETTINGS_KEY = 'default_chat_settings';
+
+const readDefaultChatSettings = async (): Promise<ChatSettings | null> => {
+  const raw = await AsyncStorage.getItem(DEFAULT_CHAT_SETTINGS_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    const settings = parsed as Partial<ChatSettings>;
+    if (typeof settings.systemPrompt !== 'string') return null;
+    return {
+      systemPrompt: settings.systemPrompt,
+      thinkingEnabled: settings.thinkingEnabled,
+    };
+  } catch {
+    return null;
+  }
+};
+
 export type Chat = {
   id: number;
   modelId: number;
@@ -41,13 +60,10 @@ export const createChat = async (
     );
 
     if (result.lastInsertRowId) {
-      const defaultSettings = await AsyncStorage.getItem(
-        'default_chat_settings'
-      );
+      const defaultSettings = await readDefaultChatSettings();
       if (defaultSettings) {
-        const parsedSettings: ChatSettings = JSON.parse(defaultSettings);
         await setChatSettings(db, result.lastInsertRowId, {
-          systemPrompt: modelSystemPrompt ?? parsedSettings.systemPrompt,
+          systemPrompt: modelSystemPrompt ?? defaultSettings.systemPrompt,
         });
       }
     }
@@ -90,11 +106,6 @@ export const persistMessage = async (
   db: SQLiteDatabase,
   message: Omit<Message, 'id' | 'timestamp'>
 ): Promise<number> => {
-  if (!message.tokensPerSecond || !message.timeToFirstToken) {
-    message.tokensPerSecond = 0;
-    message.timeToFirstToken = 0;
-  }
-
   const result = await db.runAsync(
     `INSERT INTO messages (chatId, role, content, modelName, tokensPerSecond, timeToFirstToken, imagePath, documentName) VALUES (?, ?, ?, ?, ?, ?, ?, ?);`,
     [
@@ -102,8 +113,8 @@ export const persistMessage = async (
       message.role,
       message.content,
       message.modelName || '',
-      message.tokensPerSecond,
-      message.timeToFirstToken,
+      message.tokensPerSecond ?? 0,
+      message.timeToFirstToken ?? 0,
       message.imagePath || null,
       message.documentName || null,
     ]
@@ -121,6 +132,10 @@ export const persistMessage = async (
   return result.lastInsertRowId;
 };
 
+// SQLite's default SQLITE_MAX_VARIABLE_NUMBER is 999 on older builds.
+// 9 params per row, so 100 rows per batch keeps us well under the limit.
+const IMPORT_BATCH_SIZE = 100;
+
 export const importMessages = async (
   db: SQLiteDatabase,
   chatId: number,
@@ -128,17 +143,27 @@ export const importMessages = async (
 ): Promise<void> => {
   if (messages.length === 0) return;
 
-  const placeholders = messages.map(() => '(?, ?, ?, ?)').join(', ');
-  const flattenedValues = messages.flatMap((msg) => [
-    chatId,
-    msg.role,
-    msg.content,
-    msg.timestamp ?? Date.now(),
-  ]);
-  await db.runAsync(
-    `INSERT INTO messages (chatId, role, content, timestamp) VALUES ${placeholders}`,
-    flattenedValues
-  );
+  for (let i = 0; i < messages.length; i += IMPORT_BATCH_SIZE) {
+    const batch = messages.slice(i, i + IMPORT_BATCH_SIZE);
+    const placeholders = batch
+      .map(() => '(?, ?, ?, ?, ?, ?, ?, ?, ?)')
+      .join(', ');
+    const flattenedValues = batch.flatMap((msg) => [
+      chatId,
+      msg.role,
+      msg.content,
+      msg.timestamp ?? Date.now(),
+      msg.modelName ?? '',
+      msg.tokensPerSecond ?? 0,
+      msg.timeToFirstToken ?? 0,
+      msg.imagePath ?? null,
+      msg.documentName ?? null,
+    ]);
+    await db.runAsync(
+      `INSERT INTO messages (chatId, role, content, timestamp, modelName, tokensPerSecond, timeToFirstToken, imagePath, documentName) VALUES ${placeholders}`,
+      flattenedValues
+    );
+  }
 };
 
 export const deleteChat = async (
@@ -161,15 +186,9 @@ export const getChatSettings = async (
   );
 
   if (!result) {
-    const defaultSettings = await AsyncStorage.getItem('default_chat_settings');
+    const defaultSettings = await readDefaultChatSettings();
     if (defaultSettings) {
-      const parsed = JSON.parse(defaultSettings) as ChatSettings & {
-        contextWindow?: number;
-      };
-      return {
-        systemPrompt: parsed.systemPrompt,
-        thinkingEnabled: parsed.thinkingEnabled,
-      };
+      return defaultSettings;
     }
   }
 
@@ -195,7 +214,7 @@ export const setChatSettings = async (
 ): Promise<void> => {
   if (chatId === null) {
     await AsyncStorage.setItem(
-      'default_chat_settings',
+      DEFAULT_CHAT_SETTINGS_KEY,
       JSON.stringify(settings)
     );
   } else {

--- a/database/db.ts
+++ b/database/db.ts
@@ -132,6 +132,17 @@ const runMigrations = async (db: SQLiteDatabase) => {
     await db.runAsync(`DELETE FROM sources`);
   }
 
+  // One-time cleanup of orphan rows from before FK enforcement was enabled.
+  await db.runAsync(
+    `DELETE FROM messages WHERE chatId NOT IN (SELECT id FROM chats)`
+  );
+  await db.runAsync(
+    `DELETE FROM chatSettings WHERE chatId NOT IN (SELECT id FROM chats)`
+  );
+  await db.runAsync(
+    `DELETE FROM chatSources WHERE chatId NOT IN (SELECT id FROM chats) OR sourceId NOT IN (SELECT id FROM sources)`
+  );
+
   await db.runAsync(
     `DELETE FROM models
      WHERE source = 'built-in'
@@ -175,6 +186,7 @@ const runMigrations = async (db: SQLiteDatabase) => {
 export const initDatabase = async (db: SQLiteDatabase) => {
   await db.execAsync(`
     PRAGMA journal_mode = 'wal';
+    PRAGMA foreign_keys = ON;
     CREATE TABLE IF NOT EXISTS models (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       modelName TEXT UNIQUE NOT NULL,
@@ -216,6 +228,7 @@ export const initDatabase = async (db: SQLiteDatabase) => {
       tokensPerSecond INTEGER DEFAULT 0,
       timeToFirstToken INTEGER DEFAULT 0,
       imagePath TEXT DEFAULT NULL,
+      documentName TEXT DEFAULT NULL,
       FOREIGN KEY (chatId) REFERENCES chats (id) ON DELETE CASCADE
     );
   `);
@@ -249,7 +262,8 @@ export const initDatabase = async (db: SQLiteDatabase) => {
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       name TEXT NOT NULL,
       size INTEGER,
-      type TEXT NOT NULL
+      type TEXT NOT NULL,
+      firstChunk TEXT DEFAULT NULL
     );
   `);
 

--- a/database/exportImportRepository.ts
+++ b/database/exportImportRepository.ts
@@ -5,6 +5,30 @@ import * as Sharing from 'expo-sharing';
 import * as DocumentPicker from 'expo-document-picker';
 import { Alert } from 'react-native';
 
+const VALID_ROLES = new Set(['user', 'assistant', 'system', 'event']);
+
+const isValidMessage = (m: unknown): m is Message => {
+  if (!m || typeof m !== 'object') return false;
+  const msg = m as Record<string, unknown>;
+  return (
+    typeof msg.role === 'string' &&
+    VALID_ROLES.has(msg.role) &&
+    typeof msg.content === 'string'
+  );
+};
+
+const parseImportedChat = (
+  raw: unknown
+): { title: string; messages: Message[] } | null => {
+  if (!raw || typeof raw !== 'object') return null;
+  const data = raw as Record<string, unknown>;
+  if (typeof data.title !== 'string') return null;
+  if (!Array.isArray(data.history)) return null;
+  const messages = data.history.filter(isValidMessage) as Message[];
+  if (messages.length !== data.history.length) return null;
+  return { title: data.title, messages };
+};
+
 export const exportChatRoom = async (
   db: SQLiteDatabase,
   chatId: number,
@@ -55,15 +79,22 @@ export async function importChatRoom(): Promise<
     const file = new File(uri);
     const fileContent = await file.text();
 
-    const chatData = JSON.parse(fileContent);
-    const chat = {
-      title: chatData.title,
-      messages: chatData.history.map((msg: any) => ({
-        role: msg.role,
-        content: msg.content,
-        createdAt: msg.createdAt,
-      })),
-    };
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(fileContent);
+    } catch {
+      Alert.alert('Invalid file', 'The selected file is not valid JSON.');
+      return;
+    }
+
+    const chat = parseImportedChat(parsed);
+    if (!chat) {
+      Alert.alert(
+        'Invalid chat file',
+        'The file does not match the expected chat export format.'
+      );
+      return;
+    }
     return chat;
   } catch (error) {
     console.error('Failed to import chat room JSON:', error);

--- a/database/modelRepository.ts
+++ b/database/modelRepository.ts
@@ -103,6 +103,16 @@ type RawModel = Omit<
   systemPrompt: string | null;
 };
 
+const parseLabels = (raw: string | null): string[] | undefined => {
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 const hydrateModel = (model: RawModel): Model => {
   const defaults =
     model.source === 'built-in'
@@ -121,7 +131,7 @@ const hydrateModel = (model: RawModel): Model => {
     experimental: model.experimental === 1,
     thinking: model.thinking === 1,
     vision: model.vision === 1,
-    labels: model.labels ? JSON.parse(model.labels) : undefined,
+    labels: parseLabels(model.labels),
     systemPrompt: model.systemPrompt ?? null,
   };
 };
@@ -158,10 +168,10 @@ export const updateModel = async (
 };
 
 export const getStartingModels = async (db: SQLiteDatabase) => {
+  const placeholders = startingModels.map(() => '?').join(', ');
   const rawModels = await db.getAllAsync<RawModel>(
-    `SELECT * FROM models WHERE modelName IN (${startingModels
-      .map((model) => `'${model}'`)
-      .join(', ')})`
+    `SELECT * FROM models WHERE modelName IN (${placeholders})`,
+    startingModels
   );
   return rawModels.map(hydrateModel);
 };

--- a/hooks/useAttachment.ts
+++ b/hooks/useAttachment.ts
@@ -31,19 +31,22 @@ const requestAndroidGalleryPermission = async (): Promise<boolean> => {
   return result === PermissionsAndroid.RESULTS.GRANTED;
 };
 
+const IMAGE_EXTENSIONS = [
+  'jpg',
+  'jpeg',
+  'png',
+  'gif',
+  'webp',
+  'bmp',
+  'heic',
+  'heif',
+];
+
 const isImageUri = (uri: string): boolean => {
-  const imageExtensions = [
-    '.jpg',
-    '.jpeg',
-    '.png',
-    '.gif',
-    '.webp',
-    '.bmp',
-    '.heic',
-    '.heif',
-  ];
-  const lowerUri = uri.toLowerCase();
-  return imageExtensions.some((ext) => lowerUri.includes(ext));
+  const pathPart = uri.split('?')[0].split('#')[0];
+  const lastSegment = pathPart.split('/').pop() ?? '';
+  const ext = lastSegment.split('.').pop()?.toLowerCase() ?? '';
+  return IMAGE_EXTENSIONS.includes(ext);
 };
 
 export const useAttachment = () => {
@@ -161,12 +164,10 @@ export const useAttachment = () => {
 
   const removeAttachment = useCallback(
     (id: string) => {
-      let hadSourceId = false;
-      setAttachments((prev) => {
-        hadSourceId = prev.some((a) => a.id === id && a.sourceId);
-        return prev.filter((a) => a.id !== id);
-      });
-
+      const hadSourceId = attachmentsRef.current.some(
+        (a) => a.id === id && a.sourceId
+      );
+      setAttachments((prev) => prev.filter((a) => a.id !== id));
       if (hadSourceId && vectorStore) {
         useSourceStore.getState().cleanupOrphanedSources(vectorStore);
       }
@@ -175,12 +176,8 @@ export const useAttachment = () => {
   );
 
   const clearAll = useCallback(() => {
-    let hadDocuments = false;
-    setAttachments((prev) => {
-      hadDocuments = prev.some((a) => a.sourceId);
-      return [];
-    });
-
+    const hadDocuments = attachmentsRef.current.some((a) => a.sourceId);
+    setAttachments([]);
     if (hadDocuments && vectorStore) {
       useSourceStore.getState().cleanupOrphanedSources(vectorStore);
     }

--- a/hooks/useBenchmarkRunner.tsx
+++ b/hooks/useBenchmarkRunner.tsx
@@ -10,23 +10,33 @@ import {
 const BENCHMARK_ITERATIONS = 3;
 
 const calculateAverageBenchmark = (
-  results: BenchmarkResultPerformanceNumbers[],
-  iterations: number
+  results: BenchmarkResultPerformanceNumbers[]
 ) => {
-  const averageResult = results.reduce((acc, curr) => {
-    acc.totalTime += curr.totalTime;
-    acc.timeToFirstToken += curr.timeToFirstToken;
-    acc.tokensPerSecond += curr.tokensPerSecond;
-    acc.tokensGenerated += curr.tokensGenerated;
-    return acc;
-  });
-  averageResult.totalTime /= iterations;
-  averageResult.timeToFirstToken /= iterations;
-  averageResult.tokensPerSecond /= iterations;
-  averageResult.tokensGenerated /= iterations;
-  averageResult.peakMemory =
-    Math.max(...results.map((r) => r.peakMemory)) / 1024 / 1024 / 1024;
-  return averageResult;
+  const n = results.length;
+  const sum = results.reduce(
+    (acc, curr) => {
+      acc.totalTime += curr.totalTime;
+      acc.timeToFirstToken += curr.timeToFirstToken;
+      acc.tokensPerSecond += curr.tokensPerSecond;
+      acc.tokensGenerated += curr.tokensGenerated;
+      return acc;
+    },
+    {
+      totalTime: 0,
+      timeToFirstToken: 0,
+      tokensPerSecond: 0,
+      tokensGenerated: 0,
+    }
+  );
+
+  return {
+    totalTime: sum.totalTime / n,
+    timeToFirstToken: sum.timeToFirstToken / n,
+    tokensPerSecond: sum.tokensPerSecond / n,
+    tokensGenerated: sum.tokensGenerated / n,
+    peakMemory:
+      Math.max(...results.map((r) => r.peakMemory)) / 1024 / 1024 / 1024,
+  };
 };
 
 interface UseBenchmarkRunnerParams {
@@ -61,18 +71,17 @@ export default function useBenchmarkRunner({
       try {
         await loadModel(selectedModel, true);
 
-        const iterations = BENCHMARK_ITERATIONS;
         const results: BenchmarkResultPerformanceNumbers[] = [];
 
-        for (let i = 0; i < iterations; i++) {
+        for (let i = 0; i < BENCHMARK_ITERATIONS; i++) {
           if (isCancelled.current) break;
           const result = await runBenchmark();
           if (result) results.push(result);
         }
 
-        if (isCancelled.current) return;
+        if (isCancelled.current || results.length === 0) return;
 
-        const averageResult = calculateAverageBenchmark(results, iterations);
+        const averageResult = calculateAverageBenchmark(results);
         const benchmarkId = await insertBenchmark(db, {
           ...averageResult,
           modelId: selectedModel.id,

--- a/hooks/useDefaultHeader.tsx
+++ b/hooks/useDefaultHeader.tsx
@@ -1,17 +1,14 @@
-import React from 'react';
+import React, { useLayoutEffect } from 'react';
 import { useNavigation } from 'expo-router';
-import { useLayoutEffect } from 'react';
 import DrawerToggleButton from '../components/drawer/DrawerToggleButton';
-import { useTheme } from '../context/ThemeContext';
 
 export default function useDefaultHeader() {
   const navigation = useNavigation();
-  const { theme } = useTheme();
 
   useLayoutEffect(() => {
     navigation.setOptions({
       headerShadowVisible: false,
       headerLeft: () => <DrawerToggleButton />,
     });
-  }, [navigation, theme]);
+  }, [navigation]);
 }

--- a/hooks/useOnboardingRedirect.ts
+++ b/hooks/useOnboardingRedirect.ts
@@ -1,8 +1,14 @@
 import { useEffect } from 'react';
 import { useRouter } from 'expo-router';
-import { isOnboardingComplete } from '../utils/onboardingStatus';
+import {
+  isOnboardingComplete,
+  resetOnboarding,
+} from '../utils/onboardingStatus';
 import { getAllModels } from '../database/modelRepository';
 import { useSQLiteContext } from 'expo-sqlite';
+
+// DEBUG: flip to true to force the onboarding screen on every dev-build launch.
+const FORCE_ONBOARDING_IN_DEV = false;
 
 function useOnboardingRedirect() {
   const router = useRouter();
@@ -10,6 +16,9 @@ function useOnboardingRedirect() {
 
   useEffect(() => {
     const checkOnboardingAndModels = async () => {
+      if (__DEV__ && FORCE_ONBOARDING_IN_DEV) {
+        await resetOnboarding();
+      }
       const complete = await isOnboardingComplete();
       if (!complete) {
         router.push('/onboarding');
@@ -17,7 +26,7 @@ function useOnboardingRedirect() {
       }
 
       const models = await getAllModels(db);
-      if (models.filter((m) => m.isDownloaded).length === 0) {
+      if (!models.some((m) => m.isDownloaded)) {
         router.push('/(modals)/select-starting-model');
       }
     };

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1568,7 +1568,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - react-native-executorch (0.8.3):
+  - react-native-executorch (0.8.4):
     - hermes-engine
     - opencv-rne (~> 4.11.0)
     - RCTRequired
@@ -3030,7 +3030,7 @@ SPEC CHECKSUMS:
   React-logger: d0632d799fbd3507cdd5406f72489a83ed5f9163
   React-Mapbuffer: 274cb203819492f7fb594bbb3a1f3f5061fa794d
   React-microtasksnativemodule: 563b4dcc8b8570814d6de4fc1196f48d2944acd4
-  react-native-executorch: fb50d0e78bc33ae6f9d7674a054da7019f0aa9dd
+  react-native-executorch: e9e06764f4b102d80453c32b820ea019bba83c6c
   react-native-image-picker: 48d850454b4a389753053e1d7378b624d3b47d77
   react-native-keyboard-controller: 6b4bc1ef1ad46ace3842f49ed03815a96a99b139
   react-native-netinfo: f852c868bf5175e46165c7e4db48a204a95c3800

--- a/ios/Podfile.properties.json
+++ b/ios/Podfile.properties.json
@@ -3,5 +3,6 @@
   "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true",
   "expo.sqlite.customBuildFlags": "-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_ENABLE_SNAPSHOT=1",
   "expo.sqlite.enableFTS": "true",
-  "expo.sqlite.useSQLCipher": "true"
+  "expo.sqlite.useSQLCipher": "true",
+  "ios.deploymentTarget": "17.0"
 }

--- a/ios/PrivateMind.xcodeproj/project.pbxproj
+++ b/ios/PrivateMind.xcodeproj/project.pbxproj
@@ -12,8 +12,8 @@
 		32F43A4FAAFE43CAB9BE00A7 /* DMSans_600SemiBold_Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6C29292FCCC44E1586B7C9CF /* DMSans_600SemiBold_Italic.ttf */; };
 		3A30DC296BB4ECFE97F3FF29 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 272ACEAAFDD8426E0C1F6403 /* ExpoModulesProvider.swift */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
-		46B3EB6D303F411E19EFF8F2 /* libPods-PrivateMind.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A197F4BA0DCBF670F2E11520 /* libPods-PrivateMind.a */; };
 		6630830CFD817D04D79F6004 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 310E719E7D17B68EAB076840 /* PrivacyInfo.xcprivacy */; };
+		9FA66496D2A1FE342CB78E4C /* libPods-PrivateMind.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 398D0253698E87EA13053414 /* libPods-PrivateMind.a */; };
 		A456D382113E4F809F5F3370 /* DMSans_400Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FA101E8EB8804D83A63257DB /* DMSans_400Regular.ttf */; };
 		B608B0ACB64346BE919AC1FB /* DMSans_400Regular_Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AE6540C32FA046209A5CF928 /* DMSans_400Regular_Italic.ttf */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
@@ -30,11 +30,11 @@
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = PrivateMind/Info.plist; sourceTree = "<group>"; };
 		272ACEAAFDD8426E0C1F6403 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-PrivateMind/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		310E719E7D17B68EAB076840 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = PrivateMind/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		4A3471387AC778A7C0BFA0C4 /* Pods-PrivateMind.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrivateMind.release.xcconfig"; path = "Target Support Files/Pods-PrivateMind/Pods-PrivateMind.release.xcconfig"; sourceTree = "<group>"; };
+		398D0253698E87EA13053414 /* libPods-PrivateMind.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PrivateMind.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5424661DD6A31C495A946056 /* Pods-PrivateMind.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrivateMind.debug.xcconfig"; path = "Target Support Files/Pods-PrivateMind/Pods-PrivateMind.debug.xcconfig"; sourceTree = "<group>"; };
 		6C29292FCCC44E1586B7C9CF /* DMSans_600SemiBold_Italic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = DMSans_600SemiBold_Italic.ttf; path = "../node_modules/@expo-google-fonts/dm-sans/600SemiBold_Italic/DMSans_600SemiBold_Italic.ttf"; sourceTree = "<group>"; };
-		803892F098BC3B02C5B1A6C5 /* Pods-PrivateMind.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrivateMind.debug.xcconfig"; path = "Target Support Files/Pods-PrivateMind/Pods-PrivateMind.debug.xcconfig"; sourceTree = "<group>"; };
+		6C31CD20F36A84CED522B085 /* Pods-PrivateMind.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrivateMind.release.xcconfig"; path = "Target Support Files/Pods-PrivateMind/Pods-PrivateMind.release.xcconfig"; sourceTree = "<group>"; };
 		88CBAE5AD83E41D2B52FB11B /* DMSans_600SemiBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = DMSans_600SemiBold.ttf; path = "../node_modules/@expo-google-fonts/dm-sans/600SemiBold/DMSans_600SemiBold.ttf"; sourceTree = "<group>"; };
-		A197F4BA0DCBF670F2E11520 /* libPods-PrivateMind.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PrivateMind.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = PrivateMind/SplashScreen.storyboard; sourceTree = "<group>"; };
 		AE6540C32FA046209A5CF928 /* DMSans_400Regular_Italic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = DMSans_400Regular_Italic.ttf; path = "../node_modules/@expo-google-fonts/dm-sans/400Regular_Italic/DMSans_400Regular_Italic.ttf"; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
@@ -49,7 +49,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				46B3EB6D303F411E19EFF8F2 /* libPods-PrivateMind.a in Frameworks */,
+				9FA66496D2A1FE342CB78E4C /* libPods-PrivateMind.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -82,7 +82,7 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				A197F4BA0DCBF670F2E11520 /* libPods-PrivateMind.a */,
+				398D0253698E87EA13053414 /* libPods-PrivateMind.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -151,8 +151,8 @@
 		BCF382F4D21BC5C170FA0B1C /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				803892F098BC3B02C5B1A6C5 /* Pods-PrivateMind.debug.xcconfig */,
-				4A3471387AC778A7C0BFA0C4 /* Pods-PrivateMind.release.xcconfig */,
+				5424661DD6A31C495A946056 /* Pods-PrivateMind.debug.xcconfig */,
+				6C31CD20F36A84CED522B085 /* Pods-PrivateMind.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -164,14 +164,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "PrivateMind" */;
 			buildPhases = (
-				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
+				52747FD643BBBA193963047E /* [CP] Check Pods Manifest.lock */,
 				BF6AC1D5FD18C4112BBD27FA /* [Expo] Configure project */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				800E24972A6A228C8D4807E9 /* [CP] Copy Pods Resources */,
-				1E2031A8D5C2A0AAA94CA939 /* [CP] Embed Pods Frameworks */,
+				54C9EBF7FBE2295F5827DA55 /* [CP] Embed Pods Frameworks */,
+				EA4216B189D4A1CB7679CEA5 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -251,7 +251,7 @@
 			shellPath = /bin/sh;
 			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios absolute | tail -n 1)\"\nfi\n\nif [[ -z \"$CLI_PATH\" ]]; then\n  # Use Expo CLI\n  export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\")\"\nfi\nif [[ -z \"$BUNDLE_COMMAND\" ]]; then\n  # Default Expo CLI command for bundling\n  export BUNDLE_COMMAND=\"export:embed\"\nfi\n\n# Source .xcode.env.updates if it exists to allow\n# SKIP_BUNDLING to be unset if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.updates\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.updates\"\nfi\n# Source local changes to allow overrides\n# if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
 		};
-		08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */ = {
+		52747FD643BBBA193963047E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -273,7 +273,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		1E2031A8D5C2A0AAA94CA939 /* [CP] Embed Pods Frameworks */ = {
+		54C9EBF7FBE2295F5827DA55 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -307,7 +307,31 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PrivateMind/Pods-PrivateMind-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		800E24972A6A228C8D4807E9 /* [CP] Copy Pods Resources */ = {
+		BF6AC1D5FD18C4112BBD27FA /* [Expo] Configure project */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+				"$(SRCROOT)/PrivateMind/PrivateMind.entitlements",
+				"$(SRCROOT)/Pods/Target Support Files/Pods-PrivateMind/expo-configure-project.sh",
+			);
+			name = "[Expo] Configure project";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/Pods/Target Support Files/Pods-PrivateMind/ExpoModulesProvider.swift",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# This script configures Expo modules and generates the modules provider file.\nbash -l -c \"./Pods/Target\\ Support\\ Files/Pods-PrivateMind/expo-configure-project.sh\"\n";
+		};
+		EA4216B189D4A1CB7679CEA5 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -353,30 +377,6 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PrivateMind/Pods-PrivateMind-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BF6AC1D5FD18C4112BBD27FA /* [Expo] Configure project */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/.xcode.env",
-				"$(SRCROOT)/.xcode.env.local",
-				"$(SRCROOT)/PrivateMind/PrivateMind.entitlements",
-				"$(SRCROOT)/Pods/Target Support Files/Pods-PrivateMind/expo-configure-project.sh",
-			);
-			name = "[Expo] Configure project";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(SRCROOT)/Pods/Target Support Files/Pods-PrivateMind/ExpoModulesProvider.swift",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# This script configures Expo modules and generates the modules provider file.\nbash -l -c \"./Pods/Target\\ Support\\ Files/Pods-PrivateMind/expo-configure-project.sh\"\n";
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -394,7 +394,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 803892F098BC3B02C5B1A6C5 /* Pods-PrivateMind.debug.xcconfig */;
+			baseConfigurationReference = 5424661DD6A31C495A946056 /* Pods-PrivateMind.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -435,7 +435,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4A3471387AC778A7C0BFA0C4 /* Pods-PrivateMind.release.xcconfig */;
+			baseConfigurationReference = 6C31CD20F36A84CED522B085 /* Pods-PrivateMind.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "react-native-audio-api": "0.12.0-nightly-f7c925b-20260402",
     "react-native-device-info": "^15.0.1",
     "react-native-enriched-markdown": "^0.4.1",
-    "react-native-executorch": "^0.8.3",
+    "react-native-executorch": "^0.8.4",
     "react-native-executorch-expo-resource-fetcher": "^0.8.0",
     "react-native-gesture-handler": "~2.30.0",
     "react-native-image-picker": "^8.2.1",

--- a/scripts/download-models.js
+++ b/scripts/download-models.js
@@ -30,12 +30,30 @@ async function ensureModelAssets() {
 
     console.log(`Downloading ${url}...`);
     const res = await fetch(url);
-    await new Promise((resolve, reject) => {
-      const fileStream = fs.createWriteStream(filePath);
-      fileStream.on('finish', resolve);
-      fileStream.on('error', reject);
-      Readable.fromWeb(res.body).pipe(fileStream);
-    });
+    if (!res.ok) {
+      throw new Error(`Failed to download ${url}: ${res.status} ${res.statusText}`);
+    }
+
+    // Write to a .part file first, then rename on success. Prevents a
+    // half-finished or error-body file from being treated as valid on the
+    // next run (fs.existsSync check above would skip the redownload).
+    const tempPath = `${filePath}.part`;
+    try {
+      await new Promise((resolve, reject) => {
+        const fileStream = fs.createWriteStream(tempPath);
+        fileStream.on('finish', resolve);
+        fileStream.on('error', reject);
+        Readable.fromWeb(res.body).pipe(fileStream);
+      });
+      fs.renameSync(tempPath, filePath);
+    } catch (err) {
+      try {
+        fs.unlinkSync(tempPath);
+      } catch {
+        // ignore
+      }
+      throw err;
+    }
   }
 }
 

--- a/scripts/download-models.js
+++ b/scripts/download-models.js
@@ -31,7 +31,9 @@ async function ensureModelAssets() {
     console.log(`Downloading ${url}...`);
     const res = await fetch(url);
     if (!res.ok) {
-      throw new Error(`Failed to download ${url}: ${res.status} ${res.statusText}`);
+      throw new Error(
+        `Failed to download ${url}: ${res.status} ${res.statusText}`
+      );
     }
 
     // Write to a .part file first, then rename on success. Prevents a

--- a/store/chatStore.ts
+++ b/store/chatStore.ts
@@ -99,14 +99,11 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   },
 
   updateLastUsed: (id: number) => {
-    get().chats.forEach((chat) => {
-      if (chat.id === id) {
-        chat.lastUsed = Date.now();
-      }
-    });
-
+    const now = Date.now();
     set((state) => ({
-      chats: state.chats.sort((a, b) => b.lastUsed - a.lastUsed),
+      chats: state.chats
+        .map((chat) => (chat.id === id ? { ...chat, lastUsed: now } : chat))
+        .sort((a, b) => b.lastUsed - a.lastUsed),
     }));
   },
 
@@ -142,7 +139,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         },
         ...state.chats,
       ],
-      phantomChat: undefined,
+      phantomChat: null,
     }));
 
     maybePromptReview();

--- a/store/llmStore.ts
+++ b/store/llmStore.ts
@@ -106,7 +106,7 @@ const updateChatStateForGeneration = (
   set: (
     partial: Partial<LLMStore> | ((state: LLMStore) => Partial<LLMStore>)
   ) => void,
-  phase: 'start' | 'generating' | 'complete',
+  phase: 'start' | 'generating' | 'complete' | 'failed',
   data?: {
     chatId?: number;
     activeChatMessages?: Message[];
@@ -159,6 +159,24 @@ const updateChatStateForGeneration = (
           isProcessingPrompt: false,
         });
       }
+      break;
+    case 'failed':
+      // Drop the empty assistant placeholder left behind when generation
+      // failed, was interrupted before any tokens, or produced no response.
+      set((state) => {
+        const messages = state.activeChatMessages;
+        const last = messages[messages.length - 1];
+        const cleaned =
+          last && last.role === 'assistant' && last.id === -1 && !last.content
+            ? messages.slice(0, -1)
+            : messages;
+        return {
+          activeChatMessages: cleaned,
+          isGenerating: false,
+          generatingForChatId: null,
+          isProcessingPrompt: false,
+        };
+      });
       break;
   }
 };
@@ -269,8 +287,13 @@ export const useLLMStore = create<LLMStore>((set, get) => ({
         },
         () => {},
         (token) => {
-          const isFirstToken = get().performance.tokenCount === 0;
-          if (isFirstToken && !get().isBenchmarking) {
+          // Snapshot once: all read decisions below must see the same state,
+          // otherwise intermediate set() calls in this callback race with
+          // concurrent updates.
+          const snapshot = get();
+          const isFirstToken = snapshot.performance.tokenCount === 0;
+
+          if (isFirstToken && !snapshot.isBenchmarking) {
             Feedback.success();
           }
 
@@ -279,33 +302,35 @@ export const useLLMStore = create<LLMStore>((set, get) => ({
           */
           if (
             isFirstToken &&
-            !get().isProcessingPrompt &&
-            !get().isGenerating
+            !snapshot.isProcessingPrompt &&
+            !snapshot.isGenerating
           ) {
             llmInstance?.interrupt();
             return;
           }
-          set({
+
+          const shouldAppendToActiveChat =
+            snapshot.generatingForChatId === snapshot.activeChatId;
+          const firstTokenTime = isFirstToken
+            ? performance.now()
+            : snapshot.performance.firstTokenTime;
+
+          // Use functional set so tokenCount increments relative to the
+          // latest state, not the captured snapshot.
+          set((state) => ({
             isProcessingPrompt: false,
             performance: {
-              tokenCount: get().performance.tokenCount + 1,
-              firstTokenTime: isFirstToken
-                ? performance.now()
-                : get().performance.firstTokenTime,
+              tokenCount: state.performance.tokenCount + 1,
+              firstTokenTime,
             },
-          });
-          /* This check ensures that after we leave the chat,
-          new messages history won't be overwritten by tokens sent after interrupt.
-          */
-          if (get().generatingForChatId === get().activeChatId) {
-            set({
-              activeChatMessages: get().activeChatMessages.map((msg, index) =>
-                index === get().activeChatMessages.length - 1
-                  ? { ...msg, content: msg.content + token }
-                  : msg
-              ),
-            });
-          }
+            activeChatMessages: shouldAppendToActiveChat
+              ? state.activeChatMessages.map((msg, index) =>
+                  index === state.activeChatMessages.length - 1
+                    ? { ...msg, content: msg.content + token }
+                    : msg
+                )
+              : state.activeChatMessages,
+          }));
         }
       );
 
@@ -370,6 +395,7 @@ export const useLLMStore = create<LLMStore>((set, get) => ({
 
       // Check if user interrupted during model loading
       if (!get().isProcessingPrompt) {
+        updateChatStateForGeneration(set, 'failed');
         return;
       }
 
@@ -395,11 +421,11 @@ export const useLLMStore = create<LLMStore>((set, get) => ({
           updateChatStateForGeneration(set, 'complete');
         }
       } else {
-        updateChatStateForGeneration(set, 'complete');
+        updateChatStateForGeneration(set, 'failed');
       }
     } catch (e) {
       console.error('Chat sendMessage failed', e);
-      updateChatStateForGeneration(set, 'complete');
+      updateChatStateForGeneration(set, 'failed');
     }
   },
 

--- a/store/llmStore.ts
+++ b/store/llmStore.ts
@@ -15,6 +15,7 @@ import { type Message as ExecutorchMessage } from 'react-native-executorch';
 import { Platform } from 'react-native';
 import { Feedback } from '../utils/Feedback';
 import { prepareMessagesForLLM } from '../utils/promptUtils';
+import { getGenerationConfigForModel } from '../constants/default-models';
 
 interface LLMStore {
   isLoading: boolean;
@@ -333,6 +334,11 @@ export const useLLMStore = create<LLMStore>((set, get) => ({
           }));
         }
       );
+
+      const generationConfig = getGenerationConfigForModel(model.modelPath);
+      if (generationConfig) {
+        llmInstance.configure({ generationConfig });
+      }
 
       set({ isLoading: false });
     } catch (e) {

--- a/store/modelStore.ts
+++ b/store/modelStore.ts
@@ -11,7 +11,6 @@ import {
 import Toast from 'react-native-toast-message';
 import { ResourceFetcher } from 'react-native-executorch';
 import { ExpoResourceFetcher } from 'react-native-executorch-expo-resource-fetcher';
-import { unlink, exists } from '@dr.pogodin/react-native-fs';
 
 export enum ModelState {
   Downloaded = 'downloaded',
@@ -47,18 +46,14 @@ interface ModelStore {
 
 const MS_PER_FRAME = 16; // ~60 fps
 
-// Track local file paths returned by ResourceFetcher.fetch for cleanup
-const downloadedPaths = new Map<number, string[]>();
-
-async function deleteLocalFiles(paths: string[]) {
-  for (const filePath of paths) {
-    try {
-      if (await exists(filePath)) {
-        await unlink(filePath);
-      }
-    } catch (e) {
-      console.warn('Failed to delete file:', filePath, e);
-    }
+// Wrapper around ExpoResourceFetcher.deleteResources that swallows errors.
+// We pass model.* source paths (URLs); the fetcher derives the on-disk
+// filename and deletes only files it manages — never user-supplied local paths.
+async function deleteRemoteResources(...sources: string[]) {
+  try {
+    await ExpoResourceFetcher.deleteResources(...sources);
+  } catch (err) {
+    console.warn('ExpoResourceFetcher.deleteResources failed:', err);
   }
 }
 
@@ -141,8 +136,6 @@ export const useModelStore = create<ModelStore>((set, get) => ({
         return;
       }
 
-      downloadedPaths.set(model.id, result);
-
       const db = get().db;
       if (db) {
         await updateModelDownloaded(db, model.id, 1);
@@ -184,32 +177,6 @@ export const useModelStore = create<ModelStore>((set, get) => ({
     }));
   },
 
-  removeModel: async (modelId: number) => {
-    const db = get().db;
-    if (!db) return;
-
-    const model = get().models.find((m) => m.id === modelId);
-    if (!model) return;
-
-    try {
-      if (model.source === 'remote') {
-        const paths = downloadedPaths.get(modelId) || [];
-        await deleteLocalFiles(paths);
-        downloadedPaths.delete(modelId);
-        await updateModelDownloaded(db, modelId, 0);
-        set((state) => {
-          const { [modelId]: _, ...rest } = state.downloadStates;
-          return { downloadStates: rest };
-        });
-      }
-
-      await removeModelFiles(db, modelId);
-      await get().loadModels();
-    } catch (err) {
-      console.error('Failed to remove files:', err);
-    }
-  },
-
   removeModelFiles: async (modelId: number) => {
     const db = get().db;
     if (!db) return;
@@ -218,22 +185,15 @@ export const useModelStore = create<ModelStore>((set, get) => ({
     if (!model) return;
 
     try {
-      // Fall back to the resource-fetcher source strings when we don't have
-      // tracked paths from this session (e.g. model was downloaded previously).
-      const paths = downloadedPaths.get(modelId) || [];
-      if (paths.length > 0) {
-        await deleteLocalFiles(paths);
-      }
-      try {
-        await ExpoResourceFetcher.deleteResources(
+      // Only remote-downloaded models live inside the app sandbox; local
+      // models point at user-provided files, which we must never touch.
+      if (model.source === 'remote') {
+        await deleteRemoteResources(
           model.modelPath,
           model.tokenizerPath,
           model.tokenizerConfigPath
         );
-      } catch (err) {
-        console.warn('ExpoResourceFetcher.deleteResources failed:', err);
       }
-      downloadedPaths.delete(modelId);
       await updateModelDownloaded(db, modelId, 0);
       await get().loadModels();
       set((state) => {
@@ -242,6 +202,23 @@ export const useModelStore = create<ModelStore>((set, get) => ({
       });
     } catch (err) {
       console.error('Failed to remove model files:', err);
+    }
+  },
+
+  removeModel: async (modelId: number) => {
+    const db = get().db;
+    if (!db) return;
+
+    const model = get().models.find((m) => m.id === modelId);
+    if (!model) return;
+
+    try {
+      // Reuse removeModelFiles so file cleanup + state reset stay in one place.
+      await get().removeModelFiles(modelId);
+      await removeModelFiles(db, modelId);
+      await get().loadModels();
+    } catch (err) {
+      console.error('Failed to remove model:', err);
     }
   },
 
@@ -259,30 +236,27 @@ export const useModelStore = create<ModelStore>((set, get) => ({
 
     try {
       if (model.source === 'remote' && model.isDownloaded) {
-        const oldPaths = [];
-        const newPaths = [];
+        const oldSources: string[] = [];
+        const newSources: string[] = [];
 
         if (model.tokenizerPath !== localTokenizerPath) {
-          oldPaths.push(model.tokenizerPath);
-          newPaths.push(localTokenizerPath);
+          oldSources.push(model.tokenizerPath);
+          newSources.push(localTokenizerPath);
         }
 
         if (model.tokenizerConfigPath !== localTokenizerConfigPath) {
-          oldPaths.push(model.tokenizerConfigPath);
-          newPaths.push(localTokenizerConfigPath);
+          oldSources.push(model.tokenizerConfigPath);
+          newSources.push(localTokenizerConfigPath);
         }
 
-        if (oldPaths.length > 0) {
-          // Delete the old local files corresponding to these source paths
-          const cachedPaths = downloadedPaths.get(modelId) || [];
-          await deleteLocalFiles(cachedPaths);
+        if (oldSources.length > 0) {
+          // Delete only the on-disk copies of the changed sources, leaving
+          // the model file alone.
+          await deleteRemoteResources(...oldSources);
         }
 
-        if (newPaths.length > 0) {
-          const result = await ResourceFetcher.fetch(() => {}, ...newPaths);
-          if (result) {
-            downloadedPaths.set(modelId, result);
-          }
+        if (newSources.length > 0) {
+          await ResourceFetcher.fetch(() => {}, ...newSources);
         }
       }
 

--- a/store/modelStore.ts
+++ b/store/modelStore.ts
@@ -185,9 +185,10 @@ export const useModelStore = create<ModelStore>((set, get) => ({
     if (!model) return;
 
     try {
-      // Only remote-downloaded models live inside the app sandbox; local
-      // models point at user-provided files, which we must never touch.
-      if (model.source === 'remote') {
+      // Only `local` models point at user-provided files we must never touch.
+      // `remote` and `built-in` both download into the app sandbox via the
+      // resource fetcher, so the same cleanup path applies to both.
+      if (model.source !== 'local') {
         await deleteRemoteResources(
           model.modelPath,
           model.tokenizerPath,

--- a/store/sourceStore.ts
+++ b/store/sourceStore.ts
@@ -59,50 +59,38 @@ export const useSourceStore = create<SourceStore>((set, get) => ({
     if (!db) return { success: false };
 
     const tempId = -Date.now();
-
     set({ isReading: true });
 
     try {
       const sourceTextContent = await readDocumentText(sourceUri, source.type);
 
       if (!sourceTextContent || sourceTextContent.trim().length === 0) {
-        set({ isReading: false });
         return { success: false, isEmpty: true };
       }
 
-      const tempSource: Source = {
-        ...source,
-        id: tempId,
-        isProcessing: true,
-      };
-      set((state) => ({
-        sources: [...state.sources, tempSource],
-      }));
+      const tempSource: Source = { ...source, id: tempId, isProcessing: true };
+      set((state) => ({ sources: [...state.sources, tempSource] }));
 
       const textSplitter = new RecursiveCharacterTextSplitter({
         chunkSize: TEXT_SPLITTER_CHUNK_SIZE,
         chunkOverlap: TEXT_SPLITTER_CHUNK_OVERLAP,
       });
-
       const chunks = await textSplitter.splitText(sourceTextContent);
 
-      const sourceWithFirstChunk = {
+      const sourceId = await insertSource(db, {
         ...source,
         firstChunk: chunks[0] || undefined,
-      };
-      const sourceId = await insertSource(db, sourceWithFirstChunk);
+      });
       if (!sourceId) {
         set((state) => ({
           sources: state.sources.filter((s) => s.id !== tempId),
         }));
-        set({ isReading: false });
         return { success: false };
       }
 
       for (let i = 0; i < chunks.length; i++) {
-        const chunk = chunks[i]!;
         await vectorStore?.add({
-          document: chunk,
+          document: chunks[i]!,
           metadata: { documentId: sourceId, isFirstChunk: i === 0 },
         });
       }
@@ -114,16 +102,15 @@ export const useSourceStore = create<SourceStore>((set, get) => ({
             : s
         ),
       }));
-
-      set({ isReading: false });
       return { success: true, sourceId };
     } catch (e) {
       console.error(e);
       set((state) => ({
         sources: state.sources.filter((s) => s.id !== tempId),
       }));
-      set({ isReading: false });
       return { success: false };
+    } finally {
+      set({ isReading: false });
     }
   },
 

--- a/utils/Feedback.ts
+++ b/utils/Feedback.ts
@@ -1,27 +1,7 @@
 import * as Haptics from 'expo-haptics';
 import { Platform } from 'react-native';
 
-/*
-    Haptic feedback is only used on iOS as it offers very subtle and precise feedback which
-    brings joy and happiness to your soul :)
-*/
-
 export class Feedback {
-  static light() {
-    if (Platform.OS === 'ios')
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-  }
-
-  static medium() {
-    if (Platform.OS === 'ios')
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-  }
-
-  static heavy() {
-    if (Platform.OS === 'ios')
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
-  }
-
   static soft = () => {
     if (Platform.OS === 'ios')
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
@@ -30,9 +10,5 @@ export class Feedback {
   static success = () => {
     if (Platform.OS === 'ios')
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-  };
-
-  static selection = () => {
-    if (Platform.OS === 'ios') Haptics.selectionAsync();
   };
 }

--- a/utils/modelFamily.ts
+++ b/utils/modelFamily.ts
@@ -23,5 +23,8 @@ export const groupModelsByFamily = (models: Model[]): ModelFamily[] => {
       map.set(family, [model]);
     }
   }
-  return Array.from(map.entries()).map(([name, models]) => ({ name, models }));
+  return Array.from(map.entries()).map(([name, familyModels]) => ({
+    name,
+    models: familyModels,
+  }));
 };

--- a/utils/onboardingStatus.ts
+++ b/utils/onboardingStatus.ts
@@ -19,3 +19,6 @@ export const markOnboardingComplete = () =>
     ONBOARDING_COMPLETE_STORE_KEY,
     OnboardingCompleteValue.TRUE
   );
+
+export const resetOnboarding = () =>
+  AsyncStorage.removeItem(ONBOARDING_COMPLETE_STORE_KEY);

--- a/utils/promptUtils.ts
+++ b/utils/promptUtils.ts
@@ -23,22 +23,16 @@ export const prepareMessagesForLLM = (
   let systemPrompt = settings.systemPrompt;
 
   if (context.length > 0) {
-    systemPrompt = systemPrompt + CONTEXT_INSTRUCTION;
+    systemPrompt += CONTEXT_INSTRUCTION;
   }
 
-  const filteredMessages: ExecutorchMessage[] = activeChatMessages.reduce(
-    (acc: ExecutorchMessage[], msg) => {
-      if (msg.role !== 'event') {
-        acc.push({
-          role: msg.role,
-          content: msg.content,
-          ...(msg.imagePath ? { mediaPath: msg.imagePath } : {}),
-        });
-      }
-      return acc;
-    },
-    []
-  );
+  const filteredMessages: ExecutorchMessage[] = activeChatMessages
+    .filter((msg) => msg.role !== 'event')
+    .map((msg) => ({
+      role: msg.role,
+      content: msg.content,
+      ...(msg.imagePath ? { mediaPath: msg.imagePath } : {}),
+    }));
 
   const messagesWithSystemPrompt: ExecutorchMessage[] = [
     { role: 'system', content: systemPrompt },
@@ -58,7 +52,13 @@ export const prepareMessagesForLLM = (
   }
 
   if (context.length > 0) {
-    lastMessage.content = `<context>${context.join(' ')}</context>
+    // Strip any nested </context> in source chunks — otherwise a document
+    // containing the literal closing tag (e.g. an HTML export) would close
+    // the delimiter early and the rest would be parsed as user instruction.
+    const safeContext = context
+      .map((c) => c.replace(/<\/context>/gi, ''))
+      .join(' ');
+    lastMessage.content = `<context>${safeContext}</context>
         ${lastMessage.content}
         `;
   }

--- a/utils/reviewPrompt.ts
+++ b/utils/reviewPrompt.ts
@@ -12,7 +12,7 @@ export function shouldPromptReview(
   lastPromptedAt: number | null
 ): boolean {
   if (totalChats < FIRST_PROMPT_AT) return false;
-  if (lastPromptedAt === null) return totalChats >= FIRST_PROMPT_AT;
+  if (lastPromptedAt === null) return true;
   return totalChats - lastPromptedAt >= RE_PROMPT_INTERVAL;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11164,7 +11164,7 @@ __metadata:
     react-native-audio-api: 0.12.0-nightly-f7c925b-20260402
     react-native-device-info: ^15.0.1
     react-native-enriched-markdown: ^0.4.1
-    react-native-executorch: ^0.8.3
+    react-native-executorch: ^0.8.4
     react-native-executorch-expo-resource-fetcher: ^0.8.0
     react-native-gesture-handler: ~2.30.0
     react-native-image-picker: ^8.2.1
@@ -11427,9 +11427,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-executorch@npm:^0.8.3":
-  version: 0.8.3
-  resolution: "react-native-executorch@npm:0.8.3"
+"react-native-executorch@npm:^0.8.4":
+  version: 0.8.4
+  resolution: "react-native-executorch@npm:0.8.4"
   dependencies:
     "@huggingface/jinja": ^0.5.0
     jsonrepair: ^3.12.0
@@ -11439,7 +11439,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 8b81aead343458e95d1991ee9c33f17b89beab6ef8596c7f1f7b638f69ed35298a221f6bdb97761c2e1508bfd285fbbeb23722983411e936e1d0bd6455387dc2
+  checksum: f231d384b1743491249709c8ed6fba91390f05a63c593fa523bd1a9fd48d9c4b0020e9d493f6ecffa35dedb24c5da5d0de1708ce1acb2cb4fb15f1c1d94a3f82
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bug sweep across the audit report (FK pragma, JSON.parse guards, ghost assistant placeholder, RAG context escape, ChatSpeechInput cleanup, etc.)
- Tightened model file lifecycle: delete on-disk files via \`ExpoResourceFetcher.deleteResources\` so cleanup survives app restarts; \`editModel\` no longer wipes the model \`.pte\` when only the tokenizer is being swapped
- Per-model generation config: when an RNE model constant ships a \`generationConfig\`, apply it on \`loadModel\`
- Misc dead-code/duplicate-JSX cleanup
- Bumped \`react-native-executorch\` to \`^0.8.4\` and iOS deployment target to 17.0

## Test plan
- [x] Unit tests pass (\`yarn test\` — 353 tests)
- [x] Built-in model: \"Delete downloaded files\" actually removes the 1.14 GB \`.pte\` from disk (confirmed by listing the sandbox)
- [x] Local custom model: \"Remove from the app\" leaves user-supplied files on the device untouched
- [x] Remote custom model: \"Delete downloaded files\" removes the on-disk copy, model stays in catalog as not-downloaded
- [ ] Manual: edit a remote model's tokenizer URL — confirm only the tokenizer is re-fetched, model file stays
- [ ] Manual: VLM behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)