### PR TITLE
feat(chat): fade messages into the background at the list edges

### DIFF
--- a/__tests__/useKeyboardLift.test.ts
+++ b/__tests__/useKeyboardLift.test.ts
@@ -1,0 +1,71 @@
+import { renderHook } from '@testing-library/react-native';
+import { useReanimatedKeyboardAnimation } from 'react-native-keyboard-controller';
+import { useKeyboardLift } from '../components/chat-screen/useKeyboardLift';
+
+let mockInsetsBottom = 0;
+
+jest.mock('../context/ThemeContext', () => ({
+  useTheme: () => ({
+    theme: {
+      insets: { top: 0, bottom: mockInsetsBottom, left: 0, right: 0 },
+    },
+  }),
+}));
+
+const { height, progress } = useReanimatedKeyboardAnimation();
+
+describe('useKeyboardLift', () => {
+  beforeEach(() => {
+    height.value = 0;
+    progress.value = 0;
+    mockInsetsBottom = 0;
+  });
+
+  it('returns 0 when the keyboard is closed', () => {
+    const { result } = renderHook(() => useKeyboardLift());
+
+    expect(result.current.value).toBe(0);
+  });
+
+  it('gives back the bottom inset the open keyboard swallows', () => {
+    mockInsetsBottom = 34;
+    height.value = -346;
+    progress.value = 1;
+
+    const { result } = renderHook(() => useKeyboardLift());
+
+    expect(result.current.value).toBe(-312);
+  });
+
+  it('scales the inset compensation with keyboard progress', () => {
+    mockInsetsBottom = 34;
+    height.value = -173;
+    progress.value = 0.5;
+
+    const { result } = renderHook(() => useKeyboardLift());
+
+    expect(result.current.value).toBe(-156);
+  });
+
+  it('equals the raw keyboard height on a device without a bottom inset', () => {
+    height.value = -300;
+    progress.value = 1;
+
+    const { result } = renderHook(() => useKeyboardLift());
+
+    expect(result.current.value).toBe(-300);
+  });
+
+  it('recomputes after the keyboard values change', () => {
+    mockInsetsBottom = 34;
+    const { result, rerender } = renderHook(() => useKeyboardLift());
+
+    expect(result.current.value).toBe(0);
+
+    height.value = -346;
+    progress.value = 1;
+    rerender({});
+
+    expect(result.current.value).toBe(-312);
+  });
+});

--- a/__tests__/useKeyboardLift.test.ts
+++ b/__tests__/useKeyboardLift.test.ts
@@ -1,8 +1,9 @@
 import { renderHook } from '@testing-library/react-native';
-import { useReanimatedKeyboardAnimation } from 'react-native-keyboard-controller';
 import { useKeyboardLift } from '../components/chat-screen/useKeyboardLift';
 
 let mockInsetsBottom = 0;
