### PR TITLE
fix(chat): coalesce streaming token updates via requestAnimationFrame

### DIFF
--- a/__tests__/llmStore.test.ts
+++ b/__tests__/llmStore.test.ts
@@ -88,7 +88,8 @@ beforeEach(() => {
   );
 });
 
-afterEach(() => {
+afterEach(async () => {
+  await flushFrame();
   jest.restoreAllMocks();
 });
 
@@ -98,8 +99,6 @@ const loadModel = async (model = baseModel) => {
   return capturedTokenCallback!;
 };
 
-// Streaming token appends are coalesced and applied on the next animation
-// frame, so tests that assert the flushed store state await one frame.
 const flushFrame = () =>
   new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
@@ -175,9 +174,12 @@ describe('token callback', () => {
     useLLMStore.setState({ isProcessingPrompt: true, isGenerating: true });
 
     onToken('first');
+    await flushFrame();
     const firstTime = useLLMStore.getState().performance.firstTokenTime;
+    expect(firstTime).toBeGreaterThan(0);
 
     onToken('second');
+    await flushFrame();
     expect(useLLMStore.getState().performance.firstTokenTime).toBe(firstTime);
   });
 
@@ -630,5 +632,23 @@ describe('runBenchmark', () => {
 
     expect(useLLMStore.getState().isGenerating).toBe(false);
     expect(useLLMStore.getState().isBenchmarking).toBe(false);
+  });
+
+  it('tracks a fresh first token on every run without stale carry-over', async () => {
+    await loadModel();
+    useLLMStore.setState({ model: baseModel });
+
+    mockInstance.generate.mockImplementation(async () => {
+      await flushFrame();
+      capturedTokenCallback!('tok');
+      await flushFrame();
+      return 'out';
+    });
+
+    const first = await useLLMStore.getState().runBenchmark();
+    const second = await useLLMStore.getState().runBenchmark();
+
+    expect(first?.timeToFirstToken).toBeGreaterThan(0);
+    expect(second?.timeToFirstToken).toBeGreaterThan(0);
   });
 });

--- a/__tests__/llmStore.test.ts
+++ b/__tests__/llmStore.test.ts
@@ -98,6 +98,11 @@ const loadModel = async (model = baseModel) => {
   return capturedTokenCallback!;
 };
 
