### PR TITLE
feat(drawer): revamp the sidebar — chat search, context menu & top bar

### DIFF
--- a/__mocks__/react-native-reanimated.ts
+++ b/__mocks__/react-native-reanimated.ts
@@ -31,7 +31,11 @@ module.exports = {
   useAnimatedRef: () => ({ current: null }),
   useDerivedValue: (fn: () => any) => ({ value: fn() }),
   useAnimatedScrollHandler: (fn: any) => fn,
-  withTiming: (val: any, _config: any, callback?: (finished: boolean) => void) => {
+  withTiming: (
+    val: any,
+    _config: any,
+    callback?: (finished: boolean) => void
+  ) => {
     callback?.(true);
     return val;
   },

--- a/__mocks__/react-native-reanimated.ts
+++ b/__mocks__/react-native-reanimated.ts
@@ -17,12 +17,24 @@ module.exports = {
   default: Animated,
   ...Animated,
   createAnimatedComponent,
-  useSharedValue: (init: any) => ({ value: init }),
+  useSharedValue: (init: any) => {
+    const shared = {
+      value: init,
+      get: () => shared.value,
+      set: (next: any) => {
+        shared.value = typeof next === 'function' ? next(shared.value) : next;
+      },
+    };
+    return shared;
+  },
   useAnimatedStyle: (fn: () => any) => fn(),
   useAnimatedRef: () => ({ current: null }),
   useDerivedValue: (fn: () => any) => ({ value: fn() }),
   useAnimatedScrollHandler: (fn: any) => fn,
-  withTiming: (val: any) => val,
+  withTiming: (val: any, _config: any, callback?: (finished: boolean) => void) => {
+    callback?.(true);
+    return val;
+  },
   withSpring: (val: any) => val,
   withRepeat: (val: any) => val,
   withDelay: (_d: any, val: any) => val,
@@ -32,6 +44,7 @@ module.exports = {
     linear: (t: any) => t,
     ease: (t: any) => t,
     quad: (t: any) => t,
+    bezier: () => (t: any) => t,
     inOut: (fn: any) => fn,
     out: (fn: any) => fn,
     in: (fn: any) => fn,

--- a/__tests__/DrawerMenu.test.tsx
+++ b/__tests__/DrawerMenu.test.tsx
@@ -1,0 +1,340 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { Platform, ActionSheetIOS } from 'react-native';
+
+jest.mock('../context/ThemeContext', () => ({
+  useTheme: () => ({ theme: require('./helpers/renderWithTheme').testTheme }),
+}));
+
+jest.mock('react-native-gesture-handler', () => {
+  const RN = require('react-native');
+  return { ScrollView: RN.ScrollView, Pressable: RN.Pressable };
+});
+
+jest.mock('expo-sqlite', () => ({
+  useSQLiteContext: jest.fn(() => ({})),
+}));
+
+const mockReplace = jest.fn();
+const mockPush = jest.fn();
+let mockPathname = '/';
+
+jest.mock('expo-router', () => ({
+  router: { replace: jest.fn(), push: jest.fn(), back: jest.fn() },
+  useRouter: () => ({ replace: mockReplace, push: mockPush, back: jest.fn() }),
+  usePathname: () => mockPathname,
+}));
+
+const mockStartPhantomChat = jest.fn();
+jest.mock('../utils/startPhantomChat', () => ({
+  startPhantomChat: (...args: unknown[]) => mockStartPhantomChat(...args),
+}));
+
+const mockInterrupt = jest.fn();
+jest.mock('../store/llmStore', () => ({
+  useLLMStore: jest.fn(() => ({ interrupt: mockInterrupt })),
+}));
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+const mockNow = new Date('2026-03-10T12:00:00Z').getTime();
+const mockChats = [
+  { id: 1, modelId: 1, title: 'Pizza recipe', lastUsed: mockNow - HOUR },
+  { id: 2, modelId: 1, title: 'Meeting notes', lastUsed: mockNow - 2 * HOUR },
+  { id: 3, modelId: 1, title: 'Trip to Rome', lastUsed: mockNow - DAY },
+];
+
+const mockRenameChat = jest.fn();
+const mockDeleteChat = jest.fn();
+jest.mock('../store/chatStore', () => ({
+  useChatStore: jest.fn(() => ({
+    chats: mockChats,
+    phantomChat: null,
+    renameChat: mockRenameChat,
+    deleteChat: mockDeleteChat,
+  })),
+}));
+
+jest.mock('../context/VectorStoreContext', () => ({
+  useVectorStore: jest.fn(() => ({ vectorStore: null })),
+}));
+
+jest.mock('../database/exportImportRepository', () => ({
+  exportChatRoom: jest.fn(),
+}));
+
+import DrawerMenu from '../components/drawer/DrawerMenu';
+
+const setPlatform = (os: string) => {
+  Object.defineProperty(Platform, 'OS', { get: () => os, configurable: true });
+};
+
+const defaultProps = {
+  searching: false,
+  search: '',
+  now: mockNow,
+  navHeight: 151,
+  onNavMeasured: jest.fn(),
+  onChangeSearch: jest.fn(),
+  onOpenSearch: jest.fn(),
+  onCloseSearch: jest.fn(),
+};
+
+const renderMenu = (props: Partial<typeof defaultProps> = {}) =>
+  render(<DrawerMenu {...defaultProps} {...props} />);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPathname = '/';
+  setPlatform('ios');
+});
+
+describe('DrawerMenu — collapsed', () => {
+  it('keeps New chat, Models and App Info at the top', () => {
+    renderMenu();
+
+    expect(screen.getByText('New chat')).toBeTruthy();
+    expect(screen.getByText('Models')).toBeTruthy();
+    expect(screen.getByText('App Info')).toBeTruthy();
+  });
+
+  it('renders the app name and a search button instead of a search field', () => {
+    renderMenu();
+
+    expect(screen.getByText('Private Mind')).toBeTruthy();
+    expect(screen.getByTestId('drawer-search-open')).toBeTruthy();
+    expect(screen.queryByTestId('drawer-search-input')).toBeNull();
+  });
+
+  it('requests the search state when the search icon is pressed', () => {
+    const onOpenSearch = jest.fn();
+    renderMenu({ onOpenSearch });
+
+    fireEvent.press(screen.getByTestId('drawer-search-open'));
+
+    expect(onOpenSearch).toHaveBeenCalled();
+  });
+
+  it('renders chats grouped by relative date', () => {
+    renderMenu();
+
+    expect(screen.getByText('Today')).toBeTruthy();
+    expect(screen.getByText('Yesterday')).toBeTruthy();
+    expect(screen.getByText('Pizza recipe')).toBeTruthy();
+  });
+
+  it('groups chats against the given now instead of the wall clock', () => {
+    const { rerender } = render(<DrawerMenu {...defaultProps} />);
+    expect(screen.getByText('Today')).toBeTruthy();
+
+    rerender(<DrawerMenu {...defaultProps} now={mockNow + 30 * HOUR} />);
+
+    expect(screen.queryByText('Today')).toBeNull();
+    expect(screen.getByText('Yesterday')).toBeTruthy();
+    expect(screen.getByText('2 days ago')).toBeTruthy();
+  });
+
+  it('records the scroll offset it was scrolled to', () => {
+    const scrollOffsetRef = { current: 0 };
+    renderMenu({ scrollOffsetRef });
+
+    fireEvent.scroll(screen.getByTestId('drawer-scroll'), {
+      nativeEvent: { contentOffset: { x: 0, y: 120 } },
+    });
+
+    expect(scrollOffsetRef.current).toBe(120);
+  });
+
+  it('keeps the sections identical between the collapsed and searching states', () => {
+    const sectionsOf = (element: React.ReactElement) => {
+      const view = render(element);
+      const titles = ['Today', 'Yesterday', '2 days ago'].filter(
+        (title) => view.queryByText(title) !== null
+      );
+      view.unmount();
+      return titles;
+    };
+
+    expect(sectionsOf(<DrawerMenu {...defaultProps} searching />)).toEqual(
+      sectionsOf(<DrawerMenu {...defaultProps} />)
+    );
+  });
+
+  it('starts a phantom chat when New chat is pressed', () => {
+    mockPathname = '/model-hub';
+    const onNavigate = jest.fn();
+    renderMenu({ onNavigate } as never);
+
+    fireEvent.press(screen.getByTestId('drawer-new-chat'));
+
+    expect(mockStartPhantomChat).toHaveBeenCalledWith({}, 'replace');
+    expect(onNavigate).toHaveBeenCalled();
+  });
+
+  it('navigates to the chat when an item is pressed', () => {
+    renderMenu();
+
+    fireEvent.press(screen.getByTestId('drawer-chat-1'));
+
+    expect(mockReplace).toHaveBeenCalledWith('/chat/1');
+  });
+});
+
+describe('DrawerMenu — searching', () => {
+  it('shows the search field and back button instead of the search icon', () => {
+    renderMenu({ searching: true });
+
+    expect(screen.getByTestId('drawer-search-back')).toBeTruthy();
+    expect(screen.getByTestId('drawer-search-input')).toBeTruthy();
+    expect(screen.queryByTestId('drawer-search-open')).toBeNull();
+  });
+
+  it('opens the list at the offset the drawer was scrolled to', () => {
+    const scrollOffsetRef = { current: 120 };
+    renderMenu({ searching: true, scrollOffsetRef } as never);
+
+    expect(screen.getByTestId('drawer-scroll').props.contentOffset).toEqual({
+      x: 0,
+      y: 120,
+    });
+  });
+
+  it('does not record the offset of a filtered list', () => {
+    const scrollOffsetRef = { current: 120 };
+    renderMenu({
+      searching: true,
+      search: 'meeting',
+      scrollOffsetRef,
+    } as never);
+
+    fireEvent.scroll(screen.getByTestId('drawer-scroll'), {
+      nativeEvent: { contentOffset: { x: 0, y: 0 } },
+    });
+
+    expect(scrollOffsetRef.current).toBe(120);
+  });
+
+  it('keeps the navigation items while the query is still empty', () => {
+    renderMenu({ searching: true });
+
+    expect(screen.getByText('New chat')).toBeTruthy();
+    expect(screen.getByText('Models')).toBeTruthy();
+    expect(screen.getByText('App Info')).toBeTruthy();
+  });
+
+  it('hides the navigation items once a query is typed, leaving only results', () => {
+    renderMenu({ searching: true, search: 'pizza' });
+
+    expect(screen.queryByText('New chat')).toBeNull();
+    expect(screen.queryByText('Models')).toBeNull();
+    expect(screen.queryByText('App Info')).toBeNull();
+    expect(screen.getByText('Pizza recipe')).toBeTruthy();
+  });
+
+  it('brings the navigation back when the query is cleared', () => {
+    const { rerender } = renderMenu({ searching: true, search: 'pizza' });
+    expect(screen.queryByText('Models')).toBeNull();
+
+    rerender(
+      <DrawerMenu
+        {...defaultProps}
+        searching
+        search=""
+        onNavigate={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Models')).toBeTruthy();
+  });
+
+  it('filters the chat list by the query', () => {
+    renderMenu({ searching: true, search: 'rome' });
+
+    expect(screen.getByText('Trip to Rome')).toBeTruthy();
+    expect(screen.queryByText('Pizza recipe')).toBeNull();
+    expect(screen.queryByText('Today')).toBeNull();
+  });
+
+  it('matches case-insensitively and ignores surrounding whitespace', () => {
+    renderMenu({ searching: true, search: '  PIZZA  ' });
+
+    expect(screen.getByText('Pizza recipe')).toBeTruthy();
+    expect(screen.queryByText('Trip to Rome')).toBeNull();
+  });
+
+  it('shows an empty state when nothing matches', () => {
+    renderMenu({ searching: true, search: 'nonexistent' });
+
+    expect(screen.getByText('No chats found')).toBeTruthy();
+    expect(screen.getByText('Start new chat')).toBeTruthy();
+  });
+
+  it('starts a new chat from the empty state', () => {
+    const onNavigate = jest.fn();
+    renderMenu({
+      searching: true,
+      search: 'nonexistent',
+      onNavigate,
+    } as never);
+
+    fireEvent.press(screen.getByText('Start new chat'));
+
+    expect(mockStartPhantomChat).toHaveBeenCalledWith({}, 'replace');
+    expect(onNavigate).toHaveBeenCalled();
+  });
+
+  it('closes the search state from the back button', () => {
+    const onCloseSearch = jest.fn();
+    renderMenu({ searching: true, onCloseSearch });
+
+    fireEvent.press(screen.getByTestId('drawer-search-back'));
+
+    expect(onCloseSearch).toHaveBeenCalled();
+  });
+});
+
+describe('DrawerMenu — context menu', () => {
+  it('opens the context menu on long press', () => {
+    const spy = jest
+      .spyOn(ActionSheetIOS, 'showActionSheetWithOptions')
+      .mockImplementation(() => {});
+
+    renderMenu();
+
+    fireEvent(screen.getByTestId('drawer-chat-1'), 'longPress');
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: ['Rename', 'Export Chat', 'Delete Chat', 'Cancel'],
+        destructiveButtonIndex: 2,
+        cancelButtonIndex: 3,
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('does not open the context menu on a plain press', () => {
+    const spy = jest
+      .spyOn(ActionSheetIOS, 'showActionSheetWithOptions')
+      .mockImplementation(() => {});
+
+    renderMenu();
+
+    fireEvent.press(screen.getByTestId('drawer-chat-1'));
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('reports the menu as active so the search state is not torn down', () => {
+    jest
+      .spyOn(ActionSheetIOS, 'showActionSheetWithOptions')
+      .mockImplementation(() => {});
+    const onMenuActiveChange = jest.fn();
+
+    renderMenu({ searching: true, onMenuActiveChange } as never);
+
+    fireEvent(screen.getByTestId('drawer-chat-1'), 'longPress');
+
+    expect(onMenuActiveChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/__tests__/DrawerMenu.test.tsx
+++ b/__tests__/DrawerMenu.test.tsx
@@ -69,6 +69,8 @@ const setPlatform = (os: string) => {
   Object.defineProperty(Platform, 'OS', { get: () => os, configurable: true });
 };
 
+const ORIGINAL_OS = Platform.OS;
+
 const defaultProps = {
   searching: false,
   search: '',
@@ -90,6 +92,8 @@ beforeEach(() => {
   mockPathname = '/';
   setPlatform('ios');
 });
+
+afterEach(() => setPlatform(ORIGINAL_OS));
 
 describe('DrawerMenu — collapsed', () => {
   it('keeps New chat, Models and App Info at the top', () => {

--- a/__tests__/DrawerMenu.test.tsx
+++ b/__tests__/DrawerMenu.test.tsx
@@ -80,7 +80,9 @@ const defaultProps = {
   onCloseSearch: jest.fn(),
 };
 
-const renderMenu = (props: Partial<typeof defaultProps> = {}) =>
+type MenuProps = React.ComponentProps<typeof DrawerMenu>;
+
+const renderMenu = (props: Partial<MenuProps> = {}) =>
   render(<DrawerMenu {...defaultProps} {...props} />);
 
 beforeEach(() => {
@@ -163,7 +165,7 @@ describe('DrawerMenu — collapsed', () => {
   it('starts a phantom chat when New chat is pressed', () => {
     mockPathname = '/model-hub';
     const onNavigate = jest.fn();
-    renderMenu({ onNavigate } as never);
+    renderMenu({ onNavigate });
 
     fireEvent.press(screen.getByTestId('drawer-new-chat'));
 
@@ -191,7 +193,7 @@ describe('DrawerMenu — searching', () => {
 
   it('opens the list at the offset the drawer was scrolled to', () => {
     const scrollOffsetRef = { current: 120 };
-    renderMenu({ searching: true, scrollOffsetRef } as never);
+    renderMenu({ searching: true, scrollOffsetRef });
 
     expect(screen.getByTestId('drawer-scroll').props.contentOffset).toEqual({
       x: 0,
@@ -205,7 +207,7 @@ describe('DrawerMenu — searching', () => {
       searching: true,
       search: 'meeting',
       scrollOffsetRef,
-    } as never);
+    });
 
     fireEvent.scroll(screen.getByTestId('drawer-scroll'), {
       nativeEvent: { contentOffset: { x: 0, y: 0 } },
@@ -275,7 +277,7 @@ describe('DrawerMenu — searching', () => {
       searching: true,
       search: 'nonexistent',
       onNavigate,
-    } as never);
+    });
 
     fireEvent.press(screen.getByText('Start new chat'));
 
@@ -331,7 +333,7 @@ describe('DrawerMenu — context menu', () => {
       .mockImplementation(() => {});
     const onMenuActiveChange = jest.fn();
 
-    renderMenu({ searching: true, onMenuActiveChange } as never);
+    renderMenu({ searching: true, onMenuActiveChange });
 
     fireEvent(screen.getByTestId('drawer-chat-1'), 'longPress');
 

--- a/__tests__/chatLabel.test.ts
+++ b/__tests__/chatLabel.test.ts
@@ -1,0 +1,11 @@
+import { chatLabel } from '../utils/chatLabel';
+
+describe('chatLabel', () => {
+  it('returns the title when the chat has one', () => {
+    expect(chatLabel({ id: 3, title: 'Trip to Rome' })).toBe('Trip to Rome');
+  });
+
+  it('falls back to "Chat <id>" for an empty title', () => {
+    expect(chatLabel({ id: 9, title: '' })).toBe('Chat 9');
+  });
+});

--- a/__tests__/chatSections.test.ts
+++ b/__tests__/chatSections.test.ts
@@ -1,0 +1,92 @@
+import {
+  buildChatSections,
+  getRelativeDateSection,
+  sortChatsByRecency,
+} from '../components/drawer/chatSections';
+import { Chat } from '../database/chatRepository';
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+const NOW = new Date('2026-03-10T12:00:00Z').getTime();
+
+const makeChat = (over: Partial<Chat>): Chat => ({
+  id: 1,
+  modelId: 1,
+  title: 'Chat',
+  lastUsed: NOW,
+  ...over,
+});
+
+describe('getRelativeDateSection', () => {
+  const now = new Date(NOW);
+
+  it('labels the same day as Today', () => {
+    expect(getRelativeDateSection(new Date(NOW - HOUR), now)).toBe('Today');
+  });
+
+  it('labels the previous day as Yesterday', () => {
+    expect(getRelativeDateSection(new Date(NOW - DAY), now)).toBe('Yesterday');
+  });
+
+  it('labels 2-6 days back as "<n> days ago"', () => {
+    expect(getRelativeDateSection(new Date(NOW - 2 * DAY), now)).toBe(
+      '2 days ago'
+    );
+  });
+
+  it('labels anything older than a year as "More than a year ago"', () => {
+    expect(getRelativeDateSection(new Date(NOW - 400 * DAY), now)).toBe(
+      'More than a year ago'
+    );
+  });
+});
+
+describe('sortChatsByRecency', () => {
+  it('orders chats most-recent first without mutating the input', () => {
+    const input = [
+      makeChat({ id: 1, lastUsed: NOW - DAY }),
+      makeChat({ id: 2, lastUsed: NOW - HOUR }),
+      makeChat({ id: 3, lastUsed: NOW - 2 * DAY }),
+    ];
+
+    const sorted = sortChatsByRecency(input);
+
+    expect(sorted.map((chat) => chat.id)).toEqual([2, 1, 3]);
+    expect(input.map((chat) => chat.id)).toEqual([1, 2, 3]);
+  });
+});
+
+describe('buildChatSections', () => {
+  const chats = [
+    makeChat({ id: 1, title: 'Pizza recipe', lastUsed: NOW - HOUR }),
+    makeChat({ id: 2, title: 'Meeting notes', lastUsed: NOW - 2 * HOUR }),
+    makeChat({ id: 3, title: 'Trip to Rome', lastUsed: NOW - DAY }),
+  ];
+
+  it('groups pre-sorted chats by their relative date section', () => {
+    const sections = buildChatSections(chats, '', NOW);
+
+    expect(sections).toEqual([
+      ['Today', [chats[0], chats[1]]],
+      ['Yesterday', [chats[2]]],
+    ]);
+  });
+
+  it('filters by a case-insensitive label match', () => {
+    const sections = buildChatSections(chats, 'rome', NOW);
+
+    expect(sections).toEqual([['Yesterday', [chats[2]]]]);
+  });
+
+  it('matches the "Chat <id>" fallback label of untitled chats', () => {
+    const untitled = makeChat({ id: 42, title: '', lastUsed: NOW - HOUR });
+
+    const sections = buildChatSections([untitled], 'chat 42', NOW);
+
+    expect(sections).toEqual([['Today', [untitled]]]);
+  });
+
+  it('returns no sections when nothing matches', () => {
+    expect(buildChatSections(chats, 'nonexistent', NOW)).toEqual([]);
+  });
+});

--- a/__tests__/useChatActions.test.ts
+++ b/__tests__/useChatActions.test.ts
@@ -1,0 +1,194 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { Alert } from 'react-native';
+import Toast from 'react-native-toast-message';
+
+const mockDb = {};
+jest.mock('expo-sqlite', () => ({
+  useSQLiteContext: jest.fn(() => mockDb),
+}));
+
+const mockRenameChat = jest.fn();
+const mockDeleteChat = jest.fn();
+jest.mock('../store/chatStore', () => ({
+  useChatStore: jest.fn(() => ({
+    renameChat: mockRenameChat,
+    deleteChat: mockDeleteChat,
+  })),
+}));
+
+jest.mock('../context/VectorStoreContext', () => ({
+  useVectorStore: jest.fn(() => ({ vectorStore: null })),
+}));
+
+const mockExportChatRoom = jest.fn();
+jest.mock('../database/exportImportRepository', () => ({
+  exportChatRoom: (...args: any[]) => mockExportChatRoom(...args),
+}));
+
+import { useChatActions } from '../hooks/useChatActions';
+import { useVectorStore } from '../context/VectorStoreContext';
+
+const mockUseVectorStore = useVectorStore as jest.Mock;
+
+const getDeleteButton = (alertSpy: jest.SpyInstance) => {
+  const buttons = alertSpy.mock.calls[0][2] as any[];
+  return buttons.find((button) => button.text === 'Delete');
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  mockRenameChat.mockResolvedValue(undefined);
+  mockDeleteChat.mockResolvedValue(undefined);
+  mockExportChatRoom.mockResolvedValue(undefined);
+  mockUseVectorStore.mockReturnValue({ vectorStore: null });
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('rename', () => {
+  it('renames the chat and shows a toast', async () => {
+    const { result } = renderHook(() => useChatActions());
+
+    await act(async () => {
+      await result.current.rename(42, 'New title');
+    });
+
+    expect(mockRenameChat).toHaveBeenCalledWith(42, 'New title');
+    expect(Toast.show).toHaveBeenCalledWith(
+      expect.objectContaining({ text1: 'Chat renamed' })
+    );
+  });
+
+  it('clips titles longer than 25 characters', async () => {
+    const { result } = renderHook(() => useChatActions());
+
+    await act(async () => {
+      await result.current.rename(42, 'a'.repeat(30));
+    });
+
+    expect(mockRenameChat).toHaveBeenCalledWith(42, 'a'.repeat(25) + '...');
+  });
+
+  it('keeps a title of exactly 25 characters intact', async () => {
+    const { result } = renderHook(() => useChatActions());
+
+    await act(async () => {
+      await result.current.rename(42, 'a'.repeat(25));
+    });
+
+    expect(mockRenameChat).toHaveBeenCalledWith(42, 'a'.repeat(25));
+  });
+
+  it('alerts and skips the toast when renaming fails', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    mockRenameChat.mockRejectedValue(new Error('db down'));
+    const { result } = renderHook(() => useChatActions());
+
+    await act(async () => {
+      await result.current.rename(42, 'New title');
+    });
+
+    expect(alertSpy).toHaveBeenCalledWith('Error', expect.any(String));
+    expect(Toast.show).not.toHaveBeenCalled();
+  });
+});
+
+describe('exportChat', () => {
+  it('exports the chat with the database handle, id and title', async () => {
+    const { result } = renderHook(() => useChatActions());
+
+    await act(async () => {
+      await result.current.exportChat(42, 'My Chat');
+    });
+
+    expect(mockExportChatRoom).toHaveBeenCalledWith(mockDb, 42, 'My Chat');
+  });
+
+  it('alerts when exporting fails', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    mockExportChatRoom.mockRejectedValue(new Error('no disk space'));
+    const { result } = renderHook(() => useChatActions());
+
+    await act(async () => {
+      await result.current.exportChat(42, 'My Chat');
+    });
+
+    expect(alertSpy).toHaveBeenCalledWith('Error', expect.any(String));
+  });
+});
+
+describe('confirmDelete', () => {
+  it('asks for confirmation before deleting anything', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    const { result } = renderHook(() => useChatActions());
+
+    act(() => {
+      result.current.confirmDelete(42);
+    });
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Delete Chat',
+      expect.any(String),
+      expect.arrayContaining([
+        expect.objectContaining({ text: 'Cancel', style: 'cancel' }),
+        expect.objectContaining({ text: 'Delete', style: 'destructive' }),
+      ])
+    );
+    expect(mockDeleteChat).not.toHaveBeenCalled();
+  });
+
+  it('deletes the chat and notifies the caller once confirmed', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    const onDeleted = jest.fn();
+    const { result } = renderHook(() => useChatActions({ onDeleted }));
+
+    act(() => {
+      result.current.confirmDelete(42);
+    });
+
+    await act(async () => {
+      await getDeleteButton(alertSpy).onPress();
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteChat).toHaveBeenCalledWith(42, undefined);
+    });
+    expect(onDeleted).toHaveBeenCalledWith(42);
+  });
+
+  it('passes the vector store to deleteChat when one is available', async () => {
+    const vectorStore = { id: 'vs' };
+    mockUseVectorStore.mockReturnValue({ vectorStore });
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    const { result } = renderHook(() => useChatActions());
+
+    act(() => {
+      result.current.confirmDelete(42);
+    });
+
+    await act(async () => {
+      await getDeleteButton(alertSpy).onPress();
+    });
+
+    expect(mockDeleteChat).toHaveBeenCalledWith(42, vectorStore);
+  });
+
+  it('alerts and does not notify the caller when deleting fails', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    mockDeleteChat.mockRejectedValue(new Error('db down'));
+    const onDeleted = jest.fn();
+    const { result } = renderHook(() => useChatActions({ onDeleted }));
+
+    act(() => {
+      result.current.confirmDelete(42);
+    });
+
+    await act(async () => {
+      await getDeleteButton(alertSpy).onPress();
+    });
+
+    expect(onDeleted).not.toHaveBeenCalled();
+    expect(alertSpy).toHaveBeenLastCalledWith('Error', expect.any(String));
+  });
+});

--- a/__tests__/useConfirm.test.tsx
+++ b/__tests__/useConfirm.test.tsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import { Alert, Platform, Pressable, Text } from 'react-native';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from '@testing-library/react-native';
+
+jest.mock('../context/ThemeContext', () => ({
+  useTheme: () => ({ theme: require('./helpers/renderWithTheme').testTheme }),
+}));
+
+jest.mock('@gorhom/bottom-sheet', () => {
+  const ReactModule = require('react');
+  const { View } = require('react-native');
+
+  const BottomSheetModal = ReactModule.forwardRef((props: any, ref: any) => {
+    const [data, setData] = ReactModule.useState(null);
+
+    ReactModule.useImperativeHandle(ref, () => ({
+      present: (presented: any) => setData(presented ?? {}),
+      dismiss: () => {
+        setData(null);
+        props.onDismiss?.();
+      },
+    }));
+
+    if (!data) return null;
+    return (
+      <View>
+        {typeof props.children === 'function'
+          ? props.children({ data })
+          : props.children}
+      </View>
+    );
+  });
+
+  return {
+    BottomSheetModal,
+    BottomSheetView: ({ children, style }: any) => (
+      <View style={style}>{children}</View>
+    ),
+    BottomSheetBackdrop: () => null,
+    BottomSheetModalProvider: ({ children }: any) => <>{children}</>,
+  };
+});
+
+import { useConfirm } from '../hooks/useConfirm';
+
+const setPlatform = (os: string) => {
+  Object.defineProperty(Platform, 'OS', { get: () => os, configurable: true });
+};
+
+const OPTIONS = {
+  title: 'Delete Chat',
+  message: 'Are you sure you want to delete this chat?',
+  confirmLabel: 'Delete',
+};
+
+const onResult = jest.fn();
+
+const Harness = () => {
+  const { confirm, ConfirmElement } = useConfirm();
+  return (
+    <>
+      <Pressable
+        testID="ask"
+        onPress={async () => onResult(await confirm(OPTIONS))}
+      >
+        <Text>Ask</Text>
+      </Pressable>
+      {ConfirmElement}
+    </>
+  );
+};
+
+const getIosButton = (spy: jest.SpyInstance, text: string) => {
+  const buttons = spy.mock.calls[0][2] as {
+    text: string;
+    onPress: () => void;
+  }[];
+  return buttons.find((button) => button.text === text)!;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useConfirm — Android', () => {
+  beforeEach(() => setPlatform('android'));
+
+  it('shows nothing until a confirmation is requested', () => {
+    render(<Harness />);
+
+    expect(screen.queryByText('Delete Chat')).toBeNull();
+  });
+
+  it('presents the sheet with the requested copy', () => {
+    render(<Harness />);
+
+    fireEvent.press(screen.getByTestId('ask'));
+
+    expect(screen.getByText('Delete Chat')).toBeTruthy();
+    expect(
+      screen.getByText('Are you sure you want to delete this chat?')
+    ).toBeTruthy();
+    expect(screen.getByText('Delete')).toBeTruthy();
+    expect(screen.getByText('Cancel')).toBeTruthy();
+  });
+
+  it('resolves true when the destructive button is pressed', async () => {
+    render(<Harness />);
+    fireEvent.press(screen.getByTestId('ask'));
+
+    fireEvent.press(screen.getByText('Delete'));
+
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith(true));
+  });
+
+  it('resolves false when cancelled', async () => {
+    render(<Harness />);
+    fireEvent.press(screen.getByTestId('ask'));
+
+    fireEvent.press(screen.getByText('Cancel'));
+
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith(false));
+  });
+
+  it('closes the sheet once a choice is made', async () => {
+    render(<Harness />);
+    fireEvent.press(screen.getByTestId('ask'));
+
+    fireEvent.press(screen.getByText('Delete'));
+
+    await waitFor(() => expect(screen.queryByText('Delete Chat')).toBeNull());
+  });
+
+  it('settles a pending confirmation as cancelled when a new one is requested', async () => {
+    render(<Harness />);
+    fireEvent.press(screen.getByTestId('ask'));
+
+    fireEvent.press(screen.getByTestId('ask'));
+
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith(false));
+    expect(screen.getByText('Delete Chat')).toBeTruthy();
+  });
+
+  it('does not use the native alert', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    render(<Harness />);
+
+    fireEvent.press(screen.getByTestId('ask'));
+
+    expect(alertSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('useConfirm — iOS', () => {
+  beforeEach(() => setPlatform('ios'));
+
+  it('uses the native alert and mounts no sheet', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    render(<Harness />);
+
+    fireEvent.press(screen.getByTestId('ask'));
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Delete Chat',
+      'Are you sure you want to delete this chat?',
+      expect.arrayContaining([
+        expect.objectContaining({ text: 'Cancel', style: 'cancel' }),
+        expect.objectContaining({ text: 'Delete', style: 'destructive' }),
+      ])
+    );
+    expect(
+      screen.queryByText('Are you sure you want to delete this chat?')
+    ).toBeNull();
+  });
+
+  it('resolves true when the destructive button is pressed', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    render(<Harness />);
+    fireEvent.press(screen.getByTestId('ask'));
+
+    getIosButton(alertSpy, 'Delete').onPress();
+
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith(true));
+  });
+
+  it('resolves false when cancelled', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    render(<Harness />);
+    fireEvent.press(screen.getByTestId('ask'));
+
+    getIosButton(alertSpy, 'Cancel').onPress();
+
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith(false));
+  });
+});

--- a/__tests__/useConfirm.test.tsx
+++ b/__tests__/useConfirm.test.tsx
@@ -52,6 +52,8 @@ const setPlatform = (os: string) => {
   Object.defineProperty(Platform, 'OS', { get: () => os, configurable: true });
 };
 
+const ORIGINAL_OS = Platform.OS;
+
 const OPTIONS = {
   title: 'Delete Chat',
   message: 'Are you sure you want to delete this chat?',
@@ -75,6 +77,18 @@ const Harness = () => {
   );
 };
 
+const HarnessNoSheet = () => {
+  const { confirm } = useConfirm();
+  return (
+    <Pressable
+      testID="ask"
+      onPress={async () => onResult(await confirm(OPTIONS))}
+    >
+      <Text>Ask</Text>
+    </Pressable>
+  );
+};
+
 const getIosButton = (spy: jest.SpyInstance, text: string) => {
   const buttons = spy.mock.calls[0][2] as {
     text: string;
@@ -86,6 +100,8 @@ const getIosButton = (spy: jest.SpyInstance, text: string) => {
 beforeEach(() => {
   jest.clearAllMocks();
 });
+
+afterEach(() => setPlatform(ORIGINAL_OS));
 
 describe('useConfirm — Android', () => {
   beforeEach(() => setPlatform('android'));
@@ -153,6 +169,14 @@ describe('useConfirm — Android', () => {
     fireEvent.press(screen.getByTestId('ask'));
 
     expect(alertSpy).not.toHaveBeenCalled();
+  });
+
+  it('resolves false instead of hanging when no sheet is mounted', async () => {
+    render(<HarnessNoSheet />);
+
+    fireEvent.press(screen.getByTestId('ask'));
+
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith(false));
   });
 });
 

--- a/__tests__/useDrawerChatMenu.test.tsx
+++ b/__tests__/useDrawerChatMenu.test.tsx
@@ -1,0 +1,328 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+  renderHook,
+  act,
+  waitFor,
+} from '@testing-library/react-native';
+import { Platform, ActionSheetIOS, Alert } from 'react-native';
+
+jest.mock('../context/ThemeContext', () => ({
+  useTheme: () => ({ theme: require('./helpers/renderWithTheme').testTheme }),
+}));
+
+jest.mock('expo-sqlite', () => ({
+  useSQLiteContext: jest.fn(() => ({})),
+}));
+
+const mockRenameChat = jest.fn();
+const mockDeleteChat = jest.fn();
+jest.mock('../store/chatStore', () => ({
+  useChatStore: jest.fn(() => ({
+    renameChat: mockRenameChat,
+    deleteChat: mockDeleteChat,
+  })),
+}));
+
+jest.mock('../context/VectorStoreContext', () => ({
+  useVectorStore: jest.fn(() => ({ vectorStore: null })),
+}));
+
+const mockExportChatRoom = jest.fn();
+jest.mock('../database/exportImportRepository', () => ({
+  exportChatRoom: (...args: unknown[]) => mockExportChatRoom(...args),
+}));
+
+const mockReplace = jest.fn();
+let mockPathname = '/';
+jest.mock('expo-router', () => ({
+  router: { replace: jest.fn(), push: jest.fn(), back: jest.fn() },
+  useRouter: () => ({ replace: mockReplace, push: jest.fn(), back: jest.fn() }),
+  usePathname: () => mockPathname,
+}));
+
+import { useDrawerChatMenu } from '../components/drawer/useDrawerChatMenu';
+
+const chat = { id: 7, modelId: 1, title: 'Trip to Rome', lastUsed: Date.now() };
+const untitledChat = { id: 9, modelId: 1, title: '', lastUsed: Date.now() };
+
+const setPlatform = (os: string) => {
+  Object.defineProperty(Platform, 'OS', { get: () => os, configurable: true });
+};
+
+const captureSheet = () => {
+  let callback: ((index: number) => void) | null = null;
+  jest
+    .spyOn(ActionSheetIOS, 'showActionSheetWithOptions')
+    .mockImplementation((_options, cb) => {
+      callback = cb;
+    });
+  return () => callback!;
+};
+
+const captureDeleteConfirm = () => {
+  let onPress: (() => Promise<void>) | undefined;
+  jest.spyOn(Alert, 'alert').mockImplementation((...args: unknown[]) => {
+    const buttons = args[2] as {
+      text: string;
+      onPress?: () => Promise<void>;
+    }[];
+    onPress = buttons?.find((button) => button.text === 'Delete')?.onPress;
+  });
+  return () => onPress;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  mockPathname = '/';
+  setPlatform('ios');
+  mockRenameChat.mockResolvedValue(undefined);
+  mockDeleteChat.mockResolvedValue(undefined);
+  mockExportChatRoom.mockResolvedValue(undefined);
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('opening the menu', () => {
+  it('offers rename, export and delete for the long-pressed chat', () => {
+    const spy = jest
+      .spyOn(ActionSheetIOS, 'showActionSheetWithOptions')
+      .mockImplementation(() => {});
+    const { result } = renderHook(() => useDrawerChatMenu());
+
+    act(() => result.current.openMenuFor(chat));
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: ['Rename', 'Export Chat', 'Delete Chat', 'Cancel'],
+        destructiveButtonIndex: 2,
+        cancelButtonIndex: 3,
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('names the chat it was opened for', () => {
+    const spy = jest
+      .spyOn(ActionSheetIOS, 'showActionSheetWithOptions')
+      .mockImplementation(() => {});
+    const { result } = renderHook(() => useDrawerChatMenu());
+
+    act(() => result.current.openMenuFor(chat));
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Trip to Rome' }),
+      expect.any(Function)
+    );
+  });
+
+  it('shortens a long chat title so the menu header stays on one line', () => {
+    const spy = jest
+      .spyOn(ActionSheetIOS, 'showActionSheetWithOptions')
+      .mockImplementation(() => {});
+    const longChat = { ...chat, title: 'a'.repeat(40) };
+    const { result } = renderHook(() => useDrawerChatMenu());
+
+    act(() => result.current.openMenuFor(longChat));
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ title: `${'a'.repeat(32)}…` }),
+      expect.any(Function)
+    );
+  });
+
+  it('names an untitled chat by its id', () => {
+    const spy = jest
+      .spyOn(ActionSheetIOS, 'showActionSheetWithOptions')
+      .mockImplementation(() => {});
+    const { result } = renderHook(() => useDrawerChatMenu());
+
+    act(() => result.current.openMenuFor(untitledChat));
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Chat 9' }),
+      expect.any(Function)
+    );
+  });
+
+  it('reports the menu as active so a blur behind it is ignored', () => {
+    jest
+      .spyOn(ActionSheetIOS, 'showActionSheetWithOptions')
+      .mockImplementation(() => {});
+    const onMenuActiveChange = jest.fn();
+    const { result } = renderHook(() =>
+      useDrawerChatMenu({ onMenuActiveChange })
+    );
+
+    act(() => result.current.openMenuFor(chat));
+
+    expect(onMenuActiveChange).toHaveBeenCalledWith(true);
+  });
+
+  it('reports the menu as inactive once an option is chosen', () => {
+    const getCallback = captureSheet();
+    const onMenuActiveChange = jest.fn();
+    const { result } = renderHook(() =>
+      useDrawerChatMenu({ onMenuActiveChange })
+    );
+
+    act(() => result.current.openMenuFor(chat));
+    act(() => getCallback()(3));
+
+    expect(onMenuActiveChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('does not use the iOS action sheet on Android', () => {
+    setPlatform('android');
+    const spy = jest.spyOn(ActionSheetIOS, 'showActionSheetWithOptions');
+    const { result } = renderHook(() => useDrawerChatMenu());
+
+    act(() => result.current.openMenuFor(chat));
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('actions', () => {
+  it('exports the long-pressed chat under its label', async () => {
+    const getCallback = captureSheet();
+    const { result } = renderHook(() => useDrawerChatMenu());
+
+    act(() => result.current.openMenuFor(chat));
+    await act(async () => getCallback()(1));
+
+    expect(mockExportChatRoom).toHaveBeenCalledWith({}, 7, 'Trip to Rome');
+  });
+
+  it('falls back to a generated label for a chat with no title', async () => {
+    const getCallback = captureSheet();
+    const { result } = renderHook(() => useDrawerChatMenu());
+
+    act(() => result.current.openMenuFor(untitledChat));
+    await act(async () => getCallback()(1));
+
+    expect(mockExportChatRoom).toHaveBeenCalledWith({}, 9, 'Chat 9');
+  });
+
+  it('deletes the chat after the confirmation is accepted', async () => {
+    const getCallback = captureSheet();
+    const getConfirm = captureDeleteConfirm();
+    const { result } = renderHook(() => useDrawerChatMenu());
+
+    act(() => result.current.openMenuFor(chat));
+    act(() => getCallback()(2));
+    await act(async () => {
+      await getConfirm()?.();
+    });
+
+    await waitFor(() =>
+      expect(mockDeleteChat).toHaveBeenCalledWith(7, undefined)
+    );
+  });
+
+  it('leaves the route alone when the deleted chat is not the open one', async () => {
+    mockPathname = '/chat/123';
+    const getCallback = captureSheet();
+    const getConfirm = captureDeleteConfirm();
+    const { result } = renderHook(() => useDrawerChatMenu());
+
+    act(() => result.current.openMenuFor(chat));
+    act(() => getCallback()(2));
+    await act(async () => {
+      await getConfirm()?.();
+    });
+
+    await waitFor(() => expect(mockDeleteChat).toHaveBeenCalled());
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('navigates home when the deleted chat is the open one', async () => {
+    mockPathname = '/chat/7';
+    const getCallback = captureSheet();
+    const getConfirm = captureDeleteConfirm();
+    const { result } = renderHook(() => useDrawerChatMenu());
+
+    act(() => result.current.openMenuFor(chat));
+    act(() => getCallback()(2));
+    await act(async () => {
+      await getConfirm()?.();
+    });
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/'));
+  });
+});
+
+describe('rename flow', () => {
+  it('keeps the rename modal hidden until rename is chosen', () => {
+    const { result } = renderHook(() => useDrawerChatMenu());
+    render(<>{result.current.MenuElements}</>);
+
+    expect(screen.queryByDisplayValue('Trip to Rome')).toBeNull();
+  });
+
+  it('opens the rename modal seeded with the chat label', () => {
+    const getCallback = captureSheet();
+    const { result } = renderHook(() => useDrawerChatMenu());
+    const { rerender } = render(<>{result.current.MenuElements}</>);
+
+    act(() => result.current.openMenuFor(chat));
+    act(() => getCallback()(0));
+    rerender(<>{result.current.MenuElements}</>);
+
+    expect(screen.getByDisplayValue('Trip to Rome')).toBeTruthy();
+  });
+
+  it('renames the long-pressed chat on submit', async () => {
+    const getCallback = captureSheet();
+    const { result } = renderHook(() => useDrawerChatMenu());
+    const { rerender } = render(<>{result.current.MenuElements}</>);
+
+    act(() => result.current.openMenuFor(chat));
+    act(() => getCallback()(0));
+    rerender(<>{result.current.MenuElements}</>);
+
+    fireEvent.changeText(screen.getByDisplayValue('Trip to Rome'), 'Rome 2026');
+    fireEvent.press(screen.getByText('Save'));
+
+    await waitFor(() =>
+      expect(mockRenameChat).toHaveBeenCalledWith(7, 'Rome 2026')
+    );
+  });
+
+  it('keeps the menu active while the rename modal is open', () => {
+    const getCallback = captureSheet();
+    const onMenuActiveChange = jest.fn();
+    const { result } = renderHook(() =>
+      useDrawerChatMenu({ onMenuActiveChange })
+    );
+    render(<>{result.current.MenuElements}</>);
+
+    act(() => result.current.openMenuFor(chat));
+    act(() => getCallback()(0));
+
+    expect(onMenuActiveChange).toHaveBeenCalledTimes(1);
+    expect(onMenuActiveChange).toHaveBeenCalledWith(true);
+  });
+
+  it('releases the menu when the rename modal is cancelled', async () => {
+    const getCallback = captureSheet();
+    const onMenuActiveChange = jest.fn();
+    const { result } = renderHook(() =>
+      useDrawerChatMenu({ onMenuActiveChange })
+    );
+    const { rerender } = render(<>{result.current.MenuElements}</>);
+
+    act(() => result.current.openMenuFor(chat));
+    act(() => getCallback()(0));
+    rerender(<>{result.current.MenuElements}</>);
+
+    fireEvent.press(screen.getByText('Cancel'));
+
+    await waitFor(() =>
+      expect(onMenuActiveChange).toHaveBeenLastCalledWith(false)
+    );
+  });
+});

--- a/__tests__/useDrawerChatMenu.test.tsx
+++ b/__tests__/useDrawerChatMenu.test.tsx
@@ -52,6 +52,8 @@ const setPlatform = (os: string) => {
   Object.defineProperty(Platform, 'OS', { get: () => os, configurable: true });
 };
 
+const ORIGINAL_OS = Platform.OS;
+
 const captureSheet = () => {
   let callback: ((index: number) => void) | null = null;
   jest
@@ -84,7 +86,10 @@ beforeEach(() => {
   mockExportChatRoom.mockResolvedValue(undefined);
 });
 
-afterEach(() => jest.restoreAllMocks());
+afterEach(() => {
+  jest.restoreAllMocks();
+  setPlatform(ORIGINAL_OS);
+});
 
 describe('opening the menu', () => {
   it('offers rename, export and delete for the long-pressed chat', () => {
@@ -263,7 +268,7 @@ describe('rename flow', () => {
     expect(screen.queryByDisplayValue('Trip to Rome')).toBeNull();
   });
 
-  it('opens the rename modal seeded with the chat label', () => {
+  it('opens the rename modal seeded with the chat title', () => {
     const getCallback = captureSheet();
     const { result } = renderHook(() => useDrawerChatMenu());
     const { rerender } = render(<>{result.current.MenuElements}</>);
@@ -273,6 +278,19 @@ describe('rename flow', () => {
     rerender(<>{result.current.MenuElements}</>);
 
     expect(screen.getByDisplayValue('Trip to Rome')).toBeTruthy();
+  });
+
+  it('seeds the rename modal empty for an untitled chat, not its "Chat N" label', () => {
+    const getCallback = captureSheet();
+    const { result } = renderHook(() => useDrawerChatMenu());
+    const { rerender } = render(<>{result.current.MenuElements}</>);
+
+    act(() => result.current.openMenuFor(untitledChat));
+    act(() => getCallback()(0));
+    rerender(<>{result.current.MenuElements}</>);
+
+    expect(screen.queryByDisplayValue('Chat 9')).toBeNull();
+    expect(screen.getByPlaceholderText('Chat name').props.value).toBe('');
   });
 
   it('renames the long-pressed chat on submit', async () => {

--- a/app/(drawer)/_layout.tsx
+++ b/app/(drawer)/_layout.tsx
@@ -3,6 +3,7 @@ import Drawer from 'expo-router/drawer';
 import { useWindowDimensions } from 'react-native';
 import { useTheme } from '../../context/ThemeContext';
 import CustomDrawer from '../../components/drawer/CustomDrawer';
+import { getDrawerWidth } from '../../constants/drawer-layout';
 import { fontFamily, fontSizes } from '../../styles/fontStyles';
 
 const DrawerLayout = () => {
@@ -15,6 +16,7 @@ const DrawerLayout = () => {
       screenOptions={{
         overlayColor: theme.bg.overlay,
         swipeEdgeWidth: width,
+        drawerStyle: { width: getDrawerWidth(width) },
         drawerType: 'slide',
         headerShadowVisible: false,
         headerShown: true,

--- a/app/(drawer)/model-hub.tsx
+++ b/app/(drawer)/model-hub.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
-import { Alert, View, StyleSheet, Text, Platform } from 'react-native';
+import { View, StyleSheet, Text, Platform } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { ScrollView } from 'react-native-gesture-handler';
 import { useFocusEffect, useRouter } from 'expo-router';
@@ -27,6 +27,7 @@ import FamilyCard from '../../components/model-hub/FamilyCard';
 import ModelCard from '../../components/model-hub/ModelCard';
 import { groupModelsByFamily, ModelFamily } from '../../utils/modelFamily';
 import { CustomKeyboardAvoidingView } from '../../components/CustomKeyboardAvoidingView';
+import { useConfirm } from '../../hooks/useConfirm';
 
 const ModelHubScreen = () => {
   useDefaultHeader();
@@ -41,6 +42,7 @@ const ModelHubScreen = () => {
   const modelManagementSheetRef = useRef<BottomSheetModal | null>(null);
 
   const { models, removeModelFiles } = useModelStore();
+  const { confirm, ConfirmElement } = useConfirm();
   const [tab, setTab] = useState<ModelHubTab>('featured');
   const [search, setSearch] = useState('');
 
@@ -96,32 +98,26 @@ const ModelHubScreen = () => {
     [deletableDownloaded]
   );
 
-  const handleClearAll = () => {
+  const handleClearAll = async () => {
     if (deletableDownloaded.length === 0) return;
-    Alert.alert(
-      'Clear all downloaded models?',
-      `This will delete ${deletableDownloaded.length} model${
+    const confirmed = await confirm({
+      title: 'Clear all downloaded models?',
+      message: `This will delete ${deletableDownloaded.length} model${
         deletableDownloaded.length === 1 ? '' : 's'
       } (${totalDownloadedSizeGB.toFixed(
         2
       )} GB) from your device. You can redownload them later.`,
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Clear all',
-          style: 'destructive',
-          onPress: async () => {
-            for (const m of deletableDownloaded) {
-              await removeModelFiles(m.id);
-            }
-            Toast.show({
-              type: 'defaultToast',
-              text1: 'All downloaded model files have been deleted',
-            });
-          },
-        },
-      ]
-    );
+      confirmLabel: 'Clear all',
+    });
+    if (!confirmed) return;
+
+    for (const m of deletableDownloaded) {
+      await removeModelFiles(m.id);
+    }
+    Toast.show({
+      type: 'defaultToast',
+      text1: 'All downloaded model files have been deleted',
+    });
   };
 
   const isEmpty =
@@ -229,6 +225,7 @@ const ModelHubScreen = () => {
       <AddModelSheet bottomSheetModalRef={addModelSheetRef} />
       <WarningSheet bottomSheetModalRef={wifiWarningSheetRef} />
       <ModelManagementSheet bottomSheetModalRef={modelManagementSheetRef} />
+      {ConfirmElement}
     </CustomKeyboardAvoidingView>
   );
 };

--- a/components/bottomSheets/WarningSheet.tsx
+++ b/components/bottomSheets/WarningSheet.tsx
@@ -20,9 +20,10 @@ export interface WarningSheetData {
 
 interface Props {
   bottomSheetModalRef: RefObject<BottomSheetModal<WarningSheetData> | null>;
+  onDismiss?: () => void;
 }
 
-const WarningSheet = ({ bottomSheetModalRef }: Props) => {
+const WarningSheet = ({ bottomSheetModalRef, onDismiss }: Props) => {
   const { theme } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
@@ -43,6 +44,7 @@ const WarningSheet = ({ bottomSheetModalRef }: Props) => {
       ref={bottomSheetModalRef}
       backdropComponent={renderBackdrop}
       enableDynamicSizing
+      onDismiss={onDismiss}
       handleStyle={styles.handleStyle}
       handleIndicatorStyle={styles.handleIndicator}
       backgroundStyle={styles.background}

--- a/components/chat-screen/ChatTitleMenu.tsx
+++ b/components/chat-screen/ChatTitleMenu.tsx
@@ -3,19 +3,30 @@ import { ActionSheetIOS, Platform } from 'react-native';
 import { router } from 'expo-router';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { useChatActions } from '../../hooks/useChatActions';
+import { chatLabel } from '../../utils/chatLabel';
 import RenameChatModal from './RenameChatModal';
 import ChatTitleMenuSheet from './ChatTitleMenuSheet';
+import {
+  CHAT_MENU_CANCEL_INDEX,
+  CHAT_MENU_DELETE_INDEX,
+  CHAT_MENU_EXPORT_INDEX,
+  CHAT_MENU_OPTIONS,
+  CHAT_MENU_RENAME_INDEX,
+  getChatMenuTitle,
+} from '../../constants/chat-menu';
 
 interface Options {
   chatId: number;
   chatTitle: string;
 }
 
-const SHEET_TITLE = 'Chat';
-
 export const useChatTitleMenu = ({ chatId, chatTitle }: Options) => {
   const [renameVisible, setRenameVisible] = useState(false);
   const androidSheetRef = useRef<BottomSheetModal>(null);
+
+  const menuTitle = getChatMenuTitle(
+    chatLabel({ id: chatId, title: chatTitle })
+  );
 
   const { rename, exportChat, confirmDelete } = useChatActions({
     onDeleted: () => router.replace('/'),
@@ -43,27 +54,28 @@ export const useChatTitleMenu = ({ chatId, chatTitle }: Options) => {
     if (Platform.OS === 'ios') {
       ActionSheetIOS.showActionSheetWithOptions(
         {
-          title: SHEET_TITLE,
-          options: ['Rename', 'Export Chat', 'Delete Chat', 'Cancel'],
-          destructiveButtonIndex: 2,
-          cancelButtonIndex: 3,
+          title: menuTitle,
+          options: CHAT_MENU_OPTIONS,
+          destructiveButtonIndex: CHAT_MENU_DELETE_INDEX,
+          cancelButtonIndex: CHAT_MENU_CANCEL_INDEX,
         },
         (index) => {
-          if (index === 0) setRenameVisible(true);
-          else if (index === 1) handleExport();
-          else if (index === 2) handleDelete();
+          if (index === CHAT_MENU_RENAME_INDEX) setRenameVisible(true);
+          else if (index === CHAT_MENU_EXPORT_INDEX) handleExport();
+          else if (index === CHAT_MENU_DELETE_INDEX) handleDelete();
         }
       );
     } else {
       androidSheetRef.current?.present();
     }
-  }, [handleExport, handleDelete]);
+  }, [menuTitle, handleExport, handleDelete]);
 
   const MenuElements = (
     <>
       {Platform.OS === 'android' && (
         <ChatTitleMenuSheet
           bottomSheetModalRef={androidSheetRef}
+          title={menuTitle}
           onRename={() => setRenameVisible(true)}
           onExport={handleExport}
           onDelete={handleDelete}

--- a/components/chat-screen/ChatTitleMenu.tsx
+++ b/components/chat-screen/ChatTitleMenu.tsx
@@ -28,7 +28,7 @@ export const useChatTitleMenu = ({ chatId, chatTitle }: Options) => {
     chatLabel({ id: chatId, title: chatTitle })
   );
 
-  const { rename, exportChat, confirmDelete } = useChatActions({
+  const { rename, exportChat, confirmDelete, ConfirmElement } = useChatActions({
     onDeleted: () => router.replace('/'),
   });
 
@@ -81,6 +81,7 @@ export const useChatTitleMenu = ({ chatId, chatTitle }: Options) => {
           onDelete={handleDelete}
         />
       )}
+      {ConfirmElement}
       <RenameChatModal
         visible={renameVisible}
         initialTitle={chatTitle}

--- a/components/chat-screen/ChatTitleMenu.tsx
+++ b/components/chat-screen/ChatTitleMenu.tsx
@@ -1,12 +1,8 @@
 import React, { useCallback, useRef, useState } from 'react';
-import { ActionSheetIOS, Alert, Platform } from 'react-native';
+import { ActionSheetIOS, Platform } from 'react-native';
 import { router } from 'expo-router';
-import Toast from 'react-native-toast-message';
-import { useSQLiteContext } from 'expo-sqlite';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
-import { useChatStore } from '../../store/chatStore';
-import { useVectorStore } from '../../context/VectorStoreContext';
-import { exportChatRoom } from '../../database/exportImportRepository';
+import { useChatActions } from '../../hooks/useChatActions';
 import RenameChatModal from './RenameChatModal';
 import ChatTitleMenuSheet from './ChatTitleMenuSheet';
 
@@ -18,58 +14,30 @@ interface Options {
 const SHEET_TITLE = 'Chat';
 
 export const useChatTitleMenu = ({ chatId, chatTitle }: Options) => {
-  const db = useSQLiteContext();
-  const { renameChat, deleteChat } = useChatStore();
-  const { vectorStore } = useVectorStore();
   const [renameVisible, setRenameVisible] = useState(false);
   const androidSheetRef = useRef<BottomSheetModal>(null);
+
+  const { rename, exportChat, confirmDelete } = useChatActions({
+    onDeleted: () => router.replace('/'),
+  });
 
   const handleRenameSubmit = useCallback(
     async (newTitle: string) => {
       setRenameVisible(false);
-      const clipped =
-        newTitle.length > 25 ? newTitle.slice(0, 25) + '...' : newTitle;
-      try {
-        await renameChat(chatId, clipped);
-        Toast.show({
-          type: 'defaultToast',
-          text1: 'Chat renamed',
-        });
-      } catch (error) {
-        console.error('Error renaming chat:', error);
-        Alert.alert('Error', 'Failed to rename chat. Please try again.');
-      }
+      await rename(chatId, newTitle);
     },
-    [chatId, renameChat]
+    [chatId, rename]
   );
 
-  const handleExport = useCallback(async () => {
-    try {
-      await exportChatRoom(db, chatId, chatTitle);
-    } catch (error) {
-      console.error('Error exporting chat:', error);
-      Alert.alert('Error', 'Failed to export chat. Please try again.');
-    }
-  }, [db, chatId, chatTitle]);
+  const handleExport = useCallback(
+    () => exportChat(chatId, chatTitle),
+    [exportChat, chatId, chatTitle]
+  );
 
-  const handleDelete = useCallback(() => {
-    Alert.alert('Delete Chat', 'Are you sure you want to delete this chat?', [
-      { text: 'Cancel', style: 'cancel' },
-      {
-        text: 'Delete',
-        style: 'destructive',
-        onPress: async () => {
-          try {
-            await deleteChat(chatId, vectorStore ?? undefined);
-            router.replace('/');
-          } catch (error) {
-            console.error('Error deleting chat:', error);
-            Alert.alert('Error', 'Failed to delete chat. Please try again.');
-          }
-        },
-      },
-    ]);
-  }, [chatId, deleteChat, vectorStore]);
+  const handleDelete = useCallback(
+    () => confirmDelete(chatId),
+    [confirmDelete, chatId]
+  );
 
   const openMenu = useCallback(() => {
     if (Platform.OS === 'ios') {

--- a/components/chat-screen/ChatTitleMenuSheet.tsx
+++ b/components/chat-screen/ChatTitleMenuSheet.tsx
@@ -16,6 +16,7 @@ import { Feedback } from '../../utils/Feedback';
 
 interface Props {
   bottomSheetModalRef: RefObject<BottomSheetModal | null>;
+  title: string;
   onRename: () => void;
   onExport: () => void;
   onDelete: () => void;
@@ -53,6 +54,7 @@ const MenuOption = ({
 
 const ChatTitleMenuSheet = ({
   bottomSheetModalRef,
+  title,
   onRename,
   onExport,
   onDelete,
@@ -85,6 +87,9 @@ const ChatTitleMenuSheet = ({
       handleIndicatorStyle={{ backgroundColor: theme.border.soft }}
     >
       <BottomSheetView style={styles.container}>
+        <Text numberOfLines={1} style={styles.title} testID="chat-menu-title">
+          {title}
+        </Text>
         <MenuOption
           icon={EditIcon}
           iconColor={theme.text.primary}
@@ -124,6 +129,13 @@ const createStyles = (theme: Theme) =>
       paddingTop: 8,
       paddingBottom: 32,
       gap: 4,
+    },
+    title: {
+      paddingHorizontal: 8,
+      paddingBottom: 8,
+      fontFamily: fontFamily.medium,
+      fontSize: fontSizes.sm,
+      color: theme.text.defaultTertiary,
     },
     option: {
       flexDirection: 'row',

--- a/components/chat-screen/ChatTitleMenuSheet.tsx
+++ b/components/chat-screen/ChatTitleMenuSheet.tsx
@@ -19,6 +19,7 @@ interface Props {
   onRename: () => void;
   onExport: () => void;
   onDelete: () => void;
+  onDismiss?: () => void;
 }
 
 interface OptionProps {
@@ -55,6 +56,7 @@ const ChatTitleMenuSheet = ({
   onRename,
   onExport,
   onDelete,
+  onDismiss,
 }: Props) => {
   const { theme } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
@@ -68,6 +70,7 @@ const ChatTitleMenuSheet = ({
     <BottomSheetModal
       ref={bottomSheetModalRef}
       enableDynamicSizing
+      onDismiss={onDismiss}
       onChange={(index) => {
         if (index >= 0) Feedback.sheetOpen();
       }}

--- a/components/chat-screen/RenameChatModal.tsx
+++ b/components/chat-screen/RenameChatModal.tsx
@@ -6,9 +6,8 @@ import {
   TextInput,
   StyleSheet,
   Pressable,
-  KeyboardAvoidingView,
-  Platform,
 } from 'react-native';
+import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import { useTheme } from '../../context/ThemeContext';
 import { fontFamily, fontSizes } from '../../styles/fontStyles';
 import { Theme } from '../../styles/colors';
@@ -57,10 +56,7 @@ const RenameChatModal = ({
       statusBarTranslucent
       onRequestClose={onCancel}
     >
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        style={styles.overlay}
-      >
+      <KeyboardAvoidingView behavior="padding" style={styles.overlay}>
         <Pressable style={styles.backdrop} onPress={onCancel} />
         <View style={styles.card}>
           <Text style={styles.title}>Rename chat</Text>

--- a/components/drawer/CustomDrawer.tsx
+++ b/components/drawer/CustomDrawer.tsx
@@ -78,7 +78,9 @@ const CustomDrawer = ({ navigation }: DrawerContentComponentProps) => {
 
   const handleNavigate = useCallback(() => {
     closeSearch(true);
-    navigation.closeDrawer();
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => navigation.closeDrawer());
+    });
   }, [closeSearch, navigation]);
 
   const handleMenuActiveChange = useCallback((active: boolean) => {

--- a/components/drawer/CustomDrawer.tsx
+++ b/components/drawer/CustomDrawer.tsx
@@ -1,19 +1,38 @@
-import React, { useEffect, useMemo, useRef } from 'react';
-import { View, StyleSheet } from 'react-native';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { View, StyleSheet, TextInput, Keyboard } from 'react-native';
+import { ScrollView } from 'react-native-gesture-handler';
 import { useTheme } from '../../context/ThemeContext';
 import { Theme } from '../../styles/colors';
 import DrawerMenu from './DrawerMenu';
+import { DrawerSearchOverlay } from './DrawerSearchOverlay';
 import { Feedback } from '../../utils/Feedback';
+import { getDrawerTopPadding } from '../../constants/drawer-layout';
 import {
   DrawerContentComponentProps,
   useDrawerStatus,
 } from '@react-navigation/drawer';
 
-const CustomDrawer = (props: DrawerContentComponentProps) => {
+const CustomDrawer = ({ navigation }: DrawerContentComponentProps) => {
   const isFirstRender = useRef(true);
   const { theme } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const status = useDrawerStatus();
+
+  const [searching, setSearching] = useState(false);
+  const [search, setSearch] = useState('');
+  const [closeInstantly, setCloseInstantly] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
+  const [navHeight, setNavHeight] = useState(0);
+  const menuActiveRef = useRef(false);
+  const inputRef = useRef<TextInput | null>(null);
+  const scrollOffsetRef = useRef(0);
+  const collapsedScrollRef = useRef<ScrollView | null>(null);
 
   useEffect(() => {
     if (isFirstRender.current) {
@@ -24,9 +43,87 @@ const CustomDrawer = (props: DrawerContentComponentProps) => {
     Feedback.drawer();
   }, [status]);
 
+  useEffect(() => {
+    if (status === 'open') setNow(Date.now());
+  }, [status]);
+
+  useEffect(() => {
+    if (status === 'closed' && searching) {
+      setSearching(false);
+      setSearch('');
+    }
+  }, [status, searching]);
+
+  const closeSearch = useCallback((instantly = false) => {
+    Keyboard.dismiss();
+    menuActiveRef.current = false;
+    collapsedScrollRef.current?.scrollTo({
+      y: scrollOffsetRef.current,
+      animated: false,
+    });
+    setCloseInstantly(instantly);
+    setSearching(false);
+    setSearch('');
+  }, []);
+
+  const openSearch = useCallback(() => {
+    setCloseInstantly(false);
+    setSearching(true);
+  }, []);
+
+  const handleSearchBlur = useCallback(() => {
+    if (menuActiveRef.current) return;
+    closeSearch();
+  }, [closeSearch]);
+
+  const handleNavigate = useCallback(() => {
+    closeSearch(true);
+    navigation.closeDrawer();
+  }, [closeSearch, navigation]);
+
+  const handleMenuActiveChange = useCallback((active: boolean) => {
+    menuActiveRef.current = active;
+    if (!active) inputRef.current?.focus();
+  }, []);
+
   return (
     <View style={styles.container}>
-      <DrawerMenu />
+      <View
+        style={styles.menu}
+        accessibilityElementsHidden={searching}
+        importantForAccessibility={searching ? 'no-hide-descendants' : 'auto'}
+      >
+        <DrawerMenu
+          searching={false}
+          search=""
+          now={now}
+          navHeight={navHeight}
+          onNavMeasured={setNavHeight}
+          onChangeSearch={setSearch}
+          onOpenSearch={openSearch}
+          onCloseSearch={closeSearch}
+          onNavigate={handleNavigate}
+          scrollRef={collapsedScrollRef}
+          scrollOffsetRef={scrollOffsetRef}
+          resetScrollPosition={status === 'closed'}
+        />
+      </View>
+
+      <DrawerSearchOverlay
+        active={searching}
+        closeInstantly={closeInstantly}
+        search={search}
+        now={now}
+        navHeight={navHeight}
+        onNavMeasured={setNavHeight}
+        scrollOffsetRef={scrollOffsetRef}
+        onChangeSearch={setSearch}
+        onRequestClose={closeSearch}
+        onSearchBlur={handleSearchBlur}
+        onMenuActiveChange={handleMenuActiveChange}
+        onNavigate={handleNavigate}
+        inputRef={inputRef}
+      />
     </View>
   );
 };
@@ -38,6 +135,9 @@ const createStyles = (theme: Theme) =>
     container: {
       flex: 1,
       backgroundColor: theme.bg.softPrimary,
-      paddingTop: 32,
+      paddingTop: getDrawerTopPadding(theme.insets.top),
+    },
+    menu: {
+      flex: 1,
     },
   });

--- a/components/drawer/DrawerEmptyState.tsx
+++ b/components/drawer/DrawerEmptyState.tsx
@@ -1,0 +1,81 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { usePathname } from 'expo-router';
+import { useSQLiteContext } from 'expo-sqlite';
+import { useTheme } from '../../context/ThemeContext';
+import { useChatStore } from '../../store/chatStore';
+import { useLLMStore } from '../../store/llmStore';
+import { startPhantomChat } from '../../utils/startPhantomChat';
+import { fontFamily, fontSizes } from '../../styles/fontStyles';
+import { Theme } from '../../styles/colors';
+import ChatIcon from '../../assets/icons/chat.svg';
+import { DrawerItem } from './DrawerItem';
+
+interface Props {
+  onNavigate?: () => void;
+}
+
+export const DrawerEmptyState = ({ onNavigate }: Props) => {
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const pathname = usePathname();
+  const db = useSQLiteContext();
+  const { phantomChat } = useChatStore();
+  const { interrupt } = useLLMStore();
+
+  const isOnPhantomChat =
+    phantomChat != null && pathname === `/chat/${phantomChat.id}`;
+
+  const startNewChat = () => {
+    if (isOnPhantomChat) {
+      onNavigate?.();
+      return;
+    }
+    interrupt();
+    startPhantomChat(db, 'replace');
+    onNavigate?.();
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>No chats found</Text>
+      <View style={styles.action}>
+        <DrawerItem
+          icon={<ChatIcon width={18} height={18} style={styles.icon} />}
+          label="Start new chat"
+          testID="drawer-empty-new-chat"
+          active={false}
+          hugContent
+          onPress={startNewChat}
+        />
+      </View>
+    </View>
+  );
+};
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    container: {
+      paddingHorizontal: 12,
+      paddingVertical: 32,
+      alignItems: 'center',
+      gap: 16,
+    },
+    text: {
+      textAlign: 'center',
+      fontFamily: fontFamily.regular,
+      fontSize: fontSizes.sm,
+      color: theme.text.defaultTertiary,
+    },
+    action: {
+      alignSelf: 'center',
+      overflow: 'hidden',
+      borderRadius: 12,
+      borderWidth: 1,
+      borderColor: theme.border.soft,
+    },
+    icon: {
+      color: theme.text.primary,
+    },
+  });

--- a/components/drawer/DrawerItem.tsx
+++ b/components/drawer/DrawerItem.tsx
@@ -9,30 +9,48 @@ interface Props {
   label: string;
   active: boolean;
   onPress: () => void;
+  onLongPress?: () => void;
   icon?: React.ReactNode;
+  testID?: string;
+  hugContent?: boolean;
 }
 
-export const DrawerItem = memo(({ label, active, onPress, icon }: Props) => {
-  const { theme } = useTheme();
-  const styles = useMemo(() => createStyles(theme), [theme]);
+export const DrawerItem = memo(
+  ({
+    label,
+    active,
+    onPress,
+    onLongPress,
+    icon,
+    testID,
+    hugContent,
+  }: Props) => {
+    const { theme } = useTheme();
+    const styles = useMemo(() => createStyles(theme), [theme]);
 
-  return (
-    <Pressable
-      onPress={onPress}
-      style={({ pressed }) => [
-        styles.item,
-        (active || pressed) && styles.activeBackground,
-      ]}
-    >
-      <View style={styles.content}>
-        {icon}
-        <Text numberOfLines={1} style={styles.label}>
-          {label}
-        </Text>
-      </View>
-    </Pressable>
-  );
-});
+    return (
+      <Pressable
+        onPress={onPress}
+        onLongPress={onLongPress}
+        testID={testID}
+        style={({ pressed }) => [
+          styles.item,
+          (active || pressed) && styles.activeBackground,
+        ]}
+      >
+        <View style={styles.content}>
+          {icon}
+          <Text
+            numberOfLines={1}
+            style={[styles.label, hugContent && styles.labelHug]}
+          >
+            {label}
+          </Text>
+        </View>
+      </Pressable>
+    );
+  }
+);
 
 const createStyles = (theme: Theme) =>
   StyleSheet.create({
@@ -53,5 +71,8 @@ const createStyles = (theme: Theme) =>
       fontFamily: fontFamily.medium,
       color: theme.text.primary,
       flex: 1,
+    },
+    labelHug: {
+      flex: 0,
     },
   });

--- a/components/drawer/DrawerMenu.tsx
+++ b/components/drawer/DrawerMenu.tsx
@@ -48,7 +48,6 @@ interface Props {
   scrollRef?: RefObject<ScrollView | null>;
   scrollOffsetRef?: RefObject<number>;
   searchProgress?: SharedValue<number>;
-  panelProgress?: SharedValue<number>;
   resetScrollPosition?: boolean;
 }
 
@@ -68,7 +67,6 @@ const DrawerMenu = ({
   scrollRef: externalScrollRef,
   scrollOffsetRef,
   searchProgress,
-  panelProgress,
   resetScrollPosition,
 }: Props) => {
   const { theme } = useTheme();
@@ -155,7 +153,6 @@ const DrawerMenu = ({
           onBlur={onSearchBlur}
           inputRef={inputRef}
           progress={searchProgress}
-          geometryProgress={panelProgress}
         />
       </View>
 

--- a/components/drawer/DrawerMenu.tsx
+++ b/components/drawer/DrawerMenu.tsx
@@ -1,123 +1,207 @@
-import React, { useMemo } from 'react';
-import { Text, StyleSheet, View } from 'react-native';
+import React, { RefObject, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Text,
+  StyleSheet,
+  View,
+  TextInput,
+  Platform,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+} from 'react-native';
 import { useRouter, usePathname } from 'expo-router';
 import { ScrollView } from 'react-native-gesture-handler';
+import { SharedValue } from 'react-native-reanimated';
 import { useTheme } from '../../context/ThemeContext';
 import { useChatStore } from '../../store/chatStore';
 import { useLLMStore } from '../../store/llmStore';
-import { useSQLiteContext } from 'expo-sqlite';
-import { startPhantomChat } from '../../utils/startPhantomChat';
-import { Chat } from '../../database/chatRepository';
-import ChatIcon from '../../assets/icons/chat.svg';
-import ModelsIcon from '../../assets/icons/models.svg';
-import InfoCircleIcon from '../../assets/icons/info-circle.svg';
+import { chatLabel } from '../../utils/chatLabel';
 import { DrawerItem } from './DrawerItem';
+import { DrawerTopBar } from './DrawerTopBar';
+import { DrawerNavSection } from './DrawerNavSection';
+import { DrawerEmptyState } from './DrawerEmptyState';
+import { buildChatSections } from './chatSections';
+import { useDrawerChatMenu } from './useDrawerChatMenu';
+import {
+  DRAWER_HORIZONTAL_PADDING,
+  SECTION_GAP,
+} from '../../constants/drawer-layout';
 import { fontFamily, fontSizes } from '../../styles/fontStyles';
 import { Theme } from '../../styles/colors';
 
-const getRelativeDateSection = (date: Date): string => {
-  const now = new Date();
-  const diffDays = Math.floor(
-    (now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24)
-  );
+const scrollIndicatorInsets = Platform.select({
+  ios: { right: 1 },
+});
 
-  if (diffDays === 0) return 'Today';
-  if (diffDays === 1) return 'Yesterday';
-  if (diffDays <= 6) return `${diffDays} days ago`;
-  if (diffDays <= 13) return 'Last week';
-  if (diffDays <= 20) return '2 weeks ago';
-  if (diffDays <= 27) return '3 weeks ago';
-  if (diffDays <= 59) return 'Last month';
-  if (diffDays <= 89) return '2 months ago';
-  if (diffDays <= 119) return '3 months ago';
-  if (diffDays <= 364) return 'Within a year';
+interface Props {
+  searching: boolean;
+  search: string;
+  now: number;
+  navHeight: number;
+  onNavMeasured: (height: number) => void;
+  onChangeSearch: (value: string) => void;
+  onOpenSearch?: () => void;
+  onCloseSearch: () => void;
+  onSearchBlur?: () => void;
+  onMenuActiveChange?: (active: boolean) => void;
+  onNavigate?: () => void;
+  inputRef?: RefObject<TextInput | null>;
+  scrollRef?: RefObject<ScrollView | null>;
+  scrollOffsetRef?: RefObject<number>;
+  searchProgress?: SharedValue<number>;
+  panelProgress?: SharedValue<number>;
+  resetScrollPosition?: boolean;
+}
 
-  return 'More than a year ago';
-};
-
-const groupChatsByDate = (chats: Chat[]): Record<string, Chat[]> => {
-  const sections: Record<string, Chat[]> = {};
-  chats.forEach((chat) => {
-    const date = new Date(chat.lastUsed);
-    const section = getRelativeDateSection(date);
-    if (!sections[section]) {
-      sections[section] = [];
-    }
-    sections[section].push(chat);
-  });
-  return sections;
-};
-
-const DrawerMenu = () => {
+const DrawerMenu = ({
+  searching,
+  search,
+  now,
+  navHeight,
+  onNavMeasured,
+  onChangeSearch,
+  onOpenSearch,
+  onCloseSearch,
+  onSearchBlur,
+  onMenuActiveChange,
+  onNavigate,
+  inputRef,
+  scrollRef: externalScrollRef,
+  scrollOffsetRef,
+  searchProgress,
+  panelProgress,
+  resetScrollPosition,
+}: Props) => {
   const { theme } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   const router = useRouter();
   const pathname = usePathname();
 
-  const { chats, phantomChat } = useChatStore();
+  const { chats } = useChatStore();
   const { interrupt } = useLLMStore();
-  const db = useSQLiteContext();
 
-  const isOnPhantomChat =
-    phantomChat != null && pathname === `/chat/${phantomChat.id}`;
+  const { openMenuFor, MenuElements } = useDrawerChatMenu({
+    onMenuActiveChange,
+  });
 
-  const groupedChats = useMemo(
-    () => groupChatsByDate([...chats].sort((a, b) => b.lastUsed - a.lastUsed)),
-    [chats]
+  const query = search.trim().toLowerCase();
+  const isFiltering = query.length > 0;
+
+  const sections = useMemo(
+    () => buildChatSections(chats, query, now),
+    [chats, query, now]
   );
 
-  const navigate = (path: string) => {
+  const hasNoResults = isFiltering && sections.length === 0;
+
+  const internalScrollRef = useRef<ScrollView>(null);
+  const scrollRef = externalScrollRef ?? internalScrollRef;
+
+  const [initialScrollOffset] = useState(() => scrollOffsetRef?.current ?? 0);
+  const initialContentOffset = useMemo(
+    () => ({ x: 0, y: initialScrollOffset }),
+    [initialScrollOffset]
+  );
+  const isInitialQuery = useRef(true);
+  const didRestoreScroll = useRef(false);
+
+  useEffect(() => {
+    if (isInitialQuery.current) {
+      isInitialQuery.current = false;
+      return;
+    }
+
+    scrollRef.current?.scrollTo({
+      y: query ? 0 : (scrollOffsetRef?.current ?? 0),
+      animated: false,
+    });
+  }, [query, scrollRef, scrollOffsetRef]);
+
+  useEffect(() => {
+    if (resetScrollPosition) {
+      if (scrollOffsetRef) scrollOffsetRef.current = 0;
+      scrollRef.current?.scrollTo({ y: 0, animated: false });
+    }
+  }, [resetScrollPosition, scrollRef, scrollOffsetRef]);
+
+  const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    if (!scrollOffsetRef || isFiltering) return;
+    scrollOffsetRef.current = event.nativeEvent.contentOffset.y;
+  };
+
+  const handleContentSizeChange = () => {
+    if (Platform.OS === 'ios' || didRestoreScroll.current) return;
+    didRestoreScroll.current = true;
+    if (initialScrollOffset) {
+      scrollRef.current?.scrollTo({ y: initialScrollOffset, animated: false });
+    }
+  };
+
+  const openChat = (chatId: number) => {
     interrupt();
-    router.replace(path);
+    router.replace(`/chat/${chatId}`);
+    onNavigate?.();
   };
 
   return (
-    <ScrollView contentContainerStyle={styles.container}>
-      <View style={styles.section}>
-        <DrawerItem
-          icon={<ChatIcon width={18} height={18} style={styles.icon} />}
-          label="New chat"
-          active={pathname === '/' || isOnPhantomChat}
-          onPress={() => {
-            if (isOnPhantomChat) return;
-            interrupt();
-            startPhantomChat(db, 'replace');
-          }}
-        />
-        <DrawerItem
-          icon={<ModelsIcon width={18} height={18} style={styles.icon} />}
-          label="Models"
-          active={pathname === '/model-hub'}
-          onPress={() => navigate('/model-hub')}
-        />
-        <DrawerItem
-          icon={<InfoCircleIcon width={18} height={18} style={styles.icon} />}
-          label="App Info"
-          active={false}
-          onPress={() => router.push('/app-info')}
+    <View style={styles.container}>
+      <View style={styles.topBar}>
+        <DrawerTopBar
+          searching={searching}
+          search={search}
+          onChangeSearch={onChangeSearch}
+          onOpenSearch={onOpenSearch}
+          onCloseSearch={onCloseSearch}
+          onBlur={onSearchBlur}
+          inputRef={inputRef}
+          progress={searchProgress}
+          geometryProgress={panelProgress}
         />
       </View>
 
-      {Object.entries(groupedChats).map(([sectionTitle, sectionChats]) => (
-        <View key={sectionTitle} style={styles.subSectionContainer}>
-          <Text style={styles.subSection}>{sectionTitle}</Text>
-          <View>
-            {sectionChats.map((chat) => {
-              const path = `/chat/${chat.id}`;
-              return (
+      <ScrollView
+        ref={scrollRef}
+        testID="drawer-scroll"
+        style={styles.scrollView}
+        contentContainerStyle={styles.content}
+        contentOffset={initialContentOffset}
+        onScroll={handleScroll}
+        onContentSizeChange={handleContentSizeChange}
+        scrollEventThrottle={16}
+        keyboardShouldPersistTaps={hasNoResults ? 'always' : 'handled'}
+        automaticallyAdjustsScrollIndicatorInsets={false}
+        scrollIndicatorInsets={scrollIndicatorInsets}
+      >
+        <DrawerNavSection
+          collapsed={isFiltering}
+          height={navHeight}
+          onMeasured={onNavMeasured}
+          onNavigate={onNavigate}
+        />
+
+        {sections.map(([sectionTitle, sectionChats]) => (
+          <View key={sectionTitle} style={styles.section}>
+            <Text style={styles.sectionTitle}>{sectionTitle}</Text>
+            <View>
+              {sectionChats.map((chat) => (
                 <DrawerItem
                   key={chat.id}
-                  label={chat.title || `Chat ${chat.id}`}
-                  active={pathname === path}
-                  onPress={() => navigate(path)}
+                  testID={`drawer-chat-${chat.id}`}
+                  label={chatLabel(chat)}
+                  active={pathname === `/chat/${chat.id}`}
+                  onPress={() => openChat(chat.id)}
+                  onLongPress={() => openMenuFor(chat)}
                 />
-              );
-            })}
+              ))}
+            </View>
           </View>
-        </View>
-      ))}
-    </ScrollView>
+        ))}
+
+        {hasNoResults && <DrawerEmptyState onNavigate={onNavigate} />}
+      </ScrollView>
+
+      {MenuElements}
+    </View>
   );
 };
 
@@ -126,24 +210,29 @@ export default DrawerMenu;
 const createStyles = (theme: Theme) =>
   StyleSheet.create({
     container: {
-      paddingVertical: 32,
-      paddingHorizontal: 16,
-      gap: 24,
+      flex: 1,
+    },
+    topBar: {
+      paddingHorizontal: DRAWER_HORIZONTAL_PADDING,
+    },
+    scrollView: {
+      flex: 1,
+    },
+    content: {
+      paddingTop: 16,
+      paddingBottom: theme.insets.bottom + 16,
+      paddingHorizontal: DRAWER_HORIZONTAL_PADDING,
     },
     section: {
       gap: 8,
+      marginBottom: SECTION_GAP,
     },
-    subSectionContainer: {
-      gap: 8,
-    },
-    subSection: {
+    sectionTitle: {
+      alignSelf: 'flex-start',
       paddingHorizontal: 12,
       fontFamily: fontFamily.medium,
       fontSize: fontSizes.xs,
       letterSpacing: 0.1,
       color: theme.text.defaultTertiary,
-    },
-    icon: {
-      color: theme.text.primary,
     },
   });

--- a/components/drawer/DrawerMenu.tsx
+++ b/components/drawer/DrawerMenu.tsx
@@ -19,7 +19,7 @@ import { DrawerItem } from './DrawerItem';
 import { DrawerTopBar } from './DrawerTopBar';
 import { DrawerNavSection } from './DrawerNavSection';
 import { DrawerEmptyState } from './DrawerEmptyState';
-import { buildChatSections } from './chatSections';
+import { buildChatSections, sortChatsByRecency } from './chatSections';
 import { useDrawerChatMenu } from './useDrawerChatMenu';
 import {
   DRAWER_HORIZONTAL_PADDING,
@@ -85,9 +85,10 @@ const DrawerMenu = ({
   const query = search.trim().toLowerCase();
   const isFiltering = query.length > 0;
 
+  const sortedChats = useMemo(() => sortChatsByRecency(chats), [chats]);
   const sections = useMemo(
-    () => buildChatSections(chats, query, now),
-    [chats, query, now]
+    () => buildChatSections(sortedChats, query, now),
+    [sortedChats, query, now]
   );
 
   const hasNoResults = isFiltering && sections.length === 0;

--- a/components/drawer/DrawerNavSection.tsx
+++ b/components/drawer/DrawerNavSection.tsx
@@ -1,0 +1,166 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useRouter, usePathname } from 'expo-router';
+import Animated, {
+  Easing,
+  interpolate,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import { useSQLiteContext } from 'expo-sqlite';
+import { useTheme } from '../../context/ThemeContext';
+import { useChatStore } from '../../store/chatStore';
+import { useLLMStore } from '../../store/llmStore';
+import { startPhantomChat } from '../../utils/startPhantomChat';
+import { Theme } from '../../styles/colors';
+import ChatIcon from '../../assets/icons/chat.svg';
+import ModelsIcon from '../../assets/icons/models.svg';
+import InfoCircleIcon from '../../assets/icons/info-circle.svg';
+import { DrawerItem } from './DrawerItem';
+import {
+  EMPHASIZED_STANDARD,
+  NAV_COLLAPSE_DURATION,
+  SECTION_GAP,
+} from '../../constants/drawer-layout';
+
+const NAV_EASING = Easing.bezier(...EMPHASIZED_STANDARD);
+
+interface Props {
+  collapsed: boolean;
+  height: number;
+  onMeasured: (height: number) => void;
+  onNavigate?: () => void;
+}
+
+export const DrawerNavSection = ({
+  collapsed,
+  height,
+  onMeasured,
+  onNavigate,
+}: Props) => {
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const router = useRouter();
+  const pathname = usePathname();
+  const db = useSQLiteContext();
+  const { phantomChat } = useChatStore();
+  const { interrupt } = useLLMStore();
+
+  const isOnPhantomChat =
+    phantomChat != null && pathname === `/chat/${phantomChat.id}`;
+
+  const [rendered, setRendered] = useState(!collapsed);
+  const progress = useSharedValue(collapsed ? 0 : 1);
+  const isFirstRun = useRef(true);
+
+  useEffect(() => {
+    if (isFirstRun.current) {
+      isFirstRun.current = false;
+      return;
+    }
+
+    if (!collapsed) {
+      setRendered(true);
+      progress.set(
+        withTiming(1, {
+          duration: NAV_COLLAPSE_DURATION,
+          easing: NAV_EASING,
+        })
+      );
+      return;
+    }
+
+    progress.set(
+      withTiming(
+        0,
+        { duration: NAV_COLLAPSE_DURATION, easing: NAV_EASING },
+        (finished) => {
+          if (finished) runOnJS(setRendered)(false);
+        }
+      )
+    );
+  }, [collapsed, progress]);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    if (!height) return {};
+
+    return {
+      height: interpolate(progress.get(), [0, 1], [0, height]),
+      marginBottom: interpolate(progress.get(), [0, 1], [0, SECTION_GAP]),
+      opacity: progress.get(),
+    };
+  }, [height]);
+
+  if (!rendered) return null;
+
+  return (
+    <Animated.View
+      style={[styles.wrapper, animatedStyle]}
+      pointerEvents={collapsed ? 'none' : 'auto'}
+    >
+      <View
+        style={styles.section}
+        onLayout={
+          height
+            ? undefined
+            : (event) => {
+                const measured = event.nativeEvent.layout.height;
+                if (measured > 0) onMeasured(measured);
+              }
+        }
+      >
+        <DrawerItem
+          icon={<ChatIcon width={18} height={18} style={styles.icon} />}
+          label="New chat"
+          testID="drawer-new-chat"
+          active={pathname === '/' || isOnPhantomChat}
+          onPress={() => {
+            if (isOnPhantomChat) {
+              onNavigate?.();
+              return;
+            }
+            interrupt();
+            startPhantomChat(db, 'replace');
+            onNavigate?.();
+          }}
+        />
+        <DrawerItem
+          icon={<ModelsIcon width={18} height={18} style={styles.icon} />}
+          label="Models"
+          active={pathname === '/model-hub'}
+          onPress={() => {
+            interrupt();
+            router.replace('/model-hub');
+            onNavigate?.();
+          }}
+        />
+        <DrawerItem
+          icon={<InfoCircleIcon width={18} height={18} style={styles.icon} />}
+          label="App Info"
+          active={false}
+          onPress={() => {
+            router.push('/app-info');
+            onNavigate?.();
+          }}
+        />
+      </View>
+    </Animated.View>
+  );
+};
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    wrapper: {
+      overflow: 'hidden',
+      marginBottom: SECTION_GAP,
+    },
+    section: {
+      gap: 8,
+    },
+    icon: {
+      color: theme.text.primary,
+    },
+  });

--- a/components/drawer/DrawerSearchOverlay.tsx
+++ b/components/drawer/DrawerSearchOverlay.tsx
@@ -1,0 +1,134 @@
+import React, { RefObject, useMemo } from 'react';
+import {
+  Modal,
+  StyleSheet,
+  TextInput,
+  View,
+  useWindowDimensions,
+  Keyboard,
+} from 'react-native';
+import Animated, {
+  interpolate,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
+import { Pressable } from 'react-native-gesture-handler';
+import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
+import { useReanimatedKeyboardAnimation } from 'react-native-keyboard-controller';
+import { useTheme } from '../../context/ThemeContext';
+import { Theme } from '../../styles/colors';
+import DrawerMenu from './DrawerMenu';
+import { useSearchOverlayAnimation } from './useSearchOverlayAnimation';
+import {
+  getDrawerTopPadding,
+  getDrawerWidth,
+} from '../../constants/drawer-layout';
+
+interface Props {
+  active: boolean;
+  closeInstantly: boolean;
+  search: string;
+  now: number;
+  navHeight: number;
+  onNavMeasured: (height: number) => void;
+  onChangeSearch: (value: string) => void;
+  onRequestClose: () => void;
+  onSearchBlur: () => void;
+  onMenuActiveChange: (active: boolean) => void;
+  onNavigate: () => void;
+  inputRef: RefObject<TextInput | null>;
+  scrollOffsetRef: RefObject<number>;
+}
+
+export const DrawerSearchOverlay = ({
+  active,
+  closeInstantly,
+  search,
+  now,
+  navHeight,
+  onNavMeasured,
+  onChangeSearch,
+  onRequestClose,
+  onSearchBlur,
+  onMenuActiveChange,
+  onNavigate,
+  inputRef,
+  scrollOffsetRef,
+}: Props) => {
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const { width: screenWidth } = useWindowDimensions();
+
+  const { mounted, progress, contentProgress, startExpand } =
+    useSearchOverlayAnimation({ active, closeInstantly });
+  const { height: keyboardHeight } = useReanimatedKeyboardAnimation();
+
+  const collapsedWidth = getDrawerWidth(screenWidth);
+
+  const panelStyle = useAnimatedStyle(() => ({
+    width: Math.round(
+      interpolate(progress.get(), [0, 1], [collapsedWidth, screenWidth])
+    ),
+    paddingBottom: -keyboardHeight.get(),
+  }));
+
+  const handleBackdropPress = () => {
+    Keyboard.dismiss();
+    onRequestClose();
+  };
+
+  if (!mounted) return null;
+
+  return (
+    <Modal
+      visible
+      transparent
+      animationType="none"
+      statusBarTranslucent
+      onShow={startExpand}
+      onRequestClose={onRequestClose}
+    >
+      <BottomSheetModalProvider>
+        <Pressable style={styles.backdrop} onPress={handleBackdropPress} />
+        <Animated.View style={[styles.panel, panelStyle]}>
+          <View style={styles.panelContent}>
+            <DrawerMenu
+              searching
+              search={search}
+              now={now}
+              navHeight={navHeight}
+              onNavMeasured={onNavMeasured}
+              onChangeSearch={onChangeSearch}
+              onCloseSearch={onRequestClose}
+              onSearchBlur={onSearchBlur}
+              onMenuActiveChange={onMenuActiveChange}
+              onNavigate={onNavigate}
+              inputRef={inputRef}
+              scrollOffsetRef={scrollOffsetRef}
+              searchProgress={contentProgress}
+              panelProgress={progress}
+            />
+          </View>
+        </Animated.View>
+      </BottomSheetModalProvider>
+    </Modal>
+  );
+};
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    backdrop: {
+      ...StyleSheet.absoluteFillObject,
+    },
+    panel: {
+      position: 'absolute',
+      top: 0,
+      bottom: 0,
+      left: 0,
+      overflow: 'hidden',
+      backgroundColor: theme.bg.softPrimary,
+      paddingTop: getDrawerTopPadding(theme.insets.top),
+    },
+    panelContent: {
+      flex: 1,
+    },
+  });

--- a/components/drawer/DrawerSearchOverlay.tsx
+++ b/components/drawer/DrawerSearchOverlay.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useMemo } from 'react';
+import React, { RefObject, useCallback, useMemo } from 'react';
 import {
   Modal,
   StyleSheet,
@@ -11,7 +11,10 @@ import Animated, {
   interpolate,
   useAnimatedStyle,
 } from 'react-native-reanimated';
-import { Pressable } from 'react-native-gesture-handler';
+import {
+  GestureHandlerRootView,
+  Pressable,
+} from 'react-native-gesture-handler';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { useReanimatedKeyboardAnimation } from 'react-native-keyboard-controller';
 import { useTheme } from '../../context/ThemeContext';
@@ -58,7 +61,7 @@ export const DrawerSearchOverlay = ({
   const styles = useMemo(() => createStyles(theme), [theme]);
   const { width: screenWidth } = useWindowDimensions();
 
-  const { mounted, progress, contentProgress, startExpand } =
+  const { mounted, progress, contentProgress, backdropOpacity, startExpand } =
     useSearchOverlayAnimation({ active, closeInstantly });
   const { height: keyboardHeight } = useReanimatedKeyboardAnimation();
 
@@ -71,10 +74,19 @@ export const DrawerSearchOverlay = ({
     paddingBottom: -keyboardHeight.get(),
   }));
 
+  const backdropStyle = useAnimatedStyle(() => ({
+    opacity: backdropOpacity.get(),
+  }));
+
   const handleBackdropPress = () => {
     Keyboard.dismiss();
     onRequestClose();
   };
+
+  const handleShow = useCallback(() => {
+    startExpand();
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, [startExpand, inputRef]);
 
   if (!mounted) return null;
 
@@ -84,39 +96,54 @@ export const DrawerSearchOverlay = ({
       transparent
       animationType="none"
       statusBarTranslucent
-      onShow={startExpand}
+      onShow={handleShow}
       onRequestClose={onRequestClose}
     >
-      <BottomSheetModalProvider>
-        <Pressable style={styles.backdrop} onPress={handleBackdropPress} />
-        <Animated.View style={[styles.panel, panelStyle]}>
-          <View style={styles.panelContent}>
-            <DrawerMenu
-              searching
-              search={search}
-              now={now}
-              navHeight={navHeight}
-              onNavMeasured={onNavMeasured}
-              onChangeSearch={onChangeSearch}
-              onCloseSearch={onRequestClose}
-              onSearchBlur={onSearchBlur}
-              onMenuActiveChange={onMenuActiveChange}
-              onNavigate={onNavigate}
-              inputRef={inputRef}
-              scrollOffsetRef={scrollOffsetRef}
-              searchProgress={contentProgress}
-              panelProgress={progress}
-            />
-          </View>
-        </Animated.View>
-      </BottomSheetModalProvider>
+      <GestureHandlerRootView style={styles.root}>
+        <BottomSheetModalProvider>
+          <Animated.View
+            style={[styles.backdrop, backdropStyle]}
+            pointerEvents="none"
+          />
+          <Pressable
+            style={styles.backdropTouch}
+            onPress={handleBackdropPress}
+          />
+          <Animated.View style={[styles.panel, panelStyle]}>
+            <View style={styles.panelContent}>
+              <DrawerMenu
+                searching
+                search={search}
+                now={now}
+                navHeight={navHeight}
+                onNavMeasured={onNavMeasured}
+                onChangeSearch={onChangeSearch}
+                onCloseSearch={onRequestClose}
+                onSearchBlur={onSearchBlur}
+                onMenuActiveChange={onMenuActiveChange}
+                onNavigate={onNavigate}
+                inputRef={inputRef}
+                scrollOffsetRef={scrollOffsetRef}
+                searchProgress={contentProgress}
+              />
+            </View>
+          </Animated.View>
+        </BottomSheetModalProvider>
+      </GestureHandlerRootView>
     </Modal>
   );
 };
 
 const createStyles = (theme: Theme) =>
   StyleSheet.create({
+    root: {
+      flex: 1,
+    },
     backdrop: {
+      ...StyleSheet.absoluteFillObject,
+      backgroundColor: theme.bg.softPrimary,
+    },
+    backdropTouch: {
       ...StyleSheet.absoluteFillObject,
     },
     panel: {

--- a/components/drawer/DrawerTopBar.tsx
+++ b/components/drawer/DrawerTopBar.tsx
@@ -32,7 +32,6 @@ interface Props {
   onBlur?: () => void;
   inputRef?: RefObject<TextInput | null>;
   progress?: SharedValue<number>;
-  geometryProgress?: SharedValue<number>;
 }
 
 export const DrawerTopBar = ({
@@ -44,7 +43,6 @@ export const DrawerTopBar = ({
   onBlur,
   inputRef,
   progress,
-  geometryProgress,
 }: Props) => {
   const { theme } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
@@ -52,19 +50,12 @@ export const DrawerTopBar = ({
 
   const collapsedTitleWidth =
     getDrawerWidth(screenWidth) - DRAWER_HORIZONTAL_PADDING * 2;
-  const expandedTitleWidth = screenWidth - DRAWER_HORIZONTAL_PADDING * 2;
 
   const fallbackProgress = useSharedValue(1);
   const value = progress ?? fallbackProgress;
-  const geometry = geometryProgress ?? fallbackProgress;
 
   const titleLayerStyle = useAnimatedStyle(() => ({
     opacity: interpolate(value.get(), [0, 0.4], [1, 0]),
-    width: interpolate(
-      geometry.get(),
-      [0, 1],
-      [collapsedTitleWidth, expandedTitleWidth]
-    ),
   }));
 
   const fieldStyle = useAnimatedStyle(() => ({
@@ -124,7 +115,11 @@ export const DrawerTopBar = ({
       </Animated.View>
 
       <Animated.View
-        style={[styles.titleLayer, titleLayerStyle]}
+        style={[
+          styles.titleLayer,
+          { width: collapsedTitleWidth },
+          titleLayerStyle,
+        ]}
         pointerEvents="none"
         accessibilityElementsHidden
         importantForAccessibility="no-hide-descendants"

--- a/components/drawer/DrawerTopBar.tsx
+++ b/components/drawer/DrawerTopBar.tsx
@@ -1,0 +1,208 @@
+import React, { RefObject, useMemo } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  useWindowDimensions,
+} from 'react-native';
+import { Pressable } from 'react-native-gesture-handler';
+import Animated, {
+  interpolate,
+  SharedValue,
+  useAnimatedStyle,
+  useSharedValue,
+} from 'react-native-reanimated';
+import { useTheme } from '../../context/ThemeContext';
+import { fontFamily, fontSizes } from '../../styles/fontStyles';
+import { Theme } from '../../styles/colors';
+import {
+  DRAWER_HORIZONTAL_PADDING,
+  getDrawerWidth,
+} from '../../constants/drawer-layout';
+import SearchIcon from '../../assets/icons/search.svg';
+import ArrowLeftIcon from '../../assets/icons/arrow-left.svg';
+
+interface Props {
+  searching: boolean;
+  search: string;
+  onChangeSearch: (value: string) => void;
+  onOpenSearch?: () => void;
+  onCloseSearch: () => void;
+  onBlur?: () => void;
+  inputRef?: RefObject<TextInput | null>;
+  progress?: SharedValue<number>;
+  geometryProgress?: SharedValue<number>;
+}
+
+export const DrawerTopBar = ({
+  searching,
+  search,
+  onChangeSearch,
+  onOpenSearch,
+  onCloseSearch,
+  onBlur,
+  inputRef,
+  progress,
+  geometryProgress,
+}: Props) => {
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const { width: screenWidth } = useWindowDimensions();
+
+  const collapsedTitleWidth =
+    getDrawerWidth(screenWidth) - DRAWER_HORIZONTAL_PADDING * 2;
+  const expandedTitleWidth = screenWidth - DRAWER_HORIZONTAL_PADDING * 2;
+
+  const fallbackProgress = useSharedValue(1);
+  const value = progress ?? fallbackProgress;
+  const geometry = geometryProgress ?? fallbackProgress;
+
+  const titleLayerStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(value.get(), [0, 0.4], [1, 0]),
+    width: interpolate(
+      geometry.get(),
+      [0, 1],
+      [collapsedTitleWidth, expandedTitleWidth]
+    ),
+  }));
+
+  const fieldStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(value.get(), [0.35, 1], [0, 1]),
+  }));
+
+  if (!searching) {
+    return (
+      <View style={styles.bar}>
+        <Text style={styles.title}>Private Mind</Text>
+        <Pressable
+          onPress={onOpenSearch}
+          testID="drawer-search-open"
+          accessibilityRole="button"
+          accessibilityLabel="Search chats"
+          hitSlop={12}
+          style={({ pressed }) => [
+            styles.iconButton,
+            pressed && styles.pressed,
+          ]}
+        >
+          <SearchIcon width={20} height={20} style={styles.icon} />
+        </Pressable>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.bar}>
+      <Animated.View style={[styles.field, fieldStyle]}>
+        <Pressable
+          onPress={() => onCloseSearch()}
+          testID="drawer-search-back"
+          accessibilityRole="button"
+          accessibilityLabel="Close search"
+          hitSlop={12}
+          style={({ pressed }) => [styles.backButton, pressed && styles.dimmed]}
+        >
+          <ArrowLeftIcon width={20} height={20} style={styles.icon} />
+        </Pressable>
+        <TextInput
+          ref={inputRef}
+          value={search}
+          onChangeText={onChangeSearch}
+          onBlur={onBlur}
+          placeholder="Search chats..."
+          placeholderTextColor={theme.text.defaultTertiary}
+          style={styles.input}
+          testID="drawer-search-input"
+          autoFocus
+          autoCorrect={false}
+          autoCapitalize="none"
+          clearButtonMode="while-editing"
+          returnKeyType="search"
+          submitBehavior="submit"
+        />
+      </Animated.View>
+
+      <Animated.View
+        style={[styles.titleLayer, titleLayerStyle]}
+        pointerEvents="none"
+        accessibilityElementsHidden
+        importantForAccessibility="no-hide-descendants"
+      >
+        <Text style={styles.title}>Private Mind</Text>
+        <View style={styles.iconButton}>
+          <SearchIcon width={20} height={20} style={styles.icon} />
+        </View>
+      </Animated.View>
+    </View>
+  );
+};
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    bar: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+      minHeight: 44,
+    },
+    titleLayer: {
+      position: 'absolute',
+      left: 0,
+      top: 0,
+      bottom: 0,
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+      backgroundColor: theme.bg.softPrimary,
+    },
+    title: {
+      flex: 1,
+      paddingHorizontal: 12,
+      fontFamily: fontFamily.bold,
+      fontSize: fontSizes.lg,
+      color: theme.text.primary,
+    },
+    iconButton: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    pressed: {
+      backgroundColor: theme.bg.softSecondary,
+    },
+    icon: {
+      color: theme.text.primary,
+    },
+    field: {
+      flex: 1,
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 4,
+      paddingLeft: 4,
+      paddingRight: 12,
+      borderRadius: 12,
+      borderWidth: 1,
+      borderColor: theme.border.soft,
+      backgroundColor: theme.bg.softSecondary,
+    },
+    backButton: {
+      width: 36,
+      height: 36,
+      borderRadius: 18,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    dimmed: {
+      opacity: 0.5,
+    },
+    input: {
+      flex: 1,
+      paddingVertical: 10,
+      fontFamily: fontFamily.regular,
+      fontSize: fontSizes.md,
+      color: theme.text.primary,
+    },
+  });

--- a/components/drawer/DrawerTopBar.tsx
+++ b/components/drawer/DrawerTopBar.tsx
@@ -105,7 +105,6 @@ export const DrawerTopBar = ({
           placeholderTextColor={theme.text.defaultTertiary}
           style={styles.input}
           testID="drawer-search-input"
-          autoFocus
           autoCorrect={false}
           autoCapitalize="none"
           clearButtonMode="while-editing"

--- a/components/drawer/chatSections.ts
+++ b/components/drawer/chatSections.ts
@@ -22,16 +22,18 @@ export const getRelativeDateSection = (date: Date, now: Date): string => {
 
 export type ChatSection = [string, Chat[]];
 
+export const sortChatsByRecency = (chats: Chat[]): Chat[] =>
+  [...chats].sort((a, b) => b.lastUsed - a.lastUsed);
+
 export const buildChatSections = (
   chats: Chat[],
   query: string,
   now: number
 ): ChatSection[] => {
   const nowDate = new Date(now);
-  const sorted = [...chats].sort((a, b) => b.lastUsed - a.lastUsed);
   const matching = query
-    ? sorted.filter((chat) => chatLabel(chat).toLowerCase().includes(query))
-    : sorted;
+    ? chats.filter((chat) => chatLabel(chat).toLowerCase().includes(query))
+    : chats;
 
   const sections: Record<string, Chat[]> = {};
   matching.forEach((chat) => {

--- a/components/drawer/chatSections.ts
+++ b/components/drawer/chatSections.ts
@@ -1,0 +1,44 @@
+import { Chat } from '../../database/chatRepository';
+import { chatLabel } from '../../utils/chatLabel';
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+export const getRelativeDateSection = (date: Date, now: Date): string => {
+  const diffDays = Math.floor((now.getTime() - date.getTime()) / DAY_MS);
+
+  if (diffDays === 0) return 'Today';
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays <= 6) return `${diffDays} days ago`;
+  if (diffDays <= 13) return 'Last week';
+  if (diffDays <= 20) return '2 weeks ago';
+  if (diffDays <= 27) return '3 weeks ago';
+  if (diffDays <= 59) return 'Last month';
+  if (diffDays <= 89) return '2 months ago';
+  if (diffDays <= 119) return '3 months ago';
+  if (diffDays <= 364) return 'Within a year';
+
+  return 'More than a year ago';
+};
+
+export type ChatSection = [string, Chat[]];
+
+export const buildChatSections = (
+  chats: Chat[],
+  query: string,
+  now: number
+): ChatSection[] => {
+  const nowDate = new Date(now);
+  const sorted = [...chats].sort((a, b) => b.lastUsed - a.lastUsed);
+  const matching = query
+    ? sorted.filter((chat) => chatLabel(chat).toLowerCase().includes(query))
+    : sorted;
+
+  const sections: Record<string, Chat[]> = {};
+  matching.forEach((chat) => {
+    const section = getRelativeDateSection(new Date(chat.lastUsed), nowDate);
+    if (!sections[section]) sections[section] = [];
+    sections[section].push(chat);
+  });
+
+  return Object.entries(sections);
+};

--- a/components/drawer/useDrawerChatMenu.tsx
+++ b/components/drawer/useDrawerChatMenu.tsx
@@ -1,0 +1,123 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { ActionSheetIOS, Platform } from 'react-native';
+import { useRouter, usePathname } from 'expo-router';
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
+import { Chat } from '../../database/chatRepository';
+import { useChatActions } from '../../hooks/useChatActions';
+import { Feedback } from '../../utils/Feedback';
+import { chatLabel } from '../../utils/chatLabel';
+import RenameChatModal from '../chat-screen/RenameChatModal';
+import ChatTitleMenuSheet from '../chat-screen/ChatTitleMenuSheet';
+import {
+  CHAT_MENU_CANCEL_INDEX,
+  CHAT_MENU_DELETE_INDEX,
+  CHAT_MENU_EXPORT_INDEX,
+  CHAT_MENU_OPTIONS,
+  CHAT_MENU_RENAME_INDEX,
+  getChatMenuTitle,
+} from '../../constants/chat-menu';
+
+type Options = {
+  onMenuActiveChange?: (active: boolean) => void;
+};
+
+export const useDrawerChatMenu = ({ onMenuActiveChange }: Options = {}) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [targetChat, setTargetChat] = useState<Chat | null>(null);
+  const [renameVisible, setRenameVisible] = useState(false);
+  const androidSheetRef = useRef<BottomSheetModal>(null);
+
+  const { rename, exportChat, confirmDelete } = useChatActions({
+    onDeleted: (chatId) => {
+      if (pathname === `/chat/${chatId}`) {
+        router.replace('/');
+      }
+    },
+  });
+
+  const setMenuActive = useCallback(
+    (active: boolean) => onMenuActiveChange?.(active),
+    [onMenuActiveChange]
+  );
+
+  const openMenuFor = useCallback(
+    (chat: Chat) => {
+      setTargetChat(chat);
+      setMenuActive(true);
+
+      if (Platform.OS === 'ios') {
+        Feedback.sheetOpen();
+        ActionSheetIOS.showActionSheetWithOptions(
+          {
+            title: getChatMenuTitle(chatLabel(chat)),
+            options: CHAT_MENU_OPTIONS,
+            destructiveButtonIndex: CHAT_MENU_DELETE_INDEX,
+            cancelButtonIndex: CHAT_MENU_CANCEL_INDEX,
+          },
+          (index) => {
+            if (index === CHAT_MENU_RENAME_INDEX) {
+              setRenameVisible(true);
+              return;
+            }
+            if (index === CHAT_MENU_EXPORT_INDEX) {
+              exportChat(chat.id, chatLabel(chat));
+            } else if (index === CHAT_MENU_DELETE_INDEX) {
+              confirmDelete(chat.id);
+            }
+            setMenuActive(false);
+          }
+        );
+      } else {
+        androidSheetRef.current?.present();
+      }
+    },
+    [exportChat, confirmDelete, setMenuActive]
+  );
+
+  const handleRenameSubmit = useCallback(
+    async (newTitle: string) => {
+      setRenameVisible(false);
+      setMenuActive(false);
+      if (!targetChat) return;
+      await rename(targetChat.id, newTitle);
+    },
+    [rename, targetChat, setMenuActive]
+  );
+
+  const handleRenameCancel = useCallback(() => {
+    setRenameVisible(false);
+    setMenuActive(false);
+  }, [setMenuActive]);
+
+  const MenuElements = (
+    <>
+      {Platform.OS === 'android' && (
+        <ChatTitleMenuSheet
+          bottomSheetModalRef={androidSheetRef}
+          title={targetChat ? getChatMenuTitle(chatLabel(targetChat)) : ''}
+          onRename={() => setRenameVisible(true)}
+          onExport={() => {
+            setMenuActive(false);
+            if (targetChat) exportChat(targetChat.id, chatLabel(targetChat));
+          }}
+          onDelete={() => {
+            setMenuActive(false);
+            if (targetChat) confirmDelete(targetChat.id);
+          }}
+          onDismiss={() => {
+            if (!renameVisible) setMenuActive(false);
+          }}
+        />
+      )}
+      <RenameChatModal
+        visible={renameVisible}
+        initialTitle={targetChat ? chatLabel(targetChat) : ''}
+        onCancel={handleRenameCancel}
+        onSubmit={handleRenameSubmit}
+      />
+    </>
+  );
+
+  return { openMenuFor, MenuElements };
+};

--- a/components/drawer/useDrawerChatMenu.tsx
+++ b/components/drawer/useDrawerChatMenu.tsx
@@ -127,7 +127,7 @@ export const useDrawerChatMenu = ({ onMenuActiveChange }: Options = {}) => {
       {ConfirmElement}
       <RenameChatModal
         visible={renameVisible}
-        initialTitle={targetChat ? chatLabel(targetChat) : ''}
+        initialTitle={targetChat?.title ?? ''}
         onCancel={handleRenameCancel}
         onSubmit={handleRenameSubmit}
       />

--- a/components/drawer/useDrawerChatMenu.tsx
+++ b/components/drawer/useDrawerChatMenu.tsx
@@ -27,8 +27,9 @@ export const useDrawerChatMenu = ({ onMenuActiveChange }: Options = {}) => {
   const [targetChat, setTargetChat] = useState<Chat | null>(null);
   const [renameVisible, setRenameVisible] = useState(false);
   const androidSheetRef = useRef<BottomSheetModal>(null);
+  const actionPendingRef = useRef(false);
 
-  const { rename, exportChat, confirmDelete } = useChatActions({
+  const { rename, exportChat, confirmDelete, ConfirmElement } = useChatActions({
     onDeleted: (chatId) => {
       if (pathname === `/chat/${chatId}`) {
         router.replace('/');
@@ -39,6 +40,19 @@ export const useDrawerChatMenu = ({ onMenuActiveChange }: Options = {}) => {
   const setMenuActive = useCallback(
     (active: boolean) => onMenuActiveChange?.(active),
     [onMenuActiveChange]
+  );
+
+  const runAction = useCallback(
+    async (action: () => Promise<void>) => {
+      actionPendingRef.current = true;
+      try {
+        await action();
+      } finally {
+        actionPendingRef.current = false;
+        setMenuActive(false);
+      }
+    },
+    [setMenuActive]
   );
 
   const openMenuFor = useCallback(
@@ -58,21 +72,20 @@ export const useDrawerChatMenu = ({ onMenuActiveChange }: Options = {}) => {
           (index) => {
             if (index === CHAT_MENU_RENAME_INDEX) {
               setRenameVisible(true);
-              return;
-            }
-            if (index === CHAT_MENU_EXPORT_INDEX) {
-              exportChat(chat.id, chatLabel(chat));
+            } else if (index === CHAT_MENU_EXPORT_INDEX) {
+              runAction(() => exportChat(chat.id, chatLabel(chat)));
             } else if (index === CHAT_MENU_DELETE_INDEX) {
-              confirmDelete(chat.id);
+              runAction(() => confirmDelete(chat.id));
+            } else {
+              setMenuActive(false);
             }
-            setMenuActive(false);
           }
         );
       } else {
         androidSheetRef.current?.present();
       }
     },
-    [exportChat, confirmDelete, setMenuActive]
+    [exportChat, confirmDelete, runAction, setMenuActive]
   );
 
   const handleRenameSubmit = useCallback(
@@ -98,18 +111,20 @@ export const useDrawerChatMenu = ({ onMenuActiveChange }: Options = {}) => {
           title={targetChat ? getChatMenuTitle(chatLabel(targetChat)) : ''}
           onRename={() => setRenameVisible(true)}
           onExport={() => {
-            setMenuActive(false);
-            if (targetChat) exportChat(targetChat.id, chatLabel(targetChat));
+            if (targetChat)
+              runAction(() => exportChat(targetChat.id, chatLabel(targetChat)));
           }}
           onDelete={() => {
-            setMenuActive(false);
-            if (targetChat) confirmDelete(targetChat.id);
+            if (targetChat) runAction(() => confirmDelete(targetChat.id));
           }}
           onDismiss={() => {
-            if (!renameVisible) setMenuActive(false);
+            if (!renameVisible && !actionPendingRef.current) {
+              setMenuActive(false);
+            }
           }}
         />
       )}
+      {ConfirmElement}
       <RenameChatModal
         visible={renameVisible}
         initialTitle={targetChat ? chatLabel(targetChat) : ''}

--- a/components/drawer/useSearchOverlayAnimation.ts
+++ b/components/drawer/useSearchOverlayAnimation.ts
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Easing,
+  runOnJS,
+  useSharedValue,
+  withDelay,
+  withTiming,
+} from 'react-native-reanimated';
+import {
+  EMPHASIZED_ACCELERATE,
+  EMPHASIZED_DECELERATE,
+  FIELD_FADE_IN_DELAY,
+  FIELD_FADE_IN_DURATION,
+  FIELD_FADE_OUT_DURATION,
+  SEARCH_COLLAPSE_DURATION,
+  SEARCH_EXPAND_DURATION,
+} from '../../constants/drawer-layout';
+
+const EXPAND_EASING = Easing.bezier(...EMPHASIZED_DECELERATE);
+const COLLAPSE_EASING = Easing.bezier(...EMPHASIZED_ACCELERATE);
+const FADE_EASING = Easing.bezier(0.33, 1, 0.68, 1);
+
+interface Options {
+  active: boolean;
+  closeInstantly: boolean;
+}
+
+export const useSearchOverlayAnimation = ({
+  active,
+  closeInstantly,
+}: Options) => {
+  const [mounted, setMounted] = useState(active);
+  const mountedRef = useRef(active);
+  const progress = useSharedValue(0);
+  const contentProgress = useSharedValue(0);
+
+  const applyMounted = useCallback((value: boolean) => {
+    mountedRef.current = value;
+    setMounted(value);
+  }, []);
+
+  const startExpand = useCallback(() => {
+    progress.set(
+      withTiming(1, {
+        duration: SEARCH_EXPAND_DURATION,
+        easing: EXPAND_EASING,
+      })
+    );
+    contentProgress.set(
+      withDelay(
+        FIELD_FADE_IN_DELAY,
+        withTiming(1, {
+          duration: FIELD_FADE_IN_DURATION,
+          easing: FADE_EASING,
+        })
+      )
+    );
+  }, [progress, contentProgress]);
+
+  useEffect(() => {
+    if (active) {
+      if (mountedRef.current) {
+        startExpand();
+        return;
+      }
+
+      progress.set(0);
+      contentProgress.set(0);
+      applyMounted(true);
+      return;
+    }
+
+    if (!mountedRef.current) return;
+
+    if (closeInstantly) {
+      progress.set(0);
+      contentProgress.set(0);
+      applyMounted(false);
+      return;
+    }
+
+    contentProgress.set(
+      withTiming(0, {
+        duration: FIELD_FADE_OUT_DURATION,
+        easing: FADE_EASING,
+      })
+    );
+    progress.set(
+      withTiming(
+        0,
+        { duration: SEARCH_COLLAPSE_DURATION, easing: COLLAPSE_EASING },
+        (finished) => {
+          if (finished) runOnJS(applyMounted)(false);
+        }
+      )
+    );
+  }, [
+    active,
+    closeInstantly,
+    progress,
+    contentProgress,
+    startExpand,
+    applyMounted,
+  ]);
+
+  return { mounted, progress, contentProgress, startExpand };
+};

--- a/components/drawer/useSearchOverlayAnimation.ts
+++ b/components/drawer/useSearchOverlayAnimation.ts
@@ -7,6 +7,7 @@ import {
   withTiming,
 } from 'react-native-reanimated';
 import {
+  BACKDROP_FADE_IN_DURATION,
   EMPHASIZED_ACCELERATE,
   EMPHASIZED_DECELERATE,
   FIELD_FADE_IN_DELAY,
@@ -33,6 +34,7 @@ export const useSearchOverlayAnimation = ({
   const mountedRef = useRef(active);
   const progress = useSharedValue(0);
   const contentProgress = useSharedValue(0);
+  const backdropOpacity = useSharedValue(0);
 
   const applyMounted = useCallback((value: boolean) => {
     mountedRef.current = value;
@@ -40,6 +42,12 @@ export const useSearchOverlayAnimation = ({
   }, []);
 
   const startExpand = useCallback(() => {
+    backdropOpacity.set(
+      withTiming(1, {
+        duration: BACKDROP_FADE_IN_DURATION,
+        easing: EXPAND_EASING,
+      })
+    );
     progress.set(
       withTiming(1, {
         duration: SEARCH_EXPAND_DURATION,
@@ -55,7 +63,7 @@ export const useSearchOverlayAnimation = ({
         })
       )
     );
-  }, [progress, contentProgress]);
+  }, [progress, contentProgress, backdropOpacity]);
 
   useEffect(() => {
     if (active) {
@@ -66,6 +74,7 @@ export const useSearchOverlayAnimation = ({
 
       progress.set(0);
       contentProgress.set(0);
+      backdropOpacity.set(0);
       applyMounted(true);
       return;
     }
@@ -75,6 +84,7 @@ export const useSearchOverlayAnimation = ({
     if (closeInstantly) {
       progress.set(0);
       contentProgress.set(0);
+      backdropOpacity.set(0);
       applyMounted(false);
       return;
     }
@@ -83,6 +93,12 @@ export const useSearchOverlayAnimation = ({
       withTiming(0, {
         duration: FIELD_FADE_OUT_DURATION,
         easing: FADE_EASING,
+      })
+    );
+    backdropOpacity.set(
+      withTiming(0, {
+        duration: SEARCH_COLLAPSE_DURATION,
+        easing: COLLAPSE_EASING,
       })
     );
     progress.set(
@@ -99,9 +115,10 @@ export const useSearchOverlayAnimation = ({
     closeInstantly,
     progress,
     contentProgress,
+    backdropOpacity,
     startExpand,
     applyMounted,
   ]);
 
-  return { mounted, progress, contentProgress, startExpand };
+  return { mounted, progress, contentProgress, backdropOpacity, startExpand };
 };

--- a/components/model-hub/ModelCard.tsx
+++ b/components/model-hub/ModelCard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Alert, StyleSheet, View, Text } from 'react-native';
+import { StyleSheet, View, Text } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import NetInfo from '@react-native-community/netinfo';
 import Toast from 'react-native-toast-message';
@@ -11,6 +11,7 @@ import { Model } from '../../database/modelRepository';
 import { ModelState, useModelStore } from '../../store/modelStore';
 import { WarningSheetData } from '../bottomSheets/WarningSheet';
 import { isModelCompatible } from '../../utils/modelCompatibility';
+import { useConfirm } from '../../hooks/useConfirm';
 import Chip from '../Chip';
 import CircleButton from '../CircleButton';
 import ProcessorIcon from '../../assets/icons/processor.svg';
@@ -47,6 +48,7 @@ const ModelCard = ({
 
   const { downloadStates, downloadModel, cancelDownload, removeModelFiles } =
     useModelStore();
+  const { confirm, ConfirmElement } = useConfirm();
 
   const downloadState = downloadStates[model.id] || {
     progress: model.isDownloaded ? 1 : 0,
@@ -105,25 +107,19 @@ const ModelCard = ({
     await downloadModel(model);
   };
 
-  const handleDelete = () => {
-    Alert.alert(
-      'Delete model files?',
-      `${model.modelName} will be removed from your device. You can redownload it later.`,
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Delete',
-          style: 'destructive',
-          onPress: async () => {
-            await removeModelFiles(model.id);
-            Toast.show({
-              type: 'defaultToast',
-              text1: `${model.modelName} has been successfully deleted`,
-            });
-          },
-        },
-      ]
-    );
+  const handleDelete = async () => {
+    const confirmed = await confirm({
+      title: 'Delete model files?',
+      message: `${model.modelName} will be removed from your device. You can redownload it later.`,
+      confirmLabel: 'Delete',
+    });
+    if (!confirmed) return;
+
+    await removeModelFiles(model.id);
+    Toast.show({
+      type: 'defaultToast',
+      text1: `${model.modelName} has been successfully deleted`,
+    });
   };
 
   const isCompatible = isModelCompatible(model);
@@ -264,6 +260,8 @@ const ModelCard = ({
           </Text>
         </View>
       )}
+
+      {showDeleteButton && ConfirmElement}
     </TouchableOpacity>
   );
 };

--- a/constants/chat-menu.ts
+++ b/constants/chat-menu.ts
@@ -1,0 +1,18 @@
+export const CHAT_MENU_OPTIONS = [
+  'Rename',
+  'Export Chat',
+  'Delete Chat',
+  'Cancel',
+];
+
+export const CHAT_MENU_RENAME_INDEX = 0;
+export const CHAT_MENU_EXPORT_INDEX = 1;
+export const CHAT_MENU_DELETE_INDEX = 2;
+export const CHAT_MENU_CANCEL_INDEX = 3;
+
+export const CHAT_MENU_TITLE_MAX_LENGTH = 32;
+
+export const getChatMenuTitle = (label: string) =>
+  label.length > CHAT_MENU_TITLE_MAX_LENGTH
+    ? `${label.slice(0, CHAT_MENU_TITLE_MAX_LENGTH).trimEnd()}…`
+    : label;

--- a/constants/drawer-layout.ts
+++ b/constants/drawer-layout.ts
@@ -8,6 +8,8 @@ export const SEARCH_EXPAND_DURATION = 500;
 
 export const SEARCH_COLLAPSE_DURATION = 240;
 
+export const BACKDROP_FADE_IN_DURATION = 240;
+
 export const NAV_COLLAPSE_DURATION = 260;
 
 export const FIELD_FADE_IN_DELAY = 90;

--- a/constants/drawer-layout.ts
+++ b/constants/drawer-layout.ts
@@ -1,0 +1,29 @@
+export const DRAWER_EDGE_INSET = 56;
+
+export const DRAWER_TOP_SPACING = 12;
+
+export const DRAWER_HORIZONTAL_PADDING = 16;
+
+export const SEARCH_EXPAND_DURATION = 500;
+
+export const SEARCH_COLLAPSE_DURATION = 240;
+
+export const NAV_COLLAPSE_DURATION = 260;
+
+export const FIELD_FADE_IN_DELAY = 90;
+
+export const FIELD_FADE_IN_DURATION = 460;
+
+export const FIELD_FADE_OUT_DURATION = 180;
+
+export const SECTION_GAP = 24;
+
+export const EMPHASIZED_DECELERATE = [0.05, 0.7, 0.1, 1] as const;
+export const EMPHASIZED_ACCELERATE = [0.3, 0, 0.8, 0.15] as const;
+export const EMPHASIZED_STANDARD = [0.2, 0, 0, 1] as const;
+
+export const getDrawerWidth = (screenWidth: number) =>
+  Math.max(screenWidth - DRAWER_EDGE_INSET, 0);
+
+export const getDrawerTopPadding = (topInset: number) =>
+  topInset + DRAWER_TOP_SPACING;

--- a/hooks/useChatActions.ts
+++ b/hooks/useChatActions.ts
@@ -1,0 +1,75 @@
+import { useCallback } from 'react';
+import { Alert } from 'react-native';
+import Toast from 'react-native-toast-message';
+import { useSQLiteContext } from 'expo-sqlite';
+import { useChatStore } from '../store/chatStore';
+import { useVectorStore } from '../context/VectorStoreContext';
+import { exportChatRoom } from '../database/exportImportRepository';
+
+const MAX_TITLE_LENGTH = 25;
+
+interface Options {
+  onDeleted?: (chatId: number) => void;
+}
+
+export const useChatActions = ({ onDeleted }: Options = {}) => {
+  const db = useSQLiteContext();
+  const { renameChat, deleteChat } = useChatStore();
+  const { vectorStore } = useVectorStore();
+
+  const rename = useCallback(
+    async (chatId: number, newTitle: string) => {
+      const clipped =
+        newTitle.length > MAX_TITLE_LENGTH
+          ? newTitle.slice(0, MAX_TITLE_LENGTH) + '...'
+          : newTitle;
+      try {
+        await renameChat(chatId, clipped);
+        Toast.show({
+          type: 'defaultToast',
+          text1: 'Chat renamed',
+        });
+      } catch (error) {
+        console.error('Error renaming chat:', error);
+        Alert.alert('Error', 'Failed to rename chat. Please try again.');
+      }
+    },
+    [renameChat]
+  );
+
+  const exportChat = useCallback(
+    async (chatId: number, chatTitle: string) => {
+      try {
+        await exportChatRoom(db, chatId, chatTitle);
+      } catch (error) {
+        console.error('Error exporting chat:', error);
+        Alert.alert('Error', 'Failed to export chat. Please try again.');
+      }
+    },
+    [db]
+  );
+
+  const confirmDelete = useCallback(
+    (chatId: number) => {
+      Alert.alert('Delete Chat', 'Are you sure you want to delete this chat?', [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await deleteChat(chatId, vectorStore ?? undefined);
+              onDeleted?.(chatId);
+            } catch (error) {
+              console.error('Error deleting chat:', error);
+              Alert.alert('Error', 'Failed to delete chat. Please try again.');
+            }
+          },
+        },
+      ]);
+    },
+    [deleteChat, vectorStore, onDeleted]
+  );
+
+  return { rename, exportChat, confirmDelete };
+};

--- a/hooks/useChatActions.tsx
+++ b/hooks/useChatActions.tsx
@@ -5,6 +5,7 @@ import { useSQLiteContext } from 'expo-sqlite';
 import { useChatStore } from '../store/chatStore';
 import { useVectorStore } from '../context/VectorStoreContext';
 import { exportChatRoom } from '../database/exportImportRepository';
+import { useConfirm } from './useConfirm';
 
 const MAX_TITLE_LENGTH = 25;
 
@@ -16,6 +17,7 @@ export const useChatActions = ({ onDeleted }: Options = {}) => {
   const db = useSQLiteContext();
   const { renameChat, deleteChat } = useChatStore();
   const { vectorStore } = useVectorStore();
+  const { confirm, ConfirmElement } = useConfirm();
 
   const rename = useCallback(
     async (chatId: number, newTitle: string) => {
@@ -50,26 +52,24 @@ export const useChatActions = ({ onDeleted }: Options = {}) => {
   );
 
   const confirmDelete = useCallback(
-    (chatId: number) => {
-      Alert.alert('Delete Chat', 'Are you sure you want to delete this chat?', [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Delete',
-          style: 'destructive',
-          onPress: async () => {
-            try {
-              await deleteChat(chatId, vectorStore ?? undefined);
-              onDeleted?.(chatId);
-            } catch (error) {
-              console.error('Error deleting chat:', error);
-              Alert.alert('Error', 'Failed to delete chat. Please try again.');
-            }
-          },
-        },
-      ]);
+    async (chatId: number) => {
+      const confirmed = await confirm({
+        title: 'Delete Chat',
+        message: 'Are you sure you want to delete this chat?',
+        confirmLabel: 'Delete',
+      });
+      if (!confirmed) return;
+
+      try {
+        await deleteChat(chatId, vectorStore ?? undefined);
+        onDeleted?.(chatId);
+      } catch (error) {
+        console.error('Error deleting chat:', error);
+        Alert.alert('Error', 'Failed to delete chat. Please try again.');
+      }
     },
-    [deleteChat, vectorStore, onDeleted]
+    [confirm, deleteChat, vectorStore, onDeleted]
   );
 
-  return { rename, exportChat, confirmDelete };
+  return { rename, exportChat, confirmDelete, ConfirmElement };
 };

--- a/hooks/useConfirm.tsx
+++ b/hooks/useConfirm.tsx
@@ -1,0 +1,60 @@
+import React, { useCallback, useRef } from 'react';
+import { Alert, Platform } from 'react-native';
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
+import WarningSheet, {
+  WarningSheetData,
+} from '../components/bottomSheets/WarningSheet';
+
+export interface ConfirmOptions {
+  title: string;
+  message: string;
+  confirmLabel: string;
+}
+
+export const useConfirm = () => {
+  const sheetRef = useRef<BottomSheetModal<WarningSheetData>>(null);
+  const resolveRef = useRef<((confirmed: boolean) => void) | null>(null);
+
+  const settle = useCallback((confirmed: boolean) => {
+    const resolve = resolveRef.current;
+    resolveRef.current = null;
+    resolve?.(confirmed);
+  }, []);
+
+  const confirm = useCallback(
+    ({ title, message, confirmLabel }: ConfirmOptions) =>
+      new Promise<boolean>((resolve) => {
+        if (Platform.OS === 'ios') {
+          Alert.alert(title, message, [
+            { text: 'Cancel', style: 'cancel', onPress: () => resolve(false) },
+            {
+              text: confirmLabel,
+              style: 'destructive',
+              onPress: () => resolve(true),
+            },
+          ]);
+          return;
+        }
+
+        settle(false);
+        resolveRef.current = resolve;
+        sheetRef.current?.present({
+          title,
+          subtitle: message,
+          buttonTitle: confirmLabel,
+          onConfirm: () => settle(true),
+        });
+      }),
+    [settle]
+  );
+
+  const ConfirmElement =
+    Platform.OS === 'android' ? (
+      <WarningSheet
+        bottomSheetModalRef={sheetRef}
+        onDismiss={() => settle(false)}
+      />
+    ) : null;
+
+  return { confirm, ConfirmElement };
+};

--- a/hooks/useConfirm.tsx
+++ b/hooks/useConfirm.tsx
@@ -37,8 +37,14 @@ export const useConfirm = () => {
         }
 
         settle(false);
+
+        if (!sheetRef.current) {
+          resolve(false);
+          return;
+        }
+
         resolveRef.current = resolve;
-        sheetRef.current?.present({
+        sheetRef.current.present({
           title,
           subtitle: message,
           buttonTitle: confirmLabel,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
       "**/__tests__/**/*.test.tsx"
     ],
     "transformIgnorePatterns": [
-      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|react-native-gesture-handler|react-native-reanimated|zustand)"
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|react-native-gesture-handler|react-native-reanimated|react-native-keyboard-controller|zustand)"
     ],
     "setupFiles": [
       "<rootDir>/jest.setup.js"
@@ -45,7 +45,8 @@
       "^@gorhom/bottom-sheet$": "<rootDir>/__mocks__/@gorhom/bottom-sheet.tsx",
       "^react-native-safe-area-context$": "<rootDir>/__mocks__/react-native-safe-area-context.ts",
       "^expo-store-review$": "<rootDir>/__mocks__/expo-store-review.ts",
-      "^react-native-pulsar$": "<rootDir>/__mocks__/react-native-pulsar.ts"
+      "^react-native-pulsar$": "<rootDir>/__mocks__/react-native-pulsar.ts",
+      "^react-native-keyboard-controller$": "<rootDir>/node_modules/react-native-keyboard-controller/jest"
     }
   },
   "op-sqlite": {

--- a/utils/chatLabel.ts
+++ b/utils/chatLabel.ts
@@ -1,0 +1,4 @@
+import { Chat } from '../database/chatRepository';
+
+export const chatLabel = (chat: Pick<Chat, 'id' | 'title'>) =>
+  chat.title || `Chat ${chat.id}`;


### PR DESCRIPTION
## Summary
Redesign of the sidebar (closes #233): the drawer gets a proper top bar, in-drawer chat search, and a per-chat context menu, plus a round of Android interaction polish. Destructive actions now confirm through a bottom sheet instead of the native alert.

## What's included
**New drawer**
- Top bar with title + search entry point; search overlay expands from
drawer width to full screen and filters chats live.
- Per-chat context menu on long-press (rename / export / delete / cancel).
- Nav section, empty state, and date-grouped chat sections.

**Destructive-action confirmations**
- New `useConfirm` hook — native `Alert` on iOS, `WarningSheet` bottom sheet on Android.
- Adopted for chat delete and Model Hub delete / clear-all.

**Android polish & fixes**
- Search keyboard now opens reliably (focus on `onShow`, not
`autoFocus`) and overlay touches work (`GestureHandlerRootView` inside
the modal).
- Animated, opaque search backdrop — no bleed-through of the screen behind on expand, smooth reveal on collapse.
- Search title icon stays put during expand (no left/right jump).
- Rename-chat dialog keeps the keyboard up and stops jumping (keyboard-controller).
- Opening a chat from search no longer flashes the previous screen.

**Refactor**
- Extracted chat rename/export/delete into a shared `useChatActions` hook, reused by the chat title menu and the drawer context menu.

Closes #233