### PR TITLE
refactor: adopt the Reanimated 4 .get()/.set() shared-value API

### DIFF
--- a/__mocks__/react-native-reanimated.ts
+++ b/__mocks__/react-native-reanimated.ts
@@ -3,6 +3,26 @@ const RN = require('react-native');
 
 const createAnimatedComponent = (Component: any) => Component;
 
+interface MockSharedValue<T> {
+  value: T;
+  get: () => T;
+  set: (next: T | ((prev: T) => T)) => void;
+}
+
+const makeSharedValue = <T>(init: T): MockSharedValue<T> => {
+  const shared: MockSharedValue<T> = {
+    value: init,
+    get: () => shared.value,
+    set: (next) => {
+      shared.value =
+        typeof next === 'function'
+          ? (next as (prev: T) => T)(shared.value)
+          : next;
+    },
+  };
+  return shared;
+};
+
 const Animated = {
   View: RN.View,
   Text: RN.Text,
@@ -17,12 +37,19 @@ module.exports = {
   default: Animated,
   ...Animated,
   createAnimatedComponent,
-  useSharedValue: (init: any) => ({ value: init }),
+  useSharedValue: <T>(init: T) => makeSharedValue(init),
   useAnimatedStyle: (fn: () => any) => fn(),
   useAnimatedRef: () => ({ current: null }),
-  useDerivedValue: (fn: () => any) => ({ value: fn() }),
+  useDerivedValue: <T>(fn: () => T) => makeSharedValue(fn()),
   useAnimatedScrollHandler: (fn: any) => fn,
-  withTiming: (val: any) => val,
+  withTiming: (
+    val: any,
+    _config: any,
+    callback?: (finished: boolean) => void
+  ) => {
+    callback?.(true);
+    return val;
+  },
   withSpring: (val: any) => val,
   withRepeat: (val: any) => val,
   withDelay: (_d: any, val: any) => val,
@@ -32,6 +59,7 @@ module.exports = {
     linear: (t: any) => t,
     ease: (t: any) => t,
     quad: (t: any) => t,
+    bezier: () => (t: any) => t,
     inOut: (fn: any) => fn,
     out: (fn: any) => fn,
     in: (fn: any) => fn,

--- a/app/(modals)/onboarding.tsx
+++ b/app/(modals)/onboarding.tsx
@@ -103,7 +103,7 @@ function OnboardingScreen() {
           return true; // Prevent default back action
         } else if (stepNumber === 1) {
           // Go back to intro panel
-          bgSpillProgress.value = withTiming(0, { duration: 500 });
+          bgSpillProgress.set(withTiming(0, { duration: 500 }));
           setTimeout(() => setStepNumber(0), 500);
           return true; // Prevent default back action
         }
@@ -120,29 +120,29 @@ function OnboardingScreen() {
 
   const initialBgBottom = introPanel.height + 16;
   const bgDistance = useDerivedValue(() =>
-    interpolate(bgSpillProgress.value, [0, 1], [0, initialBgBottom])
+    interpolate(bgSpillProgress.get(), [0, 1], [0, initialBgBottom])
   );
 
   const divider = useDerivedValue(
-    () => SCREEN_HEIGHT - initialBgBottom + bgDistance.value
+    () => SCREEN_HEIGHT - initialBgBottom + bgDistance.get()
   );
 
   const colorBgAnimation = useAnimatedStyle(() => {
-    const topEdge = Math.max(theme.insets.top + 16 - bgDistance.value, 0);
-    const sideEdge = Math.max(16 - bgDistance.value, 0);
+    const topEdge = Math.max(theme.insets.top + 16 - bgDistance.get(), 0);
+    const sideEdge = Math.max(16 - bgDistance.get(), 0);
 
     return {
       position: 'absolute',
       top: topEdge,
       left: sideEdge,
       right: sideEdge,
-      bottom: SCREEN_HEIGHT - divider.value,
-      borderRadius: Math.max(10 - bgDistance.value, 0),
+      bottom: SCREEN_HEIGHT - divider.get(),
+      borderRadius: Math.max(10 - bgDistance.get(), 0),
     };
   });
 
   const imageAnimation = useAnimatedStyle(() => ({
-    height: divider.value,
+    height: divider.get(),
   }));
 
   return (
@@ -150,7 +150,7 @@ function OnboardingScreen() {
       <View ref={introPanel.ref} style={styles.bottomPanel}>
         <OnboardingIntroPanel
           onPressStart={() => {
-            bgSpillProgress.value = withTiming(1, { duration: 500 });
+            bgSpillProgress.set(withTiming(1, { duration: 500 }));
             setTimeout(() => setStepNumber(1), 500);
           }}
         />

--- a/components/SpinningCircle.tsx
+++ b/components/SpinningCircle.tsx
@@ -23,13 +23,15 @@ const SpinningCircle = ({
   const rotation = useSharedValue(0);
 
   useEffect(() => {
-    rotation.value = withRepeat(
-      withTiming(360, {
-        duration: 1000,
-        easing: Easing.linear,
-      }),
-      -1,
-      false
+    rotation.set(
+      withRepeat(
+        withTiming(360, {
+          duration: 1000,
+          easing: Easing.linear,
+        }),
+        -1,
+        false
+      )
     );
   }, []);
 
@@ -37,7 +39,7 @@ const SpinningCircle = ({
   const cx = size / 2;
 
   const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ rotate: `${rotation.value}deg` }],
+    transform: [{ rotate: `${rotation.get()}deg` }],
   }));
 
   return (

--- a/components/SpinningCircleTimer.tsx
+++ b/components/SpinningCircleTimer.tsx
@@ -28,13 +28,15 @@ export const SpinningCircleTimer = ({
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   useEffect(() => {
-    rotation.value = withRepeat(
-      withTiming(360, {
-        duration: 1000,
-        easing: Easing.linear,
-      }),
-      -1,
-      false
+    rotation.set(
+      withRepeat(
+        withTiming(360, {
+          duration: 1000,
+          easing: Easing.linear,
+        }),
+        -1,
+        false
+      )
     );
   }, []);
 
@@ -46,7 +48,7 @@ export const SpinningCircleTimer = ({
   const displayTime = `${minutes}:${String(seconds).padStart(2, '0')}`;
 
   const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ rotate: `${rotation.value}deg` }],
+    transform: [{ rotate: `${rotation.get()}deg` }],
   }));
 
   return (

--- a/components/SplashScreenAnimation.tsx
+++ b/components/SplashScreenAnimation.tsx
@@ -20,13 +20,15 @@ function SplashScreenAnimation() {
 
   useEffect(() => {
     SplashScreen.hide();
-    rippleProgress.value = withTiming(1, { duration: 800 }, () => {
-      runOnJS(setDone)(true);
-    });
+    rippleProgress.set(
+      withTiming(1, { duration: 800 }, () => {
+        runOnJS(setDone)(true);
+      })
+    );
   }, []);
 
   const rippleStyle = useAnimatedStyle(() => ({
-    transform: [{ scale: rippleProgress.value }],
+    transform: [{ scale: rippleProgress.get() }],
   }));
 
   if (done) {

--- a/components/chat-screen/AnimatedChatLoading.tsx
+++ b/components/chat-screen/AnimatedChatLoading.tsx
@@ -24,15 +24,17 @@ const AnimatedChatLoading = () => {
   const opacity = useSharedValue(0.4);
 
   useEffect(() => {
-    opacity.value = withRepeat(
-      withTiming(1, { duration: 900, easing: Easing.inOut(Easing.quad) }),
-      -1,
-      true
+    opacity.set(
+      withRepeat(
+        withTiming(1, { duration: 900, easing: Easing.inOut(Easing.quad) }),
+        -1,
+        true
+      )
     );
   }, [opacity]);
 
   const animatedStyle = useAnimatedStyle(() => ({
-    opacity: opacity.value,
+    opacity: opacity.get(),
   }));
 
   return (

--- a/components/chat-screen/ChatBar.tsx
+++ b/components/chat-screen/ChatBar.tsx
@@ -108,7 +108,7 @@ const ChatBar = ({
       clear: () => {
         setUserInput('');
         clearAll();
-        extraContentPadding.value = 0;
+        extraContentPadding.set(0);
         if (Platform.OS === 'ios') {
           textInputRef.current?.setNativeProps({ text: ' ' });
           textInputRef.current?.setNativeProps({ text: '' });
@@ -136,7 +136,7 @@ const ChatBar = ({
       }
       const baseline = defaultBarHeight.current || height;
       const delta = height - baseline;
-      extraContentPadding.value = Math.max(0, delta);
+      extraContentPadding.set(Math.max(0, delta));
       onHeightChange?.(height);
       if (delta > 0) {
         onBarGrow?.();

--- a/components/chat-screen/ChatScreen.tsx
+++ b/components/chat-screen/ChatScreen.tsx
@@ -315,11 +315,11 @@ export default function ChatScreen({
   const { height: windowHeight } = useWindowDimensions();
   const gradientProgress = useSharedValue(isEmpty ? 1 : 0);
   useEffect(() => {
-    gradientProgress.value = withTiming(isEmpty ? 1 : 0, { duration: 900 });
+    gradientProgress.set(withTiming(isEmpty ? 1 : 0, { duration: 900 }));
   }, [isEmpty, gradientProgress]);
   const gradientStyle = useAnimatedStyle(() => ({
-    opacity: gradientProgress.value,
-    transform: [{ translateY: (1 - gradientProgress.value) * windowHeight }],
+    opacity: gradientProgress.get(),
+    transform: [{ translateY: (1 - gradientProgress.get()) * windowHeight }],
   }));
 
   return (

--- a/components/chat-screen/ChatSpeechInput.tsx
+++ b/components/chat-screen/ChatSpeechInput.tsx
@@ -142,7 +142,7 @@ const ChatSpeechInput: React.FC<Props> = ({
   const wrapperStyle = useAnimatedStyle(() => {
     return {
       backgroundColor: interpolateColor(
-        cancelAnimationProgress.value,
+        cancelAnimationProgress.get(),
         [0, 0.5, 1],
         [theme.bg.main, theme.bg.errorPrimary, theme.bg.errorPrimary]
       ),
@@ -151,9 +151,11 @@ const ChatSpeechInput: React.FC<Props> = ({
 
   const handleCancel = () => {
     stop();
-    cancelAnimationProgress.value = withTiming(1, {
-      duration: CANCEL_ANIMATION_DURATION,
-    });
+    cancelAnimationProgress.set(
+      withTiming(1, {
+        duration: CANCEL_ANIMATION_DURATION,
+      })
+    );
 
     setTimeout(onCancel, CANCEL_ANIMATION_DURATION);
   };

--- a/components/chat-screen/Messages.tsx
+++ b/components/chat-screen/Messages.tsx
@@ -80,7 +80,7 @@ const Messages = ({
   const opacity = useSharedValue(0);
   const hasScrolledToEnd = useRef(false);
   const animatedContainerStyle = useAnimatedStyle(() => ({
-    opacity: opacity.value,
+    opacity: opacity.get(),
   }));
 
   // Re-arm the initial scroll when the chat history is cleared (e.g.
@@ -95,7 +95,7 @@ const Messages = ({
       hasScrolledToEnd.current
     ) {
       hasScrolledToEnd.current = false;
-      opacity.value = 0;
+      opacity.set(0);
     }
     prevChatLengthRef.current = chatHistory.length;
   }, [chatHistory.length, opacity]);
@@ -157,7 +157,7 @@ const Messages = ({
       lastUserHeight.current -
       lastAssistantHeight.current -
       CONTAINER_PADDING;
-    blankSpace.value = Math.max(0, raw);
+    blankSpace.set(Math.max(0, raw));
   }, [blankSpace]);
 
   useImperativeHandle(
@@ -172,7 +172,7 @@ const Messages = ({
         // messages yet).
         if (!hasScrolledToEnd.current) {
           hasScrolledToEnd.current = true;
-          opacity.value = 1;
+          opacity.set(1);
         }
         lastAssistantHeight.current = 0;
         lastUserHeight.current = 0;
@@ -180,7 +180,7 @@ const Messages = ({
 
         if (Platform.OS === 'ios') {
           if (containerHeight.current > 0) {
-            blankSpace.value = containerHeight.current;
+            blankSpace.set(containerHeight.current);
           }
         }
         pendingPinRef.current = true;
@@ -257,7 +257,7 @@ const Messages = ({
             snap();
             requestAnimationFrame(() => {
               snap();
-              opacity.value = withTiming(1, { duration: 350 });
+              opacity.set(withTiming(1, { duration: 350 }));
             });
           }, 16);
         });
@@ -275,9 +275,11 @@ const Messages = ({
       if (pendingPinRef.current) {
         pendingPinRef.current = false;
         if (Platform.OS !== 'ios' && containerHeight.current > 0) {
-          blankSpace.value = withTiming(containerHeight.current, {
-            duration: 300,
-          });
+          blankSpace.set(
+            withTiming(containerHeight.current, {
+              duration: 300,
+            })
+          );
         }
         scrollRef.current?.scrollToEnd({ animated: true });
       }

--- a/components/chat-screen/RecordingAnimation.tsx
+++ b/components/chat-screen/RecordingAnimation.tsx
@@ -55,23 +55,27 @@ const RecordingAnimation: React.FC<Props> = ({ width, height, ref }) => {
           .concat(newBars);
         lastDataRef.current = updatedBars;
 
-        offset.value = newBarsCount * BAR_OFFSET;
-        barsPath.value = prepareBarsPath(updatedBars, {
-          barsPerWindow,
-          height,
-        });
+        offset.set(newBarsCount * BAR_OFFSET);
+        barsPath.set(
+          prepareBarsPath(updatedBars, {
+            barsPerWindow,
+            height,
+          })
+        );
 
-        offset.value = withTiming(0, {
-          duration: (newBarsCount / barsPerWindow) * WINDOW_DURATION,
-          easing: Easing.linear,
-        });
+        offset.set(
+          withTiming(0, {
+            duration: (newBarsCount / barsPerWindow) * WINDOW_DURATION,
+            easing: Easing.linear,
+          })
+        );
       },
     }),
     [barsPerWindow, height]
   );
 
   const barsStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: offset.value - (offset.value % BAR_OFFSET) }],
+    transform: [{ translateX: offset.get() - (offset.get() % BAR_OFFSET) }],
   }));
 
   return (


### PR DESCRIPTION
## Summary
Reanimated deprecates direct `sharedValue.value` access in favour of `.get()` / `.set()`. This is a mechanical migration of every animation component that still used `.value`, plus the reanimated test mock. **No runtime behavior change.**

## Changes
- Migrated 10 components: `onboarding`, `Messages`, `RecordingAnimation`, `ChatScreen`, `ChatSpeechInput`, `ChatBar`, `AnimatedChatLoading`, `SplashScreenAnimation`,  `SpinningCircle`, `SpinningCircleTimer`.
- Updated `__mocks__/react-native-reanimated.ts`: `get`/`set` on shared values, `withTiming` completion callback, `Easing.bezier`, and generic typing.
- Confirmed no remaining `.value` shared-value access in the codebase.