+// Streaming token appends are coalesced and applied on the next animation
+// frame, so tests that assert the flushed store state await one frame.
+const flushFrame = () =>
+  new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
 // ─── loadModel ───────────────────────────────────────────────────────────────
 
 describe('loadModel', () => {
@@ -160,6 +165,7 @@ describe('token callback', () => {
 
     onToken('hello');
     onToken(' world');
+    await flushFrame();
 
     expect(useLLMStore.getState().performance.tokenCount).toBe(2);
   });
@@ -208,7 +214,7 @@ describe('token callback', () => {
       isGenerating: true,
       activeChatId: 5,
       generatingForChatId: 5,
-      performance: { tokenCount: 1, firstTokenTime: 1 }, // not first token
+      performance: { tokenCount: 1, firstTokenTime: 1 },
       activeChatMessages: [
         { id: 1, chatId: 5, role: 'user', content: 'Hi', timestamp: 0 },
         { id: -1, chatId: 5, role: 'assistant', content: '', timestamp: 0 },
@@ -216,6 +222,7 @@ describe('token callback', () => {
     });
 
     onToken(' hello');
+    await flushFrame();
 
     const messages = useLLMStore.getState().activeChatMessages;
     expect(messages[messages.length - 1].content).toBe(' hello');

--- a/store/llmStore.ts
+++ b/store/llmStore.ts
@@ -51,13 +51,6 @@ interface LLMStore {
 
 let llmInstance: LLMModule | null = null;
 
-// Streaming token coalescing. The executorch token callback can fire many times
-// in a single synchronous tick (notably while replaying the prompt during
-// prefill). Appending to the store on every token then schedules one React
-// update per token; a burst of them in one tick trips "Maximum update depth
-// exceeded". Instead we accumulate tokens here and flush the visible append at
-// most once per animation frame. The authoritative full text is still written
-// on generation 'complete', so a dropped/late flush never loses content.
 let streamBuffer = '';
 let streamTokenCount = 0;
 let streamFirstTokenTime = 0;
@@ -155,8 +148,6 @@ const updateChatStateForGeneration = (
       });
       break;
     case 'complete':
-      // The full response is written below; drop any buffered tail so a pending
-      // flush can't append it on top of the final content.
       streamBuffer = '';
       if (
         data?.timeToFirstToken !== undefined &&
@@ -297,13 +288,9 @@ export const useLLMStore = create<LLMStore>((set, get) => ({
       llmInstance = null;
     }
 
-    // A fresh model instance has no in-flight stream — drop any buffered tokens.
     resetStreamState();
     set({ isLoading: true, model: model });
 
-    // Append the tokens buffered since the last frame to the streaming message
-    // in a single store update, collapsing a burst of token callbacks into one
-    // React render.
     const flushStream = () => {
       streamFlushScheduled = false;
       if (!streamBuffer) return;
@@ -341,10 +328,6 @@ export const useLLMStore = create<LLMStore>((set, get) => ({
         },
         () => {},
         (token) => {
-          // First-token bookkeeping stays synchronous and per-token (it is
-          // cheap and never touches the message list). `streamTokenCount` is the
-          // authoritative in-flight counter — the store's tokenCount only
-          // updates on flush, so it can't be used to detect the first token.
           const isFirstToken = streamTokenCount === 0;
 
           if (isFirstToken && !get().isBenchmarking) {
@@ -363,8 +346,6 @@ export const useLLMStore = create<LLMStore>((set, get) => ({
             streamFirstTokenTime = performance.now();
           }
 
-          // Buffer the visible content and coalesce appends to one flush per
-          // frame, so a synchronous burst of tokens becomes a single render.
           streamTokenCount += 1;
           streamBuffer += token;
           if (!streamFlushScheduled) {
@@ -502,6 +483,7 @@ export const useLLMStore = create<LLMStore>((set, get) => ({
     });
 
     try {
+      resetStreamState();
       set({
         isGenerating: true,
         performance: { tokenCount: 0, firstTokenTime: 0 },

--- a/store/llmStore.ts
+++ b/store/llmStore.ts
@@ -51,6 +51,25 @@ interface LLMStore {
 
 let llmInstance: LLMModule | null = null;
 
+// Streaming token coalescing. The executorch token callback can fire many times
+// in a single synchronous tick (notably while replaying the prompt during
+// prefill). Appending to the store on every token then schedules one React
+// update per token; a burst of them in one tick trips "Maximum update depth
+// exceeded". Instead we accumulate tokens here and flush the visible append at
+// most once per animation frame. The authoritative full text is still written
+// on generation 'complete', so a dropped/late flush never loses content.
+let streamBuffer = '';
+let streamTokenCount = 0;
+let streamFirstTokenTime = 0;
+let streamFlushScheduled = false;
+
+const resetStreamState = () => {
+  streamBuffer = '';
+  streamTokenCount = 0;
+  streamFirstTokenTime = 0;
+  streamFlushScheduled = false;
+};
+
 const calculatePerformanceMetrics = (
   startTime: number,
   endTime: number,
@@ -126,6 +145,7 @@ const updateChatStateForGeneration = (
       });
       break;
     case 'generating':
+      resetStreamState();
       set({
         isGenerating: true,
         performance: {
@@ -135,6 +155,9 @@ const updateChatStateForGeneration = (
       });
       break;
     case 'complete':
+      // The full response is written below; drop any buffered tail so a pending
+      // flush can't append it on top of the final content.
+      streamBuffer = '';
       if (
         data?.timeToFirstToken !== undefined &&
         data?.tokensPerSecond !== undefined
@@ -162,6 +185,7 @@ const updateChatStateForGeneration = (
       }
       break;
     case 'failed':
+      streamBuffer = '';
       // Drop the empty assistant placeholder left behind when generation
       // failed, was interrupted before any tokens, or produced no response.
       set((state) => {
@@ -273,7 +297,36 @@ export const useLLMStore = create<LLMStore>((set, get) => ({
       llmInstance = null;
     }
 
+    // A fresh model instance has no in-flight stream — drop any buffered tokens.
+    resetStreamState();
     set({ isLoading: true, model: model });
+
+    // Append the tokens buffered since the last frame to the streaming message
+    // in a single store update, collapsing a burst of token callbacks into one
+    // React render.
+    const flushStream = () => {
+      streamFlushScheduled = false;
+      if (!streamBuffer) return;
+      const text = streamBuffer;
+      streamBuffer = '';
+      const snapshot = get();
+      const shouldAppendToActiveChat =
+        snapshot.generatingForChatId === snapshot.activeChatId;
+      set((state) => ({
+        isProcessingPrompt: false,
+        performance: {
+          tokenCount: streamTokenCount,
+          firstTokenTime: streamFirstTokenTime,
+        },
+        activeChatMessages: shouldAppendToActiveChat
+          ? state.activeChatMessages.map((msg, index) =>
+              index === state.activeChatMessages.length - 1
+                ? { ...msg, content: msg.content + text }
+                : msg
+            )
+          : state.activeChatMessages,
+      }));
+    };
 
     try {
       llmInstance = await LLMModule.fromModelName(
@@ -288,47 +341,36 @@ export const useLLMStore = create<LLMStore>((set, get) => ({
         },
         () => {},
         (token) => {
-          const snapshot = get();
-          const isFirstToken = snapshot.performance.tokenCount === 0;
+          // First-token bookkeeping stays synchronous and per-token (it is
+          // cheap and never touches the message list). `streamTokenCount` is the
+          // authoritative in-flight counter — the store's tokenCount only
+          // updates on flush, so it can't be used to detect the first token.
+          const isFirstToken = streamTokenCount === 0;
 
-          if (isFirstToken && !snapshot.isBenchmarking) {
+          if (isFirstToken && !get().isBenchmarking) {
             Feedback.firstToken();
           }
 
           /* Temporary solution to handle interrupt during prefill, needs to be fixed in the
           react-native-executorch library
           */
-          if (
-            isFirstToken &&
-            !snapshot.isProcessingPrompt &&
-            !snapshot.isGenerating
-          ) {
-            llmInstance?.interrupt();
-            return;
+          if (isFirstToken) {
+            const snapshot = get();
+            if (!snapshot.isProcessingPrompt && !snapshot.isGenerating) {
+              llmInstance?.interrupt();
+              return;
+            }
+            streamFirstTokenTime = performance.now();
           }
 
-          const shouldAppendToActiveChat =
-            snapshot.generatingForChatId === snapshot.activeChatId;
-          const firstTokenTime = isFirstToken
-            ? performance.now()
-            : snapshot.performance.firstTokenTime;
-
-          // Use functional set so tokenCount increments relative to the
-          // latest state, not the captured snapshot.
-          set((state) => ({
-            isProcessingPrompt: false,
-            performance: {
-              tokenCount: state.performance.tokenCount + 1,
-              firstTokenTime,
-            },
-            activeChatMessages: shouldAppendToActiveChat
-              ? state.activeChatMessages.map((msg, index) =>
-                  index === state.activeChatMessages.length - 1
-                    ? { ...msg, content: msg.content + token }
-                    : msg
-                )
-              : state.activeChatMessages,
-          }));
+          // Buffer the visible content and coalesce appends to one flush per
+          // frame, so a synchronous burst of tokens becomes a single render.
+          streamTokenCount += 1;
+          streamBuffer += token;
+          if (!streamFlushScheduled) {
+            streamFlushScheduled = true;
+            requestAnimationFrame(flushStream);
+          }
         }
       );
 


### PR DESCRIPTION
The executorch token callback can fire many times in a single synchronous tick (notably while replaying the prompt during prefill). Appending to the store on every token scheduled one React update per token, and a burst in a single tick tripped "Maximum update depth exceeded", aborting the response.

Buffer tokens at module scope and flush the visible append at most once per animation frame, collapsing a burst into a single render. First-token bookkeeping (haptics, prefill-interrupt, firstTokenTime) stays synchronous via an in-flight counter; the buffer is reset on generation start / model load and cleared on complete/failed so a late flush can't duplicate the authoritative final text.