+const mockHeight = { value: 0 };
+const mockProgress = { value: 0 };
 
 jest.mock('../context/ThemeContext', () => ({
   useTheme: () => ({
@@ -12,12 +13,17 @@ jest.mock('../context/ThemeContext', () => ({
   }),
 }));
 
-const { height, progress } = useReanimatedKeyboardAnimation();
+jest.mock('react-native-keyboard-controller', () => ({
+  useReanimatedKeyboardAnimation: () => ({
+    height: mockHeight,
+    progress: mockProgress,
+  }),
+}));
 
 describe('useKeyboardLift', () => {
   beforeEach(() => {
-    height.value = 0;
-    progress.value = 0;
+    mockHeight.value = 0;
+    mockProgress.value = 0;
     mockInsetsBottom = 0;
   });
 
@@ -29,8 +35,8 @@ describe('useKeyboardLift', () => {
 
   it('gives back the bottom inset the open keyboard swallows', () => {
     mockInsetsBottom = 34;
-    height.value = -346;
-    progress.value = 1;
+    mockHeight.value = -346;
+    mockProgress.value = 1;
 
     const { result } = renderHook(() => useKeyboardLift());
 
@@ -39,8 +45,8 @@ describe('useKeyboardLift', () => {
 
   it('scales the inset compensation with keyboard progress', () => {
     mockInsetsBottom = 34;
-    height.value = -173;
-    progress.value = 0.5;
+    mockHeight.value = -173;
+    mockProgress.value = 0.5;
 
     const { result } = renderHook(() => useKeyboardLift());
 
@@ -48,8 +54,8 @@ describe('useKeyboardLift', () => {
   });
 
   it('equals the raw keyboard height on a device without a bottom inset', () => {
-    height.value = -300;
-    progress.value = 1;
+    mockHeight.value = -300;
+    mockProgress.value = 1;
 
     const { result } = renderHook(() => useKeyboardLift());
 
@@ -62,8 +68,8 @@ describe('useKeyboardLift', () => {
 
     expect(result.current.value).toBe(0);
 
-    height.value = -346;
-    progress.value = 1;
+    mockHeight.value = -346;
+    mockProgress.value = 1;
     rerender({});
 
     expect(result.current.value).toBe(-312);

--- a/app/(drawer)/_layout.tsx
+++ b/app/(drawer)/_layout.tsx
@@ -55,7 +55,13 @@ const DrawerLayout = () => {
           title: 'Benchmark',
         }}
       />
-      <Drawer.Screen name="chat/[id]" />
+      <Drawer.Screen
+        name="chat/[id]"
+        options={{
+          headerTransparent: true,
+          headerStyle: { backgroundColor: 'transparent' },
+        }}
+      />
     </Drawer>
   );
 };

--- a/app/(drawer)/chat/[id].tsx
+++ b/app/(drawer)/chat/[id].tsx
@@ -58,14 +58,13 @@ function ChatScreenInner() {
   const isEmpty = !isLoading && activeChatMessages.length === 0;
   const shouldExitOnBack = isPhantom && isEmpty;
   const openModelSheetRef = useRef<(() => void) | null>(null);
+  const openModelSheet = useCallback(() => openModelSheetRef.current?.(), []);
 
-  const { MenuElements } = useChatHeader({
+  const { MenuElements, titleBottom } = useChatHeader({
     chatId: chatId,
     chatModel: model,
     isEmpty,
-    onSelectModelFromTitle: isPhantom
-      ? () => openModelSheetRef.current?.()
-      : undefined,
+    onSelectModelFromTitle: isPhantom ? openModelSheet : undefined,
   });
 
   useFocusEffect(
@@ -141,6 +140,7 @@ function ChatScreenInner() {
         selectModel={handleSetModel}
         openModelSheetRef={openModelSheetRef}
         revealFromTop={shouldPlayBranchEntryAnimation}
+        headerTitleBottom={titleBottom}
       />
       {MenuElements}
     </>

--- a/components/chat-screen/ChatBar.tsx
+++ b/components/chat-screen/ChatBar.tsx
@@ -105,6 +105,11 @@ const ChatBar = ({
 
   const defaultBarHeight = useRef(0);
   const prevBarHeight = useRef(0);
+
+  // Inset the baseline was captured with. Checked in the layout handler, not
+  // an effect: onLayout fires first, so an effect-driven reset would lose the
+  // pass carrying the new height.
+  const baselineInset = useRef<number | null>(null);
   const textInputRef = useRef<RNTextInput>(null);
   // iOS-only: bump the TextInput key to force a remount when a prompt
   // suggestion is set programmatically. iOS doesn't re-fire onLayout
@@ -138,12 +143,19 @@ const ChatBar = ({
   const handleBarLayoutForPadding = useCallback(
     (e: { nativeEvent: { layout: { height: number } } }) => {
       const height = e.nativeEvent.layout.height;
+      const inset = theme.insets.bottom;
       // Only capture the default height once we're in the "with messages"
       // layout — otherwise the empty-state extras (WhatsNewCard, prompt
       // suggestions) would bake into the baseline and squeeze the scroll
-      // view once they disappear.
-      if (defaultBarHeight.current === 0 && hasMessages) {
+      // view once they disappear. Re-capture on inset changes (Android
+      // navigation mode, rotation), or the stale baseline reads the difference
+      // as "the bar grew".
+      if (
+        hasMessages &&
+        (defaultBarHeight.current === 0 || baselineInset.current !== inset)
+      ) {
         defaultBarHeight.current = height;
+        baselineInset.current = inset;
       }
       const baseline = defaultBarHeight.current || height;
       const delta = height - baseline;
@@ -153,14 +165,22 @@ const ChatBar = ({
           easing: BAR_GROW_EASING,
         })
       );
-      onHeightChange?.(height);
+      // Baseline, not live height — consumers must not follow the bar as it
+      // grows with typed lines; that is what extraContentPadding is for.
+      onHeightChange?.(baseline);
       const grew = height > prevBarHeight.current;
       prevBarHeight.current = height;
       if (delta > 0 && grew) {
         onBarGrow?.();
       }
     },
-    [extraContentPadding, onHeightChange, onBarGrow, hasMessages]
+    [
+      extraContentPadding,
+      onHeightChange,
+      onBarGrow,
+      hasMessages,
+      theme.insets.bottom,
+    ]
   );
 
   const {

--- a/components/chat-screen/ChatScreen.tsx
+++ b/components/chat-screen/ChatScreen.tsx
@@ -373,8 +373,6 @@ export default function ChatScreen({
         chatBarInset={chatBarHeight}
       />
 
-      {/* Overlays the list instead of taking layout space, so messages scroll
-          underneath it and dissolve into the bottom fade. */}
       <Animated.View style={[styles.chatBarSticky, chatBarStickyStyle]}>
         <ChatBar
           chatId={chatId}

--- a/components/chat-screen/ChatScreen.tsx
+++ b/components/chat-screen/ChatScreen.tsx
@@ -133,7 +133,20 @@ export default function ChatScreen({
   // Shared values for KeyboardChatScrollView
   const extraContentPadding = useSharedValue(0);
   const blankSpace = useSharedValue(0);
-  const [chatBarSpacerHeight, setChatBarSpacerHeight] = useState(0);
+  const [chatBarHeight, setChatBarHeight] = useState(0);
+
+  const hasMessages = isLoading || messageHistory.length > 0;
+  const handleChatBarHeightChange = useCallback(
+    (h: number) => {
+      if (hasMessages) setChatBarHeight(h);
+    },
+    [hasMessages]
+  );
+  const handleBarGrow = useCallback(() => {
+    setTimeout(() => {
+      messagesRef.current?.scrollToEndIfAtBottom();
+    }, 100);
+  }, []);
 
   // Freeze the scroll view's layout whenever any overlay (model picker,
   // attachment sheet) is presented so keyboard dismiss → sheet open doesn't
@@ -357,42 +370,29 @@ export default function ChatScreen({
         isGenerating={isGenerating}
         bottomOffset={scrollBottomOffset}
         freeze={overlayOpen}
+        chatBarInset={chatBarHeight}
       />
 
-      <View
-        style={[
-          styles.chatBarSpacer,
-          chatBarSpacerHeight > 0 && { height: chatBarSpacerHeight },
-        ]}
-      >
-        <Animated.View style={[styles.chatBarSticky, chatBarStickyStyle]}>
-          <ChatBar
-            chatId={chatId}
-            onSend={handleSendMessage}
-            onSelectModel={handlePresentModelSheet}
-            onSelectPrompt={handleSelectPrompt}
-            ref={inputRef}
-            model={model}
-            isVisionModel={model?.vision === true}
-            extraContentPadding={extraContentPadding}
-            thinkingEnabled={chatSettings?.thinkingEnabled || false}
-            onThinkingToggle={handleThinkingToggle}
-            hasMessages={isLoading || messageHistory.length > 0}
-            onAttachmentSheetStateChange={setAttachmentSheetOpen}
-            onHeightChange={(h: number) => {
-              const hasMessages = isLoading || messageHistory.length > 0;
-              if (chatBarSpacerHeight === 0 && hasMessages) {
-                setChatBarSpacerHeight(h);
-              }
-            }}
-            onBarGrow={() => {
-              setTimeout(() => {
-                messagesRef.current?.scrollToEndIfAtBottom();
-              }, 100);
-            }}
-          />
-        </Animated.View>
-      </View>
+      {/* Overlays the list instead of taking layout space, so messages scroll
+          underneath it and dissolve into the bottom fade. */}
+      <Animated.View style={[styles.chatBarSticky, chatBarStickyStyle]}>
+        <ChatBar
+          chatId={chatId}
+          onSend={handleSendMessage}
+          onSelectModel={handlePresentModelSheet}
+          onSelectPrompt={handleSelectPrompt}
+          ref={inputRef}
+          model={model}
+          isVisionModel={model?.vision === true}
+          extraContentPadding={extraContentPadding}
+          thinkingEnabled={chatSettings?.thinkingEnabled || false}
+          onThinkingToggle={handleThinkingToggle}
+          hasMessages={hasMessages}
+          onAttachmentSheetStateChange={setAttachmentSheetOpen}
+          onHeightChange={handleChatBarHeightChange}
+          onBarGrow={handleBarGrow}
+        />
+      </Animated.View>
 
       <ModelSelectSheet
         bottomSheetModalRef={modelBottomSheetModalRef}
@@ -408,9 +408,6 @@ const createStyles = (theme: Theme) =>
     container: {
       flex: 1,
       backgroundColor: theme.bg.softPrimary,
-    },
-    chatBarSpacer: {
-      overflow: 'visible',
     },
     chatBarSticky: {
       position: 'absolute',

--- a/components/chat-screen/ChatScreen.tsx
+++ b/components/chat-screen/ChatScreen.tsx
@@ -8,7 +8,8 @@ import React, {
 import { Keyboard, StyleSheet, useWindowDimensions, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
-import { useReanimatedKeyboardAnimation } from 'react-native-keyboard-controller';
+import { useHeaderHeight } from '@react-navigation/elements';
+import { useKeyboardLift } from './useKeyboardLift';
 import { router } from 'expo-router';
 import Animated, {
   useAnimatedStyle,
@@ -62,6 +63,7 @@ interface Props {
   selectModel?: (model: Model) => Promise<void>;
   openModelSheetRef?: React.MutableRefObject<(() => void) | null>;
   revealFromTop?: boolean;
+  headerTitleBottom?: number;
 }
 
 const prepareContext = async (
@@ -89,6 +91,7 @@ export default function ChatScreen({
   selectModel,
   openModelSheetRef,
   revealFromTop = false,
+  headerTitleBottom,
 }: Props) {
   const inputRef = useRef<{
     clear: () => void;
@@ -119,17 +122,11 @@ export default function ChatScreen({
 
   const { theme } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const headerHeight = useHeaderHeight();
 
-  const { height: keyboardHeight, progress: keyboardProgress } =
-    useReanimatedKeyboardAnimation();
-  const insetsBottom = theme.insets.bottom;
+  const keyboardLift = useKeyboardLift();
   const chatBarStickyStyle = useAnimatedStyle(() => ({
-    transform: [
-      {
-        translateY:
-          keyboardHeight.value + keyboardProgress.value * insetsBottom,
-      },
-    ],
+    transform: [{ translateY: keyboardLift.value }],
   }));
 
   const { settings: chatSettings, setSetting } = useChatSettings(chatId);
@@ -170,7 +167,9 @@ export default function ChatScreen({
 
   const handleRootLayout = useCallback(() => {
     rootRef.current?.measureInWindow((x, y) => {
-      setRootFrame({ x, y });
+      setRootFrame((current) =>
+        current.x === x && current.y === y ? current : { x, y }
+      );
     });
   }, []);
 
@@ -400,6 +399,11 @@ export default function ChatScreen({
     };
   }, [rootFrame.x, rootFrame.y, userActionMenu, windowWidth]);
 
+  const fadeBottom =
+    headerTitleBottom !== undefined
+      ? headerTitleBottom - rootFrame.y
+      : undefined;
+
   return (
     <View
       ref={rootRef}
@@ -431,6 +435,8 @@ export default function ChatScreen({
           onBranchMarkerPress={handleBranchMarkerPress}
           onUserActionMenuChange={setUserActionMenu}
           chatBarInset={chatBarHeight}
+          topInset={headerHeight}
+          fadeBottom={fadeBottom}
         />
       </View>
 

--- a/components/chat-screen/ChatTitle.tsx
+++ b/components/chat-screen/ChatTitle.tsx
@@ -1,5 +1,11 @@
-import React, { useMemo } from 'react';
-import { Text, StyleSheet, View, Pressable } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import {
+  Text,
+  StyleSheet,
+  View,
+  Pressable,
+  useWindowDimensions,
+} from 'react-native';
 import { useTheme } from '../../context/ThemeContext';
 import { fontFamily, fontSizes } from '../../styles/fontStyles';
 import { Theme } from '../../styles/colors';
@@ -10,6 +16,7 @@ interface Props {
   modelName: string;
   onPress?: () => void;
   showChevron?: boolean;
+  onBottomMeasured?: (bottomY: number) => void;
 }
 
 const ChatTitle = ({
@@ -17,11 +24,33 @@ const ChatTitle = ({
   modelName,
   onPress,
   showChevron = false,
+  onBottomMeasured,
 }: Props) => {
   const { theme } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const containerRef = useRef<View>(null);
+  const lastReportedBottom = useRef<number | null>(null);
+  const handleLayout = useCallback(() => {
+    containerRef.current?.measureInWindow((_x, y, _width, height) => {
+      const bottom = Math.round(y + height);
+      if (bottom !== lastReportedBottom.current) {
+        lastReportedBottom.current = bottom;
+        onBottomMeasured?.(bottom);
+      }
+    });
+  }, [onBottomMeasured]);
+
+  const { width: windowWidth, height: windowHeight } = useWindowDimensions();
+  useEffect(() => {
+    if (!onBottomMeasured) return;
+    const frame = requestAnimationFrame(handleLayout);
+    return () => cancelAnimationFrame(frame);
+  }, [handleLayout, onBottomMeasured, windowWidth, windowHeight]);
+
   return (
     <Pressable
+      ref={containerRef}
+      onLayout={onBottomMeasured ? handleLayout : undefined}
       onPress={onPress}
       disabled={!onPress}
       hitSlop={8}

--- a/components/chat-screen/EdgeFade.tsx
+++ b/components/chat-screen/EdgeFade.tsx
@@ -6,8 +6,9 @@ import { withAlpha } from '../../styles/colors';
 
 export const FADE_HEIGHT = 24;
 
-const LOCATIONS = [0, 0.25, 0.5, 0.75, 1] as const;
-const ALPHAS = [0, 0.156, 0.5, 0.844, 1] as const;
+const LOCATIONS: [number, number, ...number[]] = [0, 0.25, 0.5, 0.75, 1];
+const BOTTOM_ALPHAS = [0, 0.156, 0.5, 0.844, 1];
+const TOP_ALPHAS = [...BOTTOM_ALPHAS].reverse();
 
 interface Props {
   edge: 'top' | 'bottom';
@@ -18,14 +19,18 @@ export const EdgeFade = React.memo(({ edge, style }: Props) => {
   const { theme } = useTheme();
 
   const colors = useMemo(() => {
-    const ramp = edge === 'top' ? [...ALPHAS].reverse() : [...ALPHAS];
-    return ramp.map((alpha) => withAlpha(theme.bg.softPrimary, alpha));
+    const ramp = edge === 'top' ? TOP_ALPHAS : BOTTOM_ALPHAS;
+    return ramp.map((alpha) => withAlpha(theme.bg.softPrimary, alpha)) as [
+      string,
+      string,
+      ...string[],
+    ];
   }, [edge, theme.bg.softPrimary]);
 
   return (
     <LinearGradient
-      colors={colors as [string, string, ...string[]]}
-      locations={LOCATIONS as unknown as [number, number, ...number[]]}
+      colors={colors}
+      locations={LOCATIONS}
       style={style}
       pointerEvents="none"
     />

--- a/components/chat-screen/EdgeFade.tsx
+++ b/components/chat-screen/EdgeFade.tsx
@@ -1,0 +1,37 @@
+import React, { useMemo } from 'react';
+import { StyleProp, ViewStyle } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useTheme } from '../../context/ThemeContext';
+import { withAlpha } from '../../styles/colors';
+
+export const TOP_FADE_HEIGHT = 32;
+export const BOTTOM_FADE_RUNUP = 24;
+export const BOTTOM_FADE_SCALE = 0.5;
+
+const LOCATIONS = [0, 0.25, 0.5, 0.75, 1] as const;
+const ALPHAS = [0, 0.156, 0.5, 0.844, 1] as const;
+
+interface Props {
+  edge: 'top' | 'bottom';
+  style?: StyleProp<ViewStyle>;
+}
+
+export const EdgeFade = React.memo(({ edge, style }: Props) => {
+  const { theme } = useTheme();
+
+  const colors = useMemo(() => {
+    const ramp = edge === 'top' ? [...ALPHAS].reverse() : [...ALPHAS];
+    return ramp.map((alpha) => withAlpha(theme.bg.softPrimary, alpha));
+  }, [edge, theme.bg.softPrimary]);
+
+  return (
+    <LinearGradient
+      colors={colors as [string, string, ...string[]]}
+      locations={LOCATIONS as unknown as [number, number, ...number[]]}
+      style={style}
+      pointerEvents="none"
+    />
+  );
+});
+
+EdgeFade.displayName = 'EdgeFade';

--- a/components/chat-screen/EdgeFade.tsx
+++ b/components/chat-screen/EdgeFade.tsx
@@ -4,9 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../../context/ThemeContext';
 import { withAlpha } from '../../styles/colors';
 
-export const TOP_FADE_HEIGHT = 32;
-export const BOTTOM_FADE_RUNUP = 24;
-export const BOTTOM_FADE_SCALE = 0.5;
+export const FADE_HEIGHT = 24;
 
 const LOCATIONS = [0, 0.25, 0.5, 0.75, 1] as const;
 const ALPHAS = [0, 0.156, 0.5, 0.844, 1] as const;

--- a/components/chat-screen/Messages.tsx
+++ b/components/chat-screen/Messages.tsx
@@ -22,10 +22,7 @@ import {
 } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import {
-  KeyboardChatScrollView,
-  useReanimatedKeyboardAnimation,
-} from 'react-native-keyboard-controller';
+import { KeyboardChatScrollView } from 'react-native-keyboard-controller';
 import Reanimated, {
   runOnJS,
   useSharedValue,
@@ -43,6 +40,7 @@ import ChevronDown from '../../assets/icons/chevron-down.svg';
 import BranchMarker from './BranchMarker';
 import Toast from 'react-native-toast-message';
 import { SUPPORTS_USER_ACTION_MENU } from '../../constants/chat-screen';
+import { useKeyboardLift } from './useKeyboardLift';
 
 /**
  * Height of the opaque system navigation bar the list paints behind. Android
@@ -56,7 +54,9 @@ const BOTTOM_FADE_HEIGHT = Platform.OS === 'ios' ? 64 : FADE_HEIGHT;
 
 const SEAM_OVERLAP = 1;
 
-/** Right-edge gap so the fades don't paint over the scroll indicator. */
+const FADE_GAP_TRIM = 5;
+
+/** Right-edge gap so the bottom fade doesn't paint over the scroll indicator. */
 const SCROLL_INDICATOR_GUTTER = 12;
 
 export interface MessagesHandle {
@@ -102,6 +102,16 @@ interface Props {
    * message resting above it, and sizes the bottom fade.
    */
   chatBarInset: number;
+  /**
+   * Height of the transparent navigation header (incl. status bar) the list
+   * scrolls beneath.
+   */
+  topInset: number;
+  /**
+   * Bottom edge of the header's title block, in this component's coordinate
+   * space — the top fade's ramp begins there.
+   */
+  fadeBottom?: number;
   revealFromTop?: boolean;
   branchMarkers?: ChatBranchMarker[];
   onForkMessage?: (message: Message) => void;
@@ -156,6 +166,8 @@ const Messages = ({
   bottomOffset,
   freeze = false,
   chatBarInset,
+  topInset,
+  fadeBottom,
   revealFromTop = false,
   branchMarkers = [],
   onForkMessage,
@@ -230,23 +242,34 @@ const Messages = ({
     return byMessageId;
   }, [branchMarkers]);
 
-  const { height: keyboardHeight, progress: keyboardProgress } =
-    useReanimatedKeyboardAnimation();
-  const insetsBottom = theme.insets.bottom;
+  const keyboardLift = useKeyboardLift();
   const scrollButtonAnimatedStyle = useAnimatedStyle(() => ({
     transform: [
-      {
-        translateY:
-          -extraContentPadding.value +
-          keyboardHeight.value +
-          keyboardProgress.value * insetsBottom,
-      },
+      { translateY: -extraContentPadding.value + keyboardLift.value },
     ],
   }));
 
+  const listTopPadding = topInset + 16;
+  const listBottomPadding = chatBarInset + 8;
   const contentContainerStyle = useMemo(
-    () => [styles.contentContainer, { paddingBottom: chatBarInset + 8 }],
-    [styles.contentContainer, chatBarInset]
+    () => [
+      styles.contentContainer,
+      { paddingTop: listTopPadding, paddingBottom: listBottomPadding },
+    ],
+    [styles.contentContainer, listBottomPadding, listTopPadding]
+  );
+  const fadeAnchor = fadeBottom ?? topInset;
+  const topFadeBottom = fadeAnchor + FADE_HEIGHT - FADE_GAP_TRIM;
+  const { scrollIndicatorInsets, topFadeStyle, topFadeSolidStyle } = useMemo(
+    () => ({
+      scrollIndicatorInsets: { top: topFadeBottom },
+      topFadeStyle: [styles.topFade, { height: topFadeBottom }],
+      topFadeSolidStyle: [
+        styles.topFadeSolid,
+        { height: fadeAnchor - FADE_GAP_TRIM + SEAM_OVERLAP },
+      ],
+    }),
+    [styles.topFade, styles.topFadeSolid, fadeAnchor, topFadeBottom]
   );
   const scrollButtonStyle = useMemo(
     () => [styles.scrollToBottomButtonContainer, { bottom: chatBarInset + 16 }],
@@ -254,12 +277,7 @@ const Messages = ({
   );
 
   const bottomFadeAnimatedStyle = useAnimatedStyle(() => ({
-    transform: [
-      {
-        translateY:
-          keyboardHeight.value + keyboardProgress.value * insetsBottom,
-      },
-    ],
+    transform: [{ translateY: keyboardLift.value }],
   }));
 
   // Re-arm the initial scroll when the chat history is cleared (e.g.
@@ -347,16 +365,14 @@ const Messages = ({
 
   const recomputeBlankSpace = useCallback(() => {
     if (!pinActive.current) return;
-    // Container and content both grew by chatBarInset; subtracting it keeps
-    // blankSpace unchanged.
-    const CONTAINER_PADDING = 16 + 8 + chatBarInset;
     const raw =
       containerHeight.current -
       lastUserHeight.current -
       lastAssistantHeight.current -
-      CONTAINER_PADDING;
+      listTopPadding -
+      listBottomPadding;
     blankSpace.set(Math.max(0, raw));
-  }, [blankSpace, chatBarInset]);
+  }, [blankSpace, listBottomPadding, listTopPadding]);
 
   useImperativeHandle(
     ref,
@@ -385,13 +401,13 @@ const Messages = ({
 
         if (Platform.OS === 'ios') {
           if (containerHeight.current > 0) {
-            blankSpace.set(containerHeight.current);
+            blankSpace.set(containerHeight.current - topInset);
           }
         }
         pendingPinRef.current = true;
       },
     }),
-    [blankSpace, closeUserActionMenu, opacity]
+    [blankSpace, closeUserActionMenu, opacity, topInset]
   );
 
   const handleContainerLayout = useCallback(
@@ -540,12 +556,8 @@ const Messages = ({
       // Snap to bottom then fade in. This is the most reliable place to
       // scroll because the native content size is already committed.
       if (!hasScrolledToEnd.current) {
-        // Wait until messages have actually rendered — the first
-        // onContentSizeChange fires with just padding (~24px) before
-        // the message items have laid out. Scrolling at that point is
-        // a no-op since there's nothing to scroll to.
-        const CONTENT_PADDING = 24 + chatBarInset;
-        if (h <= CONTENT_PADDING) return;
+        // The first onContentSizeChange fires with just the paddings, before
+        if (h <= listTopPadding + listBottomPadding) return;
 
         hasScrolledToEnd.current = true;
         initialScrollSettlingUntil.current = Date.now() + 650;
@@ -566,7 +578,7 @@ const Messages = ({
         closeUserActionMenu();
         if (Platform.OS !== 'ios' && containerHeight.current > 0) {
           blankSpace.set(
-            withTiming(containerHeight.current, {
+            withTiming(containerHeight.current - topInset, {
               duration: 300,
             })
           );
@@ -592,7 +604,14 @@ const Messages = ({
         }
       }
     },
-    [blankSpace, chatBarInset, closeUserActionMenu, scheduleInitialScrollToEnd]
+    [
+      blankSpace,
+      closeUserActionMenu,
+      listBottomPadding,
+      listTopPadding,
+      scheduleInitialScrollToEnd,
+      topInset,
+    ]
   );
 
   const hasMessages = chatHistory.length > 0;
@@ -623,6 +642,7 @@ const Messages = ({
         applyWorkaroundForContentInsetHitTestBug
         keyboardShouldPersistTaps="handled"
         contentContainerStyle={contentContainerStyle}
+        scrollIndicatorInsets={scrollIndicatorInsets}
         onLayout={handleContainerLayout}
         onScroll={handleScroll}
         onTouchStart={handleScrollTouchStart}
@@ -720,7 +740,12 @@ const Messages = ({
         })}
       </KeyboardChatScrollView>
 
-      {hasMessages && <EdgeFade edge="top" style={styles.topFade} />}
+      {hasMessages && (
+        <View style={topFadeStyle} pointerEvents="none">
+          <View style={topFadeSolidStyle} />
+          <EdgeFade edge="top" style={styles.topFadeRamp} />
+        </View>
+      )}
       {hasMessages && (
         <Reanimated.View
           style={[styles.bottomFade, bottomFadeAnimatedStyle]}
@@ -753,7 +778,7 @@ const Messages = ({
   );
 };
 
-export default Messages;
+export default memo(Messages);
 
 const createStyles = (theme: Theme) => {
   const navInset = navBarInset(theme);
@@ -764,18 +789,27 @@ const createStyles = (theme: Theme) => {
     },
     contentContainer: {
       paddingHorizontal: 16,
-      paddingTop: 16,
-      paddingBottom: 8,
     },
     topFade: {
       position: 'absolute',
       top: 0,
       left: 0,
-      right: SCROLL_INDICATOR_GUTTER,
+      right: 0,
+    },
+    topFadeSolid: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      backgroundColor: theme.bg.softPrimary,
+    },
+    topFadeRamp: {
+      position: 'absolute',
+      bottom: 0,
+      left: 0,
+      right: 0,
       height: FADE_HEIGHT,
     },
-    // Positions the ramp and the nav bar block below it, so the gutter set
-    // here applies to both.
     bottomFade: {
       position: 'absolute',
       bottom: 0,

--- a/components/chat-screen/Messages.tsx
+++ b/components/chat-screen/Messages.tsx
@@ -34,12 +34,7 @@ import Reanimated, {
 } from 'react-native-reanimated';
 import type { SharedValue } from 'react-native-reanimated';
 import MessageItem from './MessageItem';
-import {
-  BOTTOM_FADE_RUNUP,
-  BOTTOM_FADE_SCALE,
-  EdgeFade,
-  TOP_FADE_HEIGHT,
-} from './EdgeFade';
+import { EdgeFade, FADE_HEIGHT } from './EdgeFade';
 import { Message, type ChatBranchMarker } from '../../database/chatRepository';
 import { useTheme } from '../../context/ThemeContext';
 import { Theme } from '../../styles/colors';
@@ -256,12 +251,7 @@ const Messages = ({
     [styles.scrollToBottomButtonContainer, chatBarInset]
   );
 
-  const navInset = navBarInset(theme);
   const bottomFadeAnimatedStyle = useAnimatedStyle(() => ({
-    height:
-      (chatBarInset + extraContentPadding.value + BOTTOM_FADE_RUNUP) *
-        BOTTOM_FADE_SCALE +
-      navInset,
     transform: [
       {
         translateY:
@@ -780,15 +770,14 @@ const createStyles = (theme: Theme) => {
       top: 0,
       left: 0,
       right: SCROLL_INDICATOR_GUTTER,
-      height: TOP_FADE_HEIGHT,
+      height: FADE_HEIGHT,
     },
-    // Positions the ramp and the flat block below it, so the gutter set here
-    // applies to both.
     bottomFade: {
       position: 'absolute',
       bottom: 0,
       left: 0,
       right: SCROLL_INDICATOR_GUTTER,
+      height: FADE_HEIGHT + navInset,
     },
     // On Android the ramp must reach full opacity by the top of the navigation
     // bar, or text stays visible sliding under it. insets.bottom carries the

--- a/components/chat-screen/Messages.tsx
+++ b/components/chat-screen/Messages.tsx
@@ -28,10 +28,29 @@ import Reanimated, {
 } from 'react-native-reanimated';
 import type { SharedValue } from 'react-native-reanimated';
 import MessageItem from './MessageItem';
+import {
+  BOTTOM_FADE_RUNUP,
+  BOTTOM_FADE_SCALE,
+  EdgeFade,
+  TOP_FADE_HEIGHT,
+} from './EdgeFade';
 import { Message } from '../../database/chatRepository';
 import { useTheme } from '../../context/ThemeContext';
 import { Theme } from '../../styles/colors';
 import ChevronDown from '../../assets/icons/chevron-down.svg';
+
+/**
+ * Height of the opaque system navigation bar the list paints behind. Android
+ * only — iOS's bottom inset is the home indicator, a thin overlay that must
+ * not be blocked out.
+ */
+const navBarInset = (theme: Theme) =>
+  Platform.OS === 'android' ? theme.insets.bottom : 0;
+
+const SEAM_OVERLAP = 1;
+
+/** Right-edge gap so the fades don't paint over the scroll indicator. */
+const SCROLL_INDICATOR_GUTTER = 12;
 
 export interface MessagesHandle {
   onMessageSent: () => void;
@@ -46,10 +65,9 @@ interface Props {
   /** Whether the LLM is currently streaming a response. */
   isGenerating: boolean;
   /**
-   * Distance between the bottom of the screen and the scroll view
-   * (ChatBar height + safe area). Passed to KeyboardChatScrollView's
-   * offset prop so it correctly calculates the keyboard push distance
-   * and doesn't overshoot on keyboard dismiss.
+   * KeyboardChatScrollView's offset, so it calculates the keyboard push
+   * distance without overshooting on dismiss. Empirically tuned — change it
+   * only against a keyboard open/close test.
    */
   bottomOffset: number;
   /**
@@ -58,6 +76,12 @@ interface Props {
    * is dismissed to make room for the sheet.
    */
   freeze?: boolean;
+  /**
+   * Height of the chat bar overlaying the bottom of the list. The scroll view
+   * runs full-screen so messages slide under the bar; this keeps the last
+   * message resting above it, and sizes the bottom fade.
+   */
+  chatBarInset: number;
   ref?: Ref<MessagesHandle>;
 }
 
@@ -68,6 +92,7 @@ const Messages = ({
   isGenerating,
   bottomOffset,
   freeze = false,
+  chatBarInset,
   ref,
 }: Props) => {
   const { theme } = useTheme();
@@ -97,6 +122,29 @@ const Messages = ({
           -extraContentPadding.value +
           keyboardHeight.value +
           keyboardProgress.value * insetsBottom,
+      },
+    ],
+  }));
+
+  const contentContainerStyle = useMemo(
+    () => [styles.contentContainer, { paddingBottom: chatBarInset + 8 }],
+    [styles.contentContainer, chatBarInset]
+  );
+  const scrollButtonStyle = useMemo(
+    () => [styles.scrollToBottomButtonContainer, { bottom: chatBarInset + 16 }],
+    [styles.scrollToBottomButtonContainer, chatBarInset]
+  );
+
+  const navInset = navBarInset(theme);
+  const bottomFadeAnimatedStyle = useAnimatedStyle(() => ({
+    height:
+      (chatBarInset + extraContentPadding.value + BOTTOM_FADE_RUNUP) *
+        BOTTOM_FADE_SCALE +
+      navInset,
+    transform: [
+      {
+        translateY:
+          keyboardHeight.value + keyboardProgress.value * insetsBottom,
       },
     ],
   }));
@@ -169,14 +217,14 @@ const Messages = ({
 
   const recomputeBlankSpace = useCallback(() => {
     if (!streamingActive.current) return;
-    const CONTAINER_PADDING = 16 + 8;
+    const CONTAINER_PADDING = 16 + 8 + chatBarInset;
     const raw =
       containerHeight.current -
       lastUserHeight.current -
       lastAssistantHeight.current -
       CONTAINER_PADDING;
     blankSpace.set(Math.max(0, raw));
-  }, [blankSpace]);
+  }, [blankSpace, chatBarInset]);
 
   useImperativeHandle(
     ref,
@@ -268,7 +316,7 @@ const Messages = ({
         // onContentSizeChange fires with just padding (~24px) before
         // the message items have laid out. Scrolling at that point is
         // a no-op since there's nothing to scroll to.
-        const CONTENT_PADDING = 24;
+        const CONTENT_PADDING = 24 + chatBarInset;
         if (h <= CONTENT_PADDING) return;
 
         hasScrolledToEnd.current = true;
@@ -325,8 +373,10 @@ const Messages = ({
         }
       }
     },
-    [opacity, blankSpace]
+    [opacity, blankSpace, chatBarInset]
   );
+
+  const hasMessages = chatHistory.length > 0;
 
   // Identify the last user and last assistant indices so we can wrap
   // those specific rows in onLayout measurement Views.
@@ -353,7 +403,7 @@ const Messages = ({
         freeze={freeze}
         applyWorkaroundForContentInsetHitTestBug
         keyboardShouldPersistTaps="never"
-        contentContainerStyle={styles.contentContainer}
+        contentContainerStyle={contentContainerStyle}
         onLayout={handleContainerLayout}
         onScroll={handleScroll}
         onContentSizeChange={handleContentSizeChange}
@@ -400,13 +450,18 @@ const Messages = ({
         })}
       </KeyboardChatScrollView>
 
-      {showScrollButton && (
+      {hasMessages && <EdgeFade edge="top" style={styles.topFade} />}
+      {hasMessages && (
         <Reanimated.View
-          style={[
-            styles.scrollToBottomButtonContainer,
-            scrollButtonAnimatedStyle,
-          ]}
+          style={[styles.bottomFade, bottomFadeAnimatedStyle]}
+          pointerEvents="none"
         >
+          <EdgeFade edge="bottom" style={styles.bottomFadeRamp} />
+          <View style={styles.bottomFadeSolid} />
+        </Reanimated.View>
+      )}
+      {showScrollButton && (
+        <Reanimated.View style={[scrollButtonStyle, scrollButtonAnimatedStyle]}>
           <TouchableOpacity
             style={styles.scrollToBottomButton}
             onPress={scrollToBottom}
@@ -426,8 +481,9 @@ const Messages = ({
 
 export default Messages;
 
-const createStyles = (theme: Theme) =>
-  StyleSheet.create({
+const createStyles = (theme: Theme) => {
+  const navInset = navBarInset(theme);
+  return StyleSheet.create({
     container: {
       flex: 1,
       width: '100%',
@@ -437,9 +493,36 @@ const createStyles = (theme: Theme) =>
       paddingTop: 16,
       paddingBottom: 8,
     },
+    topFade: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: SCROLL_INDICATOR_GUTTER,
+      height: TOP_FADE_HEIGHT,
+    },
+    bottomFade: {
+      position: 'absolute',
+      bottom: 0,
+      left: 0,
+      right: SCROLL_INDICATOR_GUTTER,
+    },
+    bottomFadeRamp: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: navInset,
+    },
+    bottomFadeSolid: {
+      position: 'absolute',
+      bottom: 0,
+      left: 0,
+      right: 0,
+      height: navInset && navInset + SEAM_OVERLAP,
+      backgroundColor: theme.bg.softPrimary,
+    },
     scrollToBottomButtonContainer: {
       position: 'absolute',
-      bottom: 16,
       right: 16,
     },
     scrollToBottomButton: {
@@ -456,3 +539,4 @@ const createStyles = (theme: Theme) =>
       elevation: 4,
     },
   });
+};

--- a/components/chat-screen/Messages.tsx
+++ b/components/chat-screen/Messages.tsx
@@ -52,6 +52,8 @@ import { SUPPORTS_USER_ACTION_MENU } from '../../constants/chat-screen';
 const navBarInset = (theme: Theme) =>
   Platform.OS === 'android' ? theme.insets.bottom : 0;
 
+const BOTTOM_FADE_HEIGHT = Platform.OS === 'ios' ? 64 : FADE_HEIGHT;
+
 const SEAM_OVERLAP = 1;
 
 /** Right-edge gap so the fades don't paint over the scroll indicator. */
@@ -772,12 +774,14 @@ const createStyles = (theme: Theme) => {
       right: SCROLL_INDICATOR_GUTTER,
       height: FADE_HEIGHT,
     },
+    // Positions the ramp and the nav bar block below it, so the gutter set
+    // here applies to both.
     bottomFade: {
       position: 'absolute',
       bottom: 0,
       left: 0,
       right: SCROLL_INDICATOR_GUTTER,
-      height: FADE_HEIGHT + navInset,
+      height: BOTTOM_FADE_HEIGHT + navInset,
     },
     // On Android the ramp must reach full opacity by the top of the navigation
     // bar, or text stays visible sliding under it. insets.bottom carries the

--- a/components/chat-screen/useKeyboardLift.ts
+++ b/components/chat-screen/useKeyboardLift.ts
@@ -1,0 +1,12 @@
+import { useDerivedValue } from 'react-native-reanimated';
+import { useReanimatedKeyboardAnimation } from 'react-native-keyboard-controller';
+import { useTheme } from '../../context/ThemeContext';
+
+export const useKeyboardLift = () => {
+  const { height, progress } = useReanimatedKeyboardAnimation();
+  const insetsBottom = useTheme().theme.insets.bottom;
+  return useDerivedValue(
+    () => height.value + progress.value * insetsBottom,
+    [insetsBottom]
+  );
+};

--- a/hooks/useChatHeader.tsx
+++ b/hooks/useChatHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect } from 'react';
+import React, { useLayoutEffect, useState } from 'react';
 import { useChatStore } from '../store/chatStore';
 import NewChatHeaderButton from '../components/NewChatHeaderButton';
 import { Model } from '../database/modelRepository';
@@ -24,6 +24,7 @@ export default function useChatHeader({
   const { getChatById } = useChatStore();
   const chat = getChatById(chatId);
   const chatTitle = chat ? chat.title : ``;
+  const [titleBottom, setTitleBottom] = useState<number>();
 
   const { openMenu, MenuElements } = useChatTitleMenu({
     chatId,
@@ -40,6 +41,7 @@ export default function useChatHeader({
           modelName={chatModel?.modelName || 'No model selected'}
           onPress={onSelectModelFromTitle ?? (chat ? openMenu : undefined)}
           showChevron={!!onSelectModelFromTitle}
+          onBottomMeasured={setTitleBottom}
         />
       ),
     });
@@ -54,5 +56,5 @@ export default function useChatHeader({
     onSelectModelFromTitle,
   ]);
 
-  return { MenuElements };
+  return { MenuElements, titleBottom };
 }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3005,14 +3005,14 @@ SPEC CHECKSUMS:
   ExpoStoreReview: dab6e25f0641784bd6207f729f893423afbb6574
   ExpoSymbols: 8b63e859ba013df1f2fc666f535fddb3d5270569
   FBLazyVector: 061f518bbd81677ed8a8317e2ae60b8779495808
-  hermes-engine: b73eefca929bd717e549c62316ddf5e1785d6499
+  hermes-engine: 2f0d004f7ea59a531ab9a9087cf8663d386d3706
   iosMath: f7a6cbadf9d836d2149c2a84c435b1effc244cba
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   op-sqlite: 8d0462679673b145c995a240ff432e4346718689
   opencv-rne: 2305807573b6e29c8c87e3416ab096d09047a7a0
-  Pdfium: 2695c434cbefe1a651d3fee0034571dc2817efd5
+  Pdfium: f800387e18744bb2aa3a8054ee6d2f6c84e5e3fd
   Pulsar: db1cccc0a590d3dae98f2a9a3151bfc9be8785c3
   RCTDeprecation: 5045f20b2cc1239bf422764004338c720684a22f
   RCTRequired: b6b9724225dd780ac2989d2e575d5513c50fe04b
@@ -3022,7 +3022,7 @@ SPEC CHECKSUMS:
   React: 3e14066ac707b3e369d09e2e923d8bee7f8c33ff
   React-callinvoker: bd7959a24564feaf5e4c8c11789e64884da13482
   React-Core: f060f4e14e9301685ce63ea65fbe903bf3397e45
-  React-Core-prebuilt: b0f0b335298e2102c3b7c4cbaed0c8a1879af2c9
+  React-Core-prebuilt: 3a1e334c56ae9652c0b9227176fe068e388bcea8
   React-CoreModules: 89a1a544297be88ca4cdff317423f9e0d0c192a4
   React-cxxreact: 81b1bfa305b1b759cc0fe18327644816216e5993
   React-debug: 234fddb309822e13b9b442ef1bdca8d2b8c3cbf2
@@ -3050,7 +3050,7 @@ SPEC CHECKSUMS:
   React-logger: d0632d799fbd3507cdd5406f72489a83ed5f9163
   React-Mapbuffer: 274cb203819492f7fb594bbb3a1f3f5061fa794d
   React-microtasksnativemodule: 563b4dcc8b8570814d6de4fc1196f48d2944acd4
-  react-native-executorch: 778bfd1ed20b52fd5907b37df567b34f2b9030d6
+  react-native-executorch: c2ee5d2a9c6b7923585dc97ee63eb6f6b0558763
   react-native-image-picker: 48d850454b4a389753053e1d7378b624d3b47d77
   react-native-keyboard-controller: 6b4bc1ef1ad46ace3842f49ed03815a96a99b139
   react-native-netinfo: f852c868bf5175e46165c7e4db48a204a95c3800
@@ -3088,7 +3088,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 2b19d66e5ddfe8dc7afb6338a4626156cbf2bab1
   ReactCodegen: 43f0948182edee9407c7b977fb059455dfeb9361
   ReactCommon: c6e81cc1ae185fa84863f3ea1d58caac4be741d7
-  ReactNativeDependencies: f6a49cf945d48640a12c0f24cd404b89c7218273
+  ReactNativeDependencies: a2f9f20c34689c0ea681da2ef0e17aed80df81cb
   ReactNativeEnrichedMarkdown: 27a73f8df1bc304c35b7bd922c9885a4dfec3dc5
   ReactNativeFs: 54a8079110e99a52ab4aeb72f16c6785095eb9e8
   RNAudioAPI: a2a67b86dbd376f391252f0e249aec34a6e1ae92

--- a/styles/colors.ts
+++ b/styles/colors.ts
@@ -66,3 +66,18 @@ export const darkTheme = {
 
 export type ThemeColors = typeof lightTheme;
 export type Theme = ThemeColors & { insets: EdgeInsets };
+
+export const withAlpha = (color: string, alpha: number) => {
+  const hex = color.replace('#', '');
+  const full =
+    hex.length === 3
+      ? hex
+          .split('')
+          .map((c) => c + c)
+          .join('')
+      : hex;
+  const r = parseInt(full.slice(0, 2), 16);
+  const g = parseInt(full.slice(2, 4), 16);
+  const b = parseInt(full.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};


### PR DESCRIPTION
Resolves #253.

Messages were clipped mid-line at the top of the list and at the chat bar. The list now runs the full height of the screen so messages scroll underneath the bar, and background-coloured gradients at both edges let them dissolve instead of cutting off.

- ChatBar is an absolute overlay rather than a spacer taking layout space; Messages takes its height as chatBarInset to keep the last message resting above it and to size the bottom fade.
- ChatBar reports its baseline height instead of the live one, and re-measures when the safe-area inset changes, so switching Android navigation modes or rotating does not leave a stale baseline.
- On Android the bottom ramp reaches full opacity at the top of the system navigation bar, driven entirely by insets.bottom, so gesture and three-button modes both follow without a special case.
- Fades leave a right-edge gutter so they do not paint over the scroll indicator, and are drawn below the scroll-to-bottom button so it keeps receiving taps.

The layout and the Android navigation-bar handling were confirmed on a physical device in both navigation modes. The later changes — scroll indicator gutter, style memoisation, comment cleanup — are lint, type and unit tested only, not yet re-checked on device.