### PR TITLE
Fix/scroll down button overlaps multiline input

### DIFF
--- a/__mocks__/react-native-reanimated.ts
+++ b/__mocks__/react-native-reanimated.ts
@@ -32,6 +32,19 @@ const Animated = {
   createAnimatedComponent,
 };
 
+type AnimationBuilder = Record<
+  string,
+  (...args: unknown[]) => AnimationBuilder
+>;
+
+const makeAnimationBuilder = (): AnimationBuilder => {
+  const builder = new Proxy(
+    {},
+    { get: () => () => builder }
+  ) as AnimationBuilder;
+  return builder;
+};
+
 module.exports = {
   __esModule: true,
   default: Animated,
@@ -73,4 +86,9 @@ module.exports = {
   interpolateColor: (val: any, _r: any, outputRange: any) => outputRange[0],
   runOnJS: (fn: any) => fn,
   runOnUI: (fn: any) => fn,
+  configureReanimatedLogger: () => {},
+  LinearTransition: makeAnimationBuilder(),
+  FadeIn: makeAnimationBuilder(),
+  FadeInDown: makeAnimationBuilder(),
+  FadeOut: makeAnimationBuilder(),
 };

--- a/components/chat-screen/ChatBar.tsx
+++ b/components/chat-screen/ChatBar.tsx
@@ -385,7 +385,9 @@ const createStyles = (theme: Theme) =>
       fontSize: fontSizes.md,
       // lineHeight on Android causes typed text to be taller than the
       // placeholder, making the ChatBar jump on first keystroke.
-      ...(Platform.OS === 'ios' && { lineHeight: lineHeights.md }),
+      ...(Platform.OS === 'ios'
+        ? { lineHeight: lineHeights.md }
+        : { includeFontPadding: false }),
       fontFamily: fontFamily.regular,
       textAlignVertical: 'center',
       color: theme.text.onChatBar,

--- a/components/chat-screen/ChatBar.tsx
+++ b/components/chat-screen/ChatBar.tsx
@@ -94,6 +94,7 @@ const ChatBar = ({
   } = useAttachment();
 
   const defaultBarHeight = useRef(0);
+  const prevBarHeight = useRef(0);
   const textInputRef = useRef<RNTextInput>(null);
   // iOS-only: bump the TextInput key to force a remount when a prompt
   // suggestion is set programmatically. iOS doesn't re-fire onLayout
@@ -138,7 +139,9 @@ const ChatBar = ({
       const delta = height - baseline;
       extraContentPadding.value = Math.max(0, delta);
       onHeightChange?.(height);
-      if (delta > 0) {
+      const grew = height > prevBarHeight.current;
+      prevBarHeight.current = height;
+      if (delta > 0 && grew) {
         onBarGrow?.();
       }
     },

--- a/components/chat-screen/ChatBar.tsx
+++ b/components/chat-screen/ChatBar.tsx
@@ -15,7 +15,12 @@ import {
   Keyboard,
   Platform,
 } from 'react-native';
-import type { SharedValue } from 'react-native-reanimated';
+import Animated, {
+  Easing,
+  LinearTransition,
+  withTiming,
+  type SharedValue,
+} from 'react-native-reanimated';
 import { type PasteEventPayload, TextInputWrapper } from 'expo-paste-input';
 import AttachmentSheet from '../bottomSheets/AttachmentSheet';
 import { useAttachment, Attachment } from '../../hooks/useAttachment';
@@ -32,6 +37,11 @@ import WhatsNewCard from '../WhatsNewCard';
 import AttachmentThumbnail from './AttachmentThumbnail';
 import { AudioManager } from 'react-native-audio-api';
 import Toast from 'react-native-toast-message';
+
+const BAR_GROW_DURATION = 200;
+const BAR_GROW_EASING = Easing.out(Easing.ease);
+const BAR_GROW_LAYOUT =
+  LinearTransition.duration(BAR_GROW_DURATION).easing(BAR_GROW_EASING);
 
 interface Props {
   chatId: number | null;
@@ -137,7 +147,10 @@ const ChatBar = ({
       }
       const baseline = defaultBarHeight.current || height;
       const delta = height - baseline;
-      extraContentPadding.value = Math.max(0, delta);
+      extraContentPadding.value = withTiming(Math.max(0, delta), {
+        duration: BAR_GROW_DURATION,
+        easing: BAR_GROW_EASING,
+      });
       onHeightChange?.(height);
       const grew = height > prevBarHeight.current;
       prevBarHeight.current = height;
@@ -269,7 +282,11 @@ const ChatBar = ({
   }
 
   return (
-    <View style={containerStyle} onLayout={handleBarLayoutForPadding}>
+    <Animated.View
+      style={containerStyle}
+      onLayout={handleBarLayoutForPadding}
+      layout={BAR_GROW_LAYOUT}
+    >
       {model?.isDownloaded && (
         <>
           {!hasMessages && (
@@ -333,7 +350,7 @@ const ChatBar = ({
           />
         </>
       )}
-    </View>
+    </Animated.View>
   );
 };
 

--- a/components/chat-screen/ChatScreen.tsx
+++ b/components/chat-screen/ChatScreen.tsx
@@ -8,7 +8,7 @@ import React, {
 import { Keyboard, StyleSheet, useWindowDimensions, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
-import { KeyboardStickyView } from 'react-native-keyboard-controller';
+import { useReanimatedKeyboardAnimation } from 'react-native-keyboard-controller';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
@@ -109,11 +109,19 @@ export default function ChatScreen({
   const { theme } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
-  const stickyOffset = useMemo(
-    () => ({ closed: 0, opened: theme.insets.bottom }),
-    [theme.insets.bottom]
-  );
   const scrollBottomOffset = theme.insets.bottom;
+
+  const { height: keyboardHeight, progress: keyboardProgress } =
+    useReanimatedKeyboardAnimation();
+  const insetsBottom = theme.insets.bottom;
+  const chatBarStickyStyle = useAnimatedStyle(() => ({
+    transform: [
+      {
+        translateY:
+          keyboardHeight.value + keyboardProgress.value * insetsBottom,
+      },
+    ],
+  }));
 
   const { settings: chatSettings, setSetting } = useChatSettings(chatId);
 
@@ -349,7 +357,7 @@ export default function ChatScreen({
           chatBarSpacerHeight > 0 && { height: chatBarSpacerHeight },
         ]}
       >
-        <KeyboardStickyView offset={stickyOffset} style={styles.chatBarSticky}>
+        <Animated.View style={[styles.chatBarSticky, chatBarStickyStyle]}>
           <ChatBar
             chatId={chatId}
             onSend={handleSendMessage}
@@ -375,7 +383,7 @@ export default function ChatScreen({
               }, 100);
             }}
           />
-        </KeyboardStickyView>
+        </Animated.View>
       </View>
 
       <ModelSelectSheet

--- a/components/chat-screen/ChatScreen.tsx
+++ b/components/chat-screen/ChatScreen.tsx
@@ -379,7 +379,7 @@ export default function ChatScreen({
             }}
             onBarGrow={() => {
               setTimeout(() => {
-                messagesRef.current?.scrollToEnd();
+                messagesRef.current?.scrollToEndIfAtBottom();
               }, 100);
             }}
           />

--- a/components/chat-screen/Messages.tsx
+++ b/components/chat-screen/Messages.tsx
@@ -17,7 +17,10 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { KeyboardChatScrollView } from 'react-native-keyboard-controller';
+import {
+  KeyboardChatScrollView,
+  useReanimatedKeyboardAnimation,
+} from 'react-native-keyboard-controller';
 import Reanimated, {
   useSharedValue,
   useAnimatedStyle,
@@ -81,6 +84,20 @@ const Messages = ({
   const hasScrolledToEnd = useRef(false);
   const animatedContainerStyle = useAnimatedStyle(() => ({
     opacity: opacity.value,
+  }));
+
+  const { height: keyboardHeight, progress: keyboardProgress } =
+    useReanimatedKeyboardAnimation();
+  const insetsBottom = theme.insets.bottom;
+  const scrollButtonAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      {
+        translateY:
+          -extraContentPadding.value +
+          keyboardHeight.value +
+          keyboardProgress.value * insetsBottom,
+      },
+    ],
   }));
 
   // Re-arm the initial scroll when the chat history is cleared (e.g.
@@ -376,17 +393,24 @@ const Messages = ({
       </KeyboardChatScrollView>
 
       {showScrollButton && (
-        <TouchableOpacity
-          style={styles.scrollToBottomButton}
-          onPress={scrollToBottom}
-          activeOpacity={0.8}
+        <Reanimated.View
+          style={[
+            styles.scrollToBottomButtonContainer,
+            scrollButtonAnimatedStyle,
+          ]}
         >
-          <ChevronDown
-            width={20}
-            height={20}
-            style={{ color: theme.text.primary }}
-          />
-        </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.scrollToBottomButton}
+            onPress={scrollToBottom}
+            activeOpacity={0.8}
+          >
+            <ChevronDown
+              width={20}
+              height={20}
+              style={{ color: theme.text.primary }}
+            />
+          </TouchableOpacity>
+        </Reanimated.View>
       )}
     </Reanimated.View>
   );
@@ -405,10 +429,12 @@ const createStyles = (theme: Theme) =>
       paddingTop: 16,
       paddingBottom: 8,
     },
-    scrollToBottomButton: {
+    scrollToBottomButtonContainer: {
       position: 'absolute',
       bottom: 16,
       right: 16,
+    },
+    scrollToBottomButton: {
       width: 36,
       height: 36,
       borderRadius: 18,

--- a/components/chat-screen/Messages.tsx
+++ b/components/chat-screen/Messages.tsx
@@ -36,6 +36,7 @@ import ChevronDown from '../../assets/icons/chevron-down.svg';
 export interface MessagesHandle {
   onMessageSent: () => void;
   scrollToEnd: () => void;
+  scrollToEndIfAtBottom: () => void;
 }
 
 interface Props {
@@ -182,6 +183,11 @@ const Messages = ({
     () => ({
       scrollToEnd: () => {
         scrollRef.current?.scrollToEnd({ animated: true });
+      },
+      scrollToEndIfAtBottom: () => {
+        if (isAtBottomRef.current) {
+          scrollRef.current?.scrollToEnd({ animated: true });
+        }
       },
       onMessageSent: () => {
         // Ensure the view is visible (covers new-chat case where the


### PR DESCRIPTION
Fixes a set of chat input / scroll-to-bottom button issues and adds a smooth grow/shrink animation. Four self-contained commits:

- **Button positioning & keyboard sync** — the scroll-to-bottom button no longer slides under the input once it grows to 2–3 lines, or under the keyboard when it opens. The ChatBar is now driven by the same Reanimated keyboard values as the button (replacing `KeyboardStickyView`), so the bar and button animate frame-locked on one runtime instead of drifting apart.
- **No auto-scroll on resize** — adding or removing a line no longer forces the conversation to jump to the bottom; it only follows the latest message when the user is already at the bottom.
- **Android input height stability** — disables `includeFontPadding` on Android so the placeholder and the first typed character measure the same, removing a 1px jump on the first keystroke (iOS was already stable via `lineHeight`).
- **Smooth line grow/shrink** — the input now animates smoothly when it grows/shrinks between 1–3 lines (`LinearTransition` on the bar + a matching `withTiming` on the scroll content padding), keeping the bar, scroll content, and button in sync.