### PR TITLE
Fix ios scrollbar

### DIFF
--- a/app/(drawer)/model-hub.tsx
+++ b/app/(drawer)/model-hub.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
-import { Alert, View, StyleSheet, Text } from 'react-native';
+import { Alert, View, StyleSheet, Text, Platform } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { ScrollView } from 'react-native-gesture-handler';
 import { useFocusEffect, useRouter } from 'expo-router';
@@ -174,7 +174,12 @@ const ModelHubScreen = () => {
         {isEmpty ? (
           renderEmptyState()
         ) : (
-          <ScrollView contentContainerStyle={styles.scrollContent}>
+          <ScrollView
+            style={styles.scrollView}
+            contentContainerStyle={styles.scrollContent}
+            automaticallyAdjustsScrollIndicatorInsets={false}
+            scrollIndicatorInsets={scrollIndicatorInsets}
+          >
             {tab === 'mine'
               ? mineModels.map((model) => (
                   <ModelCard
@@ -230,6 +235,11 @@ const ModelHubScreen = () => {
 
 export default ModelHubScreen;
 
+const scrollIndicatorInsets = Platform.select({
+  // iOS 17.5 can initially place the indicator on the left when auto-adjusting.
+  ios: { right: 1 },
+});
+
 const createStyles = (theme: Theme) =>
   StyleSheet.create({
     keyboardAvoidingView: {
@@ -244,6 +254,9 @@ const createStyles = (theme: Theme) =>
       gap: 16,
       paddingHorizontal: 16,
       paddingBottom: 16,
+    },
+    scrollView: {
+      flex: 1,
     },
     scrollContent: {
       gap: 8,

--- a/app/(modals)/model-family/[family].tsx
+++ b/app/(modals)/model-family/[family].tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useRef } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { Platform, StyleSheet, Text, View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import {
@@ -58,7 +58,12 @@ const FamilyScreen = () => {
               <Text style={styles.emptyText}>No variants available.</Text>
             </View>
           ) : (
-            <ScrollView contentContainerStyle={styles.scrollContent}>
+            <ScrollView
+              style={styles.scrollView}
+              contentContainerStyle={styles.scrollContent}
+              automaticallyAdjustsScrollIndicatorInsets={false}
+              scrollIndicatorInsets={scrollIndicatorInsets}
+            >
               {description && (
                 <Text style={styles.description}>{description}</Text>
               )}
@@ -86,6 +91,11 @@ const FamilyScreen = () => {
 
 export default FamilyScreen;
 
+const scrollIndicatorInsets = Platform.select({
+  // iOS 17.5 can initially place the indicator on the left when auto-adjusting.
+  ios: { right: 1 },
+});
+
 const createStyles = (theme: Theme) =>
   StyleSheet.create({
     container: {
@@ -96,6 +106,9 @@ const createStyles = (theme: Theme) =>
       flex: 1,
       padding: 16,
       paddingBottom: theme.insets.bottom,
+    },
+    scrollView: {
+      flex: 1,
     },
     scrollContent: {
       gap: 8,

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3005,14 +3005,14 @@ SPEC CHECKSUMS:
   ExpoStoreReview: dab6e25f0641784bd6207f729f893423afbb6574
   ExpoSymbols: 8b63e859ba013df1f2fc666f535fddb3d5270569
   FBLazyVector: 061f518bbd81677ed8a8317e2ae60b8779495808
-  hermes-engine: 29ba6dff7de8ac75171da89c6f0bb7e545b4439f
+  hermes-engine: b73eefca929bd717e549c62316ddf5e1785d6499
   iosMath: f7a6cbadf9d836d2149c2a84c435b1effc244cba
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   op-sqlite: 8d0462679673b145c995a240ff432e4346718689
   opencv-rne: 2305807573b6e29c8c87e3416ab096d09047a7a0
-  Pdfium: 4c3d8adcc9108922a9e61f1df6ca35ac49d05557
+  Pdfium: 2695c434cbefe1a651d3fee0034571dc2817efd5
   Pulsar: db1cccc0a590d3dae98f2a9a3151bfc9be8785c3
   RCTDeprecation: 5045f20b2cc1239bf422764004338c720684a22f
   RCTRequired: b6b9724225dd780ac2989d2e575d5513c50fe04b
@@ -3022,7 +3022,7 @@ SPEC CHECKSUMS:
   React: 3e14066ac707b3e369d09e2e923d8bee7f8c33ff
   React-callinvoker: bd7959a24564feaf5e4c8c11789e64884da13482
   React-Core: f060f4e14e9301685ce63ea65fbe903bf3397e45
-  React-Core-prebuilt: 33f7e96253d82fd5e16c98f4b860aa92872489ed
+  React-Core-prebuilt: b0f0b335298e2102c3b7c4cbaed0c8a1879af2c9
   React-CoreModules: 89a1a544297be88ca4cdff317423f9e0d0c192a4
   React-cxxreact: 81b1bfa305b1b759cc0fe18327644816216e5993
   React-debug: 234fddb309822e13b9b442ef1bdca8d2b8c3cbf2
@@ -3050,7 +3050,7 @@ SPEC CHECKSUMS:
   React-logger: d0632d799fbd3507cdd5406f72489a83ed5f9163
   React-Mapbuffer: 274cb203819492f7fb594bbb3a1f3f5061fa794d
   React-microtasksnativemodule: 563b4dcc8b8570814d6de4fc1196f48d2944acd4
-  react-native-executorch: 893441fd77602cfca087de64a4e1378026ae05da
+  react-native-executorch: b6aa6f298b88dc3722de5b0ed9cf6d8e38b18989
   react-native-image-picker: 48d850454b4a389753053e1d7378b624d3b47d77
   react-native-keyboard-controller: 6b4bc1ef1ad46ace3842f49ed03815a96a99b139
   react-native-netinfo: f852c868bf5175e46165c7e4db48a204a95c3800
@@ -3088,7 +3088,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 2b19d66e5ddfe8dc7afb6338a4626156cbf2bab1
   ReactCodegen: 43f0948182edee9407c7b977fb059455dfeb9361
   ReactCommon: c6e81cc1ae185fa84863f3ea1d58caac4be741d7
-  ReactNativeDependencies: 2c2634fe3013b490b9173e98d1ec1928db1b8e75
+  ReactNativeDependencies: f6a49cf945d48640a12c0f24cd404b89c7218273
   ReactNativeEnrichedMarkdown: 27a73f8df1bc304c35b7bd922c9885a4dfec3dc5
   ReactNativeFs: 54a8079110e99a52ab4aeb72f16c6785095eb9e8
   RNAudioAPI: a2a67b86dbd376f391252f0e249aec34a6e1ae92


### PR DESCRIPTION
# Summary
Fixes #84. Resolves an iOS 17.5 layout bug where the scroll indicator initially rendered on the left side before snapping back to the right on layout recalculation. Fixed the initial layout bounds calculation to ensure the native scroll bar snaps to the right edge instantly.


https://github.com/user-attachments/assets/16b1b9b5-9e6b-4986-8f76-6c81ec65cdb7

