### PR TITLE
chore(build): strip console.* from production bundles

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -18,5 +18,12 @@ module.exports = function (api) {
         },
       ],
     ],
+    env: {
+      // Strip every console.* call (error included — there is no crash
+      // reporting to feed) from release bundles; dev and test keep them.
+      production: {
+        plugins: ['transform-remove-console'],
+      },
+    },
   };
 };

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "29.5.14",
     "@types/react": "~19.2.10",
+    "babel-plugin-transform-remove-console": "^6.9.4",
     "eslint": "^9",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4290,6 +4290,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-plugin-transform-remove-console@npm:^6.9.4":
+  version: 6.9.4
+  resolution: "babel-plugin-transform-remove-console@npm:6.9.4"
+  checksum: 1123c3816c6f89c064752199c8796f30265d937f5d8e1e43d3837f1c0e87ed0e6bbd0afa6117ce021c8b93ec1de7154e158674bb22331c7ed6609d10121359df
+  languageName: node
+  linkType: hard
+
 "babel-preset-current-node-syntax@npm:^1.0.0":
   version: 1.2.0
   resolution: "babel-preset-current-node-syntax@npm:1.2.0"
@@ -10287,6 +10294,7 @@ __metadata:
     "@testing-library/react-native": ^13.3.3
     "@types/jest": 29.5.14
     "@types/react": ~19.2.10
+    babel-plugin-transform-remove-console: ^6.9.4
     eslint: ^9
     eslint-config-prettier: ^10.1.8
     eslint-plugin-prettier: ^5.5.5


### PR DESCRIPTION
Resolves: #256

## PR Objective

Make logging a dev-only affair: every `console.*` call (including `console.error`) is stripped from production bundles at build time, while development and test behavior stays exactly as it is today. The app has no crash reporting that would consume production logs, so in release builds they only added bundle weight and leaked internal error messages into system logs (`adb logcat` / os_log).

## What changed?

* **`babel-plugin-transform-remove-console`** added as a devDependency.
* **`babel.config.js`:** new `env.production` block enabling the plugin. Metro sets `BABEL_ENV=production` for release bundles, so the transform applies only there — dev bundles and Jest (`test` env) are untouched.
* **No `exclude` list on purpose:** `console.error` is stripped too. If we ever add crash reporting, the follow-up should route errors through a logger instead of re-keeping raw `console.error`.
* **Zero call-site changes:** all ~37 existing `console.warn` / `console.error` calls across stores, hooks, and components stay as they are — the transform removes them from the release output.

## Verification

* Ran a sample module through the project's real Babel config in both env modes:
  * `development` → all of `log` / `warn` / `error` / `info` / `debug` kept,
  * `production` → all stripped.
* Full Jest suite and ESLint pass.

> **Note for local release builds:** reset the Metro cache once (`yarn start --reset-cache`) so the new transform takes effect.