### PR TITLE
fix(chat): grey out image attachment options on non-vision models

### DIFF
--- a/__tests__/AttachmentSheet.test.tsx
+++ b/__tests__/AttachmentSheet.test.tsx
@@ -1,0 +1,93 @@
+import React, { createRef } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import type { BottomSheetModal } from '@gorhom/bottom-sheet';
+
+jest.mock('../context/ThemeContext', () => ({
+  useTheme: () => ({
+    theme: {
+      ...require('../styles/colors').lightTheme,
+      insets: { top: 0, bottom: 0, left: 0, right: 0 },
+    },
+  }),
+}));
+
+import AttachmentSheet from '../components/bottomSheets/AttachmentSheet';
+import Toast from 'react-native-toast-message';
+
+const makeProps = (isVisionModel: boolean) => ({
+  bottomSheetModalRef: createRef<BottomSheetModal>(),
+  isVisionModel,
+  onPickFromLibrary: jest.fn(),
+  onPickFromCamera: jest.fn(),
+  onPickDocument: jest.fn(),
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('AttachmentSheet', () => {
+  it('always renders Camera, Photo Library and Document options for a vision model', () => {
+    render(<AttachmentSheet {...makeProps(true)} />);
+    expect(screen.getByTestId('attachment-camera')).toBeTruthy();
+    expect(screen.getByTestId('attachment-library')).toBeTruthy();
+    expect(screen.getByTestId('attachment-document')).toBeTruthy();
+  });
+
+  it('still renders the image options (greyed) for a non-vision model', () => {
+    render(<AttachmentSheet {...makeProps(false)} />);
+    expect(screen.getByTestId('attachment-camera')).toBeTruthy();
+    expect(screen.getByTestId('attachment-library')).toBeTruthy();
+    expect(screen.getByTestId('attachment-document')).toBeTruthy();
+  });
+
+  describe('vision model', () => {
+    it('invokes the camera picker when Camera is pressed', () => {
+      const props = makeProps(true);
+      render(<AttachmentSheet {...props} />);
+      fireEvent.press(screen.getByTestId('attachment-camera'));
+      expect(props.onPickFromCamera).toHaveBeenCalledTimes(1);
+      expect(Toast.show).not.toHaveBeenCalled();
+    });
+
+    it('invokes the library picker when Photo Library is pressed', () => {
+      const props = makeProps(true);
+      render(<AttachmentSheet {...props} />);
+      fireEvent.press(screen.getByTestId('attachment-library'));
+      expect(props.onPickFromLibrary).toHaveBeenCalledTimes(1);
+      expect(Toast.show).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('non-vision model', () => {
+    it('shows an explanatory toast and does not open the camera picker', () => {
+      const props = makeProps(false);
+      render(<AttachmentSheet {...props} />);
+      fireEvent.press(screen.getByTestId('attachment-camera'));
+      expect(props.onPickFromCamera).not.toHaveBeenCalled();
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text1: 'This model does not support images',
+        })
+      );
+    });
+
+    it('shows an explanatory toast and does not open the library picker', () => {
+      const props = makeProps(false);
+      render(<AttachmentSheet {...props} />);
+      fireEvent.press(screen.getByTestId('attachment-library'));
+      expect(props.onPickFromLibrary).not.toHaveBeenCalled();
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text1: 'This model does not support images',
+        })
+      );
+    });
+
+    it('still allows attaching a document without a toast', () => {
+      const props = makeProps(false);
+      render(<AttachmentSheet {...props} />);
+      fireEvent.press(screen.getByTestId('attachment-document'));
+      expect(props.onPickDocument).toHaveBeenCalledTimes(1);
+      expect(Toast.show).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/ChatBar.test.tsx
+++ b/__tests__/ChatBar.test.tsx
@@ -47,19 +47,13 @@ jest.mock('../components/bottomSheets/AttachmentSheet', () => {
     isVisionModel,
   }: any) => (
     <View testID="attachment-sheet">
-      {isVisionModel && (
-        <>
-          <TouchableOpacity
-            testID="pick-library-btn"
-            onPress={onPickFromLibrary}
-          >
-            <Text>Library</Text>
-          </TouchableOpacity>
-          <TouchableOpacity testID="pick-camera-btn" onPress={onPickFromCamera}>
-            <Text>Camera</Text>
-          </TouchableOpacity>
-        </>
-      )}
+      <Text>{`vision:${isVisionModel}`}</Text>
+      <TouchableOpacity testID="pick-library-btn" onPress={onPickFromLibrary}>
+        <Text>Library</Text>
+      </TouchableOpacity>
+      <TouchableOpacity testID="pick-camera-btn" onPress={onPickFromCamera}>
+        <Text>Camera</Text>
+      </TouchableOpacity>
       <TouchableOpacity testID="pick-document-btn" onPress={onPickDocument}>
         <Text>Document</Text>
       </TouchableOpacity>
@@ -505,16 +499,18 @@ describe('attachment', () => {
     ]);
   });
 
-  it('passes isVisionModel to AttachmentSheet', () => {
+  it('forwards isVisionModel=true and renders image options in AttachmentSheet', () => {
     renderBar({ isVisionModel: true });
+    expect(screen.getByText('vision:true')).toBeTruthy();
     expect(screen.getByTestId('pick-library-btn')).toBeTruthy();
     expect(screen.getByTestId('pick-camera-btn')).toBeTruthy();
   });
 
-  it('hides image options in AttachmentSheet when not a vision model', () => {
+  it('keeps image options visible and forwards isVisionModel=false for non-vision models', () => {
     renderBar({ isVisionModel: false });
-    expect(screen.queryByTestId('pick-library-btn')).toBeNull();
-    expect(screen.queryByTestId('pick-camera-btn')).toBeNull();
+    expect(screen.getByText('vision:false')).toBeTruthy();
+    expect(screen.getByTestId('pick-library-btn')).toBeTruthy();
+    expect(screen.getByTestId('pick-camera-btn')).toBeTruthy();
     expect(screen.getByTestId('pick-document-btn')).toBeTruthy();
   });
 });

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -119,8 +119,8 @@ export default function Layout() {
               <BottomSheetModalProvider>
                 <RootNavigator />
                 {Platform.OS === 'android' && <StatusBar style="auto" />}
-                <AppToast />
               </BottomSheetModalProvider>
+              <AppToast />
             </KeyboardProvider>
           </VectorStoreProvider>
           <SplashScreenAnimation />

--- a/components/bottomSheets/AttachmentSheet.tsx
+++ b/components/bottomSheets/AttachmentSheet.tsx
@@ -8,6 +8,7 @@ import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { useTheme } from '../../context/ThemeContext';
 import { Theme } from '../../styles/colors';
 import { fontFamily, fontSizes, lineHeights } from '../../styles/fontStyles';
+import Toast from 'react-native-toast-message';
 import CameraIcon from '../../assets/icons/camera.svg';
 import ImageIcon from '../../assets/icons/image.svg';
 import AttachmentIcon from '../../assets/icons/attachment.svg';
@@ -30,6 +31,7 @@ interface OptionProps {
   onPress: () => void;
   testID: string;
   styles: ReturnType<typeof createStyles>;
+  disabled?: boolean;
 }
 
 const AttachmentOption = ({
@@ -39,8 +41,13 @@ const AttachmentOption = ({
   onPress,
   testID,
   styles,
+  disabled = false,
 }: OptionProps) => (
-  <TouchableOpacity style={styles.option} onPress={onPress} testID={testID}>
+  <TouchableOpacity
+    style={[styles.option, disabled && styles.optionDisabled]}
+    onPress={onPress}
+    testID={testID}
+  >
     <View style={styles.iconWrapper}>
       <Icon width={24} height={24} style={{ color: iconColor }} />
     </View>
@@ -62,6 +69,17 @@ const AttachmentSheet = ({
   const handleOption = (action: () => void) => {
     bottomSheetModalRef.current?.dismiss();
     action();
+  };
+
+  const handleImageOption = (action: () => void) => {
+    if (!isVisionModel) {
+      Toast.show({
+        type: 'defaultToast',
+        text1: 'This model does not support images',
+      });
+      return;
+    }
+    handleOption(action);
   };
 
   return (
@@ -86,26 +104,24 @@ const AttachmentSheet = ({
       handleIndicatorStyle={{ backgroundColor: theme.border.soft }}
     >
       <BottomSheetView style={styles.container}>
-        {isVisionModel && (
-          <>
-            <AttachmentOption
-              icon={CameraIcon}
-              iconColor={theme.text.primary}
-              label="Camera"
-              onPress={() => handleOption(onPickFromCamera)}
-              testID="attachment-camera"
-              styles={styles}
-            />
-            <AttachmentOption
-              icon={ImageIcon}
-              iconColor={theme.text.primary}
-              label="Photo Library"
-              onPress={() => handleOption(onPickFromLibrary)}
-              testID="attachment-library"
-              styles={styles}
-            />
-          </>
-        )}
+        <AttachmentOption
+          icon={CameraIcon}
+          iconColor={theme.text.primary}
+          label="Camera"
+          onPress={() => handleImageOption(onPickFromCamera)}
+          testID="attachment-camera"
+          styles={styles}
+          disabled={!isVisionModel}
+        />
+        <AttachmentOption
+          icon={ImageIcon}
+          iconColor={theme.text.primary}
+          label="Photo Library"
+          onPress={() => handleImageOption(onPickFromLibrary)}
+          testID="attachment-library"
+          styles={styles}
+          disabled={!isVisionModel}
+        />
         <AttachmentOption
           icon={AttachmentIcon}
           iconColor={theme.text.primary}
@@ -136,6 +152,9 @@ const createStyles = (theme: Theme) =>
       paddingHorizontal: 8,
       gap: 16,
       borderRadius: 12,
+    },
+    optionDisabled: {
+      opacity: 0.4,
     },
     iconWrapper: {
       width: 44,


### PR DESCRIPTION
## Objective
Improves UX by keeping "Camera" and "Photo Library" options visible but disabled for non-vision models, rather than hiding them entirely. Resolves #247.

## Changes
* **Visible but disabled:** Image options are always rendered. For non-vision models, they are greyed out (`opacity: 0.4`).
* **Toast notification:** Tapping a disabled image option prevents the picker from opening and shows a toast: *"This model does not support images"*.
* **Consistency:** Matches the disabled state UX of the "Think" toggle. Document attachments remain fully enabled.