### PR TITLE
fix(chat): prevent foreign key race on first PDF send

### DIFF
--- a/components/chat-screen/ChatBar.tsx
+++ b/components/chat-screen/ChatBar.tsx
@@ -39,7 +39,7 @@ interface Props {
     userInput: string,
     imagePath?: string,
     attachments?: Attachment[]
-  ) => void;
+  ) => void | Promise<void>;
   onSelectModel: () => void;
   onSelectPrompt: (prompt: string) => void;
   ref: Ref<{
@@ -142,7 +142,7 @@ const ChatBar = ({
         onBarGrow?.();
       }
     },
-    [extraContentPadding, onHeightChange, hasMessages]
+    [extraContentPadding, onHeightChange, onBarGrow, hasMessages]
   );
 
   const {
@@ -169,8 +169,17 @@ const ChatBar = ({
 
   const handleSend = useCallback(() => {
     if (hasLoadingAttachment) return;
-    onSend(userInput, imageAttachment?.uri, attachments);
-    clearAll();
+    const attachmentsToSend = attachments;
+    const imageUriToSend = imageAttachment?.uri;
+    const inputToSend = userInput;
+
+    setUserInput('');
+    clearAll({ cleanupSources: false });
+    Promise.resolve(
+      onSend(inputToSend, imageUriToSend, attachmentsToSend)
+    ).catch((error) => {
+      console.error('Failed to send message:', error);
+    });
   }, [
     onSend,
     userInput,
@@ -235,8 +244,14 @@ const ChatBar = ({
     const handleSubmit = (transcript: string) => {
       setShowSpeechInput(false);
       if (transcript) {
-        onSend(transcript, imageAttachment?.uri, attachments);
-        clearAll();
+        const attachmentsToSend = attachments;
+        const imageUriToSend = imageAttachment?.uri;
+        clearAll({ cleanupSources: false });
+        Promise.resolve(
+          onSend(transcript, imageUriToSend, attachmentsToSend)
+        ).catch((error) => {
+          console.error('Failed to send transcript:', error);
+        });
       }
     };
 

--- a/components/chat-screen/ChatScreen.tsx
+++ b/components/chat-screen/ChatScreen.tsx
@@ -9,6 +9,7 @@ import { Keyboard, StyleSheet, useWindowDimensions, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { KeyboardStickyView } from 'react-native-keyboard-controller';
+import { router } from 'expo-router';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
@@ -94,6 +95,7 @@ export default function ChatScreen({
     isGenerating,
     sendChatMessage,
     loadModel,
+    setActiveChatId,
     model: loadedModel,
   } = useLLMStore();
   const { getModelById } = useModelStore();
@@ -153,14 +155,21 @@ export default function ChatScreen({
     const hasDocuments = attachments?.some((a) => a.type === 'document');
     if ((!userInput.trim() && !imagePath && !hasDocuments) || isGenerating)
       return;
-    if (!(await checkIfChatExists(db, chatId!))) {
+
+    let targetChatId = chatId!;
+    if (!(await checkIfChatExists(db, targetChatId))) {
       const docName = attachments?.find((a) => a.type === 'document')?.name;
       const titleSource = userInput.trim() || docName || 'New chat';
       const newChatTitle =
         titleSource.length > 25
           ? titleSource.slice(0, 25) + '...'
           : titleSource;
-      await addChat(newChatTitle, model!.id);
+      const newChatId = await addChat(newChatTitle, model!.id);
+      if (!newChatId) return;
+
+      targetChatId = newChatId;
+      await setActiveChatId(targetChatId);
+      router.replace(`/chat/${targetChatId}`);
     }
 
     let persistedImagePath: string | undefined = imagePath;
@@ -177,9 +186,8 @@ export default function ChatScreen({
       }
     }
 
-    inputRef.current?.clear();
     Keyboard.dismiss();
-    updateLastUsed(chatId!);
+    updateLastUsed(targetChatId);
 
     // Notify Messages that a send is in flight. It will seed blankSpace to
     // the full container height, then derive the final value from measured
@@ -221,7 +229,7 @@ export default function ChatScreen({
     // Enable new sources for this chat (persists for future messages)
     for (const sourceId of attachmentSourceIds) {
       if (!enabledSources.includes(sourceId)) {
-        await enableSource(chatId!, sourceId);
+        await enableSource(targetChatId, sourceId);
       }
     }
 
@@ -239,7 +247,7 @@ export default function ChatScreen({
         .join(', ') || undefined;
     await sendChatMessage(
       userInput,
-      chatId!,
+      targetChatId,
       context,
       settings,
       persistedImagePath,

--- a/hooks/useAttachment.ts
+++ b/hooks/useAttachment.ts
@@ -16,6 +16,10 @@ export interface Attachment {
   sourceId?: number;
 }
 
+interface ClearAllOptions {
+  cleanupSources?: boolean;
+}
+
 const requestAndroidGalleryPermission = async (): Promise<boolean> => {
   if (Platform.OS !== 'android') return true;
 
@@ -175,13 +179,17 @@ export const useAttachment = () => {
     [vectorStore]
   );
 
-  const clearAll = useCallback(() => {
-    const hadDocuments = attachmentsRef.current.some((a) => a.sourceId);
-    setAttachments([]);
-    if (hadDocuments && vectorStore) {
-      useSourceStore.getState().cleanupOrphanedSources(vectorStore);
-    }
-  }, [vectorStore]);
+  const clearAll = useCallback(
+    (options: ClearAllOptions = {}) => {
+      const cleanupSources = options.cleanupSources ?? true;
+      const hadDocuments = attachmentsRef.current.some((a) => a.sourceId);
+      setAttachments([]);
+      if (cleanupSources && hadDocuments && vectorStore) {
+        useSourceStore.getState().cleanupOrphanedSources(vectorStore);
+      }
+    },
+    [vectorStore]
+  );
 
   const openSheet = useCallback(() => {
     sheetRef.current?.present();


### PR DESCRIPTION
## Problem
Sending the first message in a brand-new chat that has a PDF attachment could fail with `FOREIGN KEY constraint failed`. The message and its source links were persisted against a chat id that didn't exist yet, and the attachment's source rows could be cleaned up while the send referencing them was still in flight.

## Root cause
- `ChatScreen` created the new chat but kept persisting the message, enabling sources and calling `updateLastUsed` against the original `chatId!` placeholder instead of the id actually returned by `addChat`.
- `ChatBar.handleSend` called `clearAll()` synchronously, which ran `cleanupOrphanedSources` and deleted the source rows the in-flight send needed.

## Fix
- Thread the real persisted chat id through the whole send path: `addChat` → `setActiveChatId` → `router.replace` → `enableSource` / `updateLastUsed` / `sendChatMessage`.
- Let `onSend` be async and await it; clear the input immediately but defer source cleanup via `clearAll({ cleanupSources: false })` so sources survive until the send completes.
- Add a `cleanupSources` option (default `true`) to `useAttachment.clearAll`.

## How to test
- New chat → attach a PDF → send the first message: no FK error, the message and cited sources persist, and the chat opens on its real id.
- Regression: text-only send and voice-transcript send still clear the input and clean up orphaned sources as before.