### PR TITLE
fix(chat): give prompt suggestion cards a uniform height

### DIFF
--- a/components/chat-screen/PromptSuggestions.tsx
+++ b/components/chat-screen/PromptSuggestions.tsx
@@ -82,5 +82,6 @@ const createStyles = (theme: Theme) =>
       fontFamily: fontFamily.regular,
       color: theme.text.defaultSecondary,
       lineHeight: lineHeights.xs,
+      height: lineHeights.xs * 3,
     },
   });


### PR DESCRIPTION
## What

The **Research topic** entry in the "Suggested messages" carousel has a short
prompt (`"What are the latest developments in AI?"`) that wraps to **two** lines
instead of three. Because the suggestion card has no fixed height, that card
rendered one line shorter than the rest, so its container was smaller and the
carousel looked uneven.

## Fix

Reserve the full three-line height for the prompt text (matching the
`numberOfLines={3}` cap) so every card is the same size regardless of prompt
length.

## Before / After

Same two cards in both shots — **Cooking** (3-line prompt) next to **Research
topic** (2-line prompt).

**Before** — the *Research topic* card ends a line higher than its neighbours:

![before](https://raw.githubusercontent.com/software-mansion-labs/private-mind/9024c2fb15f4d140af05b70bb2ac468a1c4036ac/before.png)

**After** — all cards share the same height (the shorter prompt just leaves the
third line empty):

![after](https://raw.githubusercontent.com/software-mansion-labs/private-mind/9024c2fb15f4d140af05b70bb2ac468a1c4036ac/after.png)
