### PR TITLE
Fix/new chat top fade

### DIFF
--- a/components/chat-screen/ChatScreen.tsx
+++ b/components/chat-screen/ChatScreen.tsx
@@ -32,9 +32,10 @@ import {
 import { Model } from '../../database/modelRepository';
 import Messages from './Messages';
 import ChatBar from './ChatBar';
+import { TopFade } from './TopFade';
 import UserMessageActionMenu from './UserMessageActionMenu';
 import ModelSelectSheet from '../bottomSheets/ModelSelectSheet';
-import { Theme } from '../../styles/colors';
+import { mixColors, Theme } from '../../styles/colors';
 import { useSQLiteContext } from 'expo-sqlite';
 import { useVectorStore } from '../../context/VectorStoreContext';
 import { Attachment } from '../../hooks/useAttachment';
@@ -120,7 +121,7 @@ export default function ChatScreen({
   const extraContentPadding = useSharedValue(0);
   const blankSpace = useSharedValue(0);
   const [chatBarHeight, setChatBarHeight] = useState(0);
-  const [rootFrame, setRootFrame] = useState({ x: 0, y: 0 });
+  const [rootFrame, setRootFrame] = useState({ x: 0, y: 0, height: 0 });
   const [userActionMenu, setUserActionMenu] =
     useState<UserMessageActionMenuState>({ isOpen: false });
   const { branchMarkers, handleForkMessage, handleBranchMarkerPress } =
@@ -148,9 +149,11 @@ export default function ChatScreen({
   }, []);
 
   const handleRootLayout = useCallback(() => {
-    rootRef.current?.measureInWindow((x, y) => {
+    rootRef.current?.measureInWindow((x, y, _width, height) => {
       setRootFrame((current) =>
-        current.x === x && current.y === y ? current : { x, y }
+        current.x === x && current.y === y && current.height === height
+          ? current
+          : { x, y, height }
       );
     });
   }, []);
@@ -413,6 +416,16 @@ export default function ChatScreen({
     headerTitleBottom !== undefined
       ? headerTitleBottom - rootFrame.y
       : undefined;
+  const topFadeAnchor = fadeBottom ?? headerHeight;
+  const emptyFadeColors = useMemo(() => {
+    const sample = (y: number) =>
+      mixColors(
+        theme.bg.softPrimary,
+        theme.bg.main,
+        rootFrame.height > 0 ? y / rootFrame.height : 0
+      );
+    return [sample(0), sample(topFadeAnchor)] as const;
+  }, [rootFrame.height, theme.bg.main, theme.bg.softPrimary, topFadeAnchor]);
 
   return (
     <View
@@ -471,6 +484,14 @@ export default function ChatScreen({
         />
       </Animated.View>
 
+      {isEmpty && (
+        <TopFade
+          anchor={topFadeAnchor}
+          colors={emptyFadeColors}
+          style={styles.topFadeOverlay}
+        />
+      )}
+
       {userActionMenuPosition && (
         <View
           style={[styles.userActionMenuOverlay, userActionMenuPosition]}
@@ -505,6 +526,10 @@ const createStyles = (theme: Theme) =>
       position: 'absolute',
       zIndex: 1000,
       elevation: 1000,
+    },
+    topFadeOverlay: {
+      zIndex: 3,
+      elevation: 3,
     },
     chatBarSticky: {
       position: 'absolute',

--- a/components/chat-screen/EdgeFade.tsx
+++ b/components/chat-screen/EdgeFade.tsx
@@ -6,6 +6,10 @@ import { withAlpha } from '../../styles/colors';
 
 export const FADE_HEIGHT = 24;
 
+export const FADE_GAP_TRIM = 5;
+
+export const SEAM_OVERLAP = 1;
+
 const LOCATIONS: [number, number, ...number[]] = [0, 0.25, 0.5, 0.75, 1];
 const BOTTOM_ALPHAS = [0, 0.156, 0.5, 0.844, 1];
 const TOP_ALPHAS = [...BOTTOM_ALPHAS].reverse();
@@ -13,19 +17,21 @@ const TOP_ALPHAS = [...BOTTOM_ALPHAS].reverse();
 interface Props {
   edge: 'top' | 'bottom';
   style?: StyleProp<ViewStyle>;
+  color?: string;
 }
 
-export const EdgeFade = React.memo(({ edge, style }: Props) => {
+export const EdgeFade = React.memo(({ edge, style, color }: Props) => {
   const { theme } = useTheme();
+  const target = color ?? theme.bg.softPrimary;
 
   const colors = useMemo(() => {
     const ramp = edge === 'top' ? TOP_ALPHAS : BOTTOM_ALPHAS;
-    return ramp.map((alpha) => withAlpha(theme.bg.softPrimary, alpha)) as [
+    return ramp.map((alpha) => withAlpha(target, alpha)) as [
       string,
       string,
       ...string[],
     ];
-  }, [edge, theme.bg.softPrimary]);
+  }, [edge, target]);
 
   return (
     <LinearGradient

--- a/components/chat-screen/Messages.tsx
+++ b/components/chat-screen/Messages.tsx
@@ -33,7 +33,8 @@ import Reanimated, {
 import type { SharedValue } from 'react-native-reanimated';
 import MessageItem from './MessageItem';
 import SourcesSheet, { type SourcesSheetHandle } from './SourcesSheet';
-import { EdgeFade, FADE_HEIGHT } from './EdgeFade';
+import { EdgeFade, FADE_HEIGHT, SEAM_OVERLAP } from './EdgeFade';
+import { TopFade, topFadeHeight } from './TopFade';
 import {
   Message,
   SourceDocument,
@@ -58,10 +59,6 @@ const navBarInset = (theme: Theme) =>
   Platform.OS === 'android' ? theme.insets.bottom : 0;
 
 const BOTTOM_FADE_HEIGHT = Platform.OS === 'ios' ? 64 : FADE_HEIGHT;
-
-const SEAM_OVERLAP = 1;
-
-const FADE_GAP_TRIM = 5;
 
 /** Right-edge gap so the bottom fade doesn't paint over the scroll indicator. */
 const SCROLL_INDICATOR_GUTTER = 12;
@@ -280,17 +277,9 @@ const Messages = ({
     [styles.contentContainer, listBottomPadding, listTopPadding]
   );
   const fadeAnchor = fadeBottom ?? topInset;
-  const topFadeBottom = fadeAnchor + FADE_HEIGHT - FADE_GAP_TRIM;
-  const { scrollIndicatorInsets, topFadeStyle, topFadeSolidStyle } = useMemo(
-    () => ({
-      scrollIndicatorInsets: { top: topFadeBottom },
-      topFadeStyle: [styles.topFade, { height: topFadeBottom }],
-      topFadeSolidStyle: [
-        styles.topFadeSolid,
-        { height: fadeAnchor - FADE_GAP_TRIM + SEAM_OVERLAP },
-      ],
-    }),
-    [styles.topFade, styles.topFadeSolid, fadeAnchor, topFadeBottom]
+  const scrollIndicatorInsets = useMemo(
+    () => ({ top: topFadeHeight(fadeAnchor) }),
+    [fadeAnchor]
   );
   const scrollButtonStyle = useMemo(
     () => [styles.scrollToBottomButtonContainer, { bottom: chatBarInset + 16 }],
@@ -871,12 +860,7 @@ const Messages = ({
         )}
       </KeyboardChatScrollView>
 
-      {hasMessages && (
-        <View style={topFadeStyle} pointerEvents="none">
-          <View style={topFadeSolidStyle} />
-          <EdgeFade edge="top" style={styles.topFadeRamp} />
-        </View>
-      )}
+      {hasMessages && <TopFade anchor={fadeAnchor} />}
       {hasMessages && (
         <Reanimated.View
           style={[styles.bottomFade, bottomFadeAnimatedStyle]}
@@ -922,26 +906,6 @@ const createStyles = (theme: Theme) => {
     },
     contentContainer: {
       paddingHorizontal: 16,
-    },
-    topFade: {
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      right: 0,
-    },
-    topFadeSolid: {
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      right: 0,
-      backgroundColor: theme.bg.softPrimary,
-    },
-    topFadeRamp: {
-      position: 'absolute',
-      bottom: 0,
-      left: 0,
-      right: 0,
-      height: FADE_HEIGHT,
     },
     bottomFade: {
       position: 'absolute',

--- a/components/chat-screen/TopFade.tsx
+++ b/components/chat-screen/TopFade.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useThemedStyles } from '../../hooks/useThemedStyles';
+import { Theme } from '../../styles/colors';
+import { EdgeFade, FADE_GAP_TRIM, FADE_HEIGHT, SEAM_OVERLAP } from './EdgeFade';
+
+export const topFadeHeight = (anchor: number) =>
+  anchor - FADE_GAP_TRIM + FADE_HEIGHT;
+
+interface Props {
+  anchor: number;
+  colors?: readonly [string, string];
+  style?: StyleProp<ViewStyle>;
+}
+
+export const TopFade = React.memo(({ anchor, colors, style }: Props) => {
+  const solidHeight = anchor - FADE_GAP_TRIM;
+  const { styles } = useThemedStyles(createStyles, solidHeight);
+
+  if (solidHeight <= 0) return null;
+
+  return (
+    <View style={[styles.container, style]} pointerEvents="none">
+      {colors ? (
+        <LinearGradient colors={colors} style={styles.solid} />
+      ) : (
+        <View style={styles.solid} />
+      )}
+      <EdgeFade edge="top" color={colors?.[1]} style={styles.ramp} />
+    </View>
+  );
+});
+
+TopFade.displayName = 'TopFade';
+
+const createStyles = (theme: Theme, solidHeight: number) =>
+  StyleSheet.create({
+    container: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      height: solidHeight + FADE_HEIGHT,
+    },
+    solid: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      height: solidHeight + SEAM_OVERLAP,
+      backgroundColor: theme.bg.softPrimary,
+    },
+    ramp: {
+      position: 'absolute',
+      bottom: 0,
+      left: 0,
+      right: 0,
+      height: FADE_HEIGHT,
+    },
+  });

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3008,14 +3008,14 @@ SPEC CHECKSUMS:
   ExpoStoreReview: 416b2de497481b0aeb28ef95d3f93bc9ae4bca6a
   ExpoSymbols: 896159288ad708e1a32dc12c92fe5f90bff01126
   FBLazyVector: 061f518bbd81677ed8a8317e2ae60b8779495808
-  hermes-engine: b73eefca929bd717e549c62316ddf5e1785d6499
+  hermes-engine: 2f0d004f7ea59a531ab9a9087cf8663d386d3706
   iosMath: f7a6cbadf9d836d2149c2a84c435b1effc244cba
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   op-sqlite: 10397885c9f2d478a9d099d20e2a7915c5fda944
   opencv-rne: 2305807573b6e29c8c87e3416ab096d09047a7a0
-  Pdfium: 2695c434cbefe1a651d3fee0034571dc2817efd5
+  Pdfium: f800387e18744bb2aa3a8054ee6d2f6c84e5e3fd
   Pulsar: 9ec19a182a03d08ecefb47877e8de9e976c2a03c
   Pulsar-haptics: f795eaf55d8d0290148fd97c747dcc6689c3d079
   RCTDeprecation: 5045f20b2cc1239bf422764004338c720684a22f
@@ -3026,7 +3026,7 @@ SPEC CHECKSUMS:
   React: 3e14066ac707b3e369d09e2e923d8bee7f8c33ff
   React-callinvoker: bd7959a24564feaf5e4c8c11789e64884da13482
   React-Core: f060f4e14e9301685ce63ea65fbe903bf3397e45
-  React-Core-prebuilt: b0f0b335298e2102c3b7c4cbaed0c8a1879af2c9
+  React-Core-prebuilt: 3a1e334c56ae9652c0b9227176fe068e388bcea8
   React-CoreModules: 89a1a544297be88ca4cdff317423f9e0d0c192a4
   React-cxxreact: 81b1bfa305b1b759cc0fe18327644816216e5993
   React-debug: 234fddb309822e13b9b442ef1bdca8d2b8c3cbf2
@@ -3054,7 +3054,7 @@ SPEC CHECKSUMS:
   React-logger: d0632d799fbd3507cdd5406f72489a83ed5f9163
   React-Mapbuffer: 274cb203819492f7fb594bbb3a1f3f5061fa794d
   React-microtasksnativemodule: 563b4dcc8b8570814d6de4fc1196f48d2944acd4
-  react-native-executorch: 778bfd1ed20b52fd5907b37df567b34f2b9030d6
+  react-native-executorch: c2ee5d2a9c6b7923585dc97ee63eb6f6b0558763
   react-native-image-picker: 48d850454b4a389753053e1d7378b624d3b47d77
   react-native-keyboard-controller: 6b4bc1ef1ad46ace3842f49ed03815a96a99b139
   react-native-netinfo: f852c868bf5175e46165c7e4db48a204a95c3800
@@ -3092,7 +3092,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 2b19d66e5ddfe8dc7afb6338a4626156cbf2bab1
   ReactCodegen: 43f0948182edee9407c7b977fb059455dfeb9361
   ReactCommon: c6e81cc1ae185fa84863f3ea1d58caac4be741d7
-  ReactNativeDependencies: f6a49cf945d48640a12c0f24cd404b89c7218273
+  ReactNativeDependencies: a2f9f20c34689c0ea681da2ef0e17aed80df81cb
   ReactNativeEnrichedMarkdown: 27a73f8df1bc304c35b7bd922c9885a4dfec3dc5
   ReactNativeFs: f2b571997aa8d6397850a6477e1c8f5823171e50
   RNAudioAPI: a2a67b86dbd376f391252f0e249aec34a6e1ae92

--- a/styles/colors.ts
+++ b/styles/colors.ts
@@ -85,7 +85,7 @@ export const darkTheme = {
 export type ThemeColors = typeof lightTheme;
 export type Theme = ThemeColors & { insets: EdgeInsets };
 
-export const withAlpha = (color: string, alpha: number) => {
+const toRgb = (color: string) => {
   const hex = color.replace('#', '');
   const full =
     hex.length === 3
@@ -94,8 +94,25 @@ export const withAlpha = (color: string, alpha: number) => {
           .map((c) => c + c)
           .join('')
       : hex;
-  const r = parseInt(full.slice(0, 2), 16);
-  const g = parseInt(full.slice(2, 4), 16);
-  const b = parseInt(full.slice(4, 6), 16);
+  return {
+    r: parseInt(full.slice(0, 2), 16),
+    g: parseInt(full.slice(2, 4), 16),
+    b: parseInt(full.slice(4, 6), 16),
+  };
+};
+
+export const withAlpha = (color: string, alpha: number) => {
+  const { r, g, b } = toRgb(color);
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
+
+export const mixColors = (from: string, to: string, t: number) => {
+  const ratio = Math.min(1, Math.max(0, t));
+  const a = toRgb(from);
+  const b = toRgb(to);
+  const channel = (start: number, end: number) =>
+    Math.round(start + (end - start) * ratio)
+      .toString(16)
+      .padStart(2, '0');
+  return `#${channel(a.r, b.r)}${channel(a.g, b.g)}${channel(a.b, b.b)}`;
 };


### PR DESCRIPTION
## PR Objective

On the new-chat (empty) screen, content met the header with a hard edge — the top fade only rendered once a conversation had messages (`hasMessages`), so an empty chat had nothing masking the seam. It is most visible with the keyboard open, when the greeting and prompt suggestions are pushed up underneath the header.

This Pull Request extracts the top fade into a reusable component and renders it in the empty state as well, tinted to match that screen's gradient background instead of painting a flat band over it.

## What changed?

### New `TopFade` component
* **`components/chat-screen/TopFade.tsx`** (new): owns the top-fade overlay — a solid block plus the `EdgeFade` ramp — that was previously inlined in `Messages.tsx`. Renders `null` when the computed height collapses (`solidHeight <= 0`).
* Exports **`topFadeHeight(anchor)`** so callers derive the same height for scroll-indicator insets instead of recomputing the geometry independently.
* Takes an optional `colors` tuple: when provided, the solid part becomes a `LinearGradient` (empty state); otherwise it stays a flat `theme.bg.softPrimary` fill (conversation), matching current behaviour.

### Empty-state fade (`components/chat-screen/ChatScreen.tsx`)
* Renders `<TopFade />` when `isEmpty`, layered above content (`zIndex`/`elevation: 3`).
* `handleRootLayout` now also captures the root **height** from `measureInWindow`, so the fade can sample the background at the correct offsets.
* `emptyFadeColors` samples `bg.softPrimary → bg.main` at the top of the screen and at the fade anchor, so the overlay follows the background gradient rather than sitting on top of it as a visible block.

### Shared fade constants (`components/chat-screen/EdgeFade.tsx`)
* `FADE_GAP_TRIM` and `SEAM_OVERLAP` moved here from `Messages.tsx` and exported — both `TopFade` and `Messages` now depend on them.
* `EdgeFade` accepts an optional `color` prop, defaulting to the previous `theme.bg.softPrimary`, so the ramp can match a custom gradient endpoint.

### Color helpers (`styles/colors.ts`)
* Hex parsing factored out of `withAlpha` into a shared `toRgb` helper.
* Added **`mixColors(from, to, t)`** — clamped linear interpolation between two hex colors, used to sample the empty-screen gradient.

### Cleanup (`components/chat-screen/Messages.tsx`)
* Drops the inline fade markup and its three style blocks (`topFade`, `topFadeSolid`, `topFadeRamp`) in favour of `<TopFade anchor={fadeAnchor} />`, and derives `scrollIndicatorInsets` from `topFadeHeight` (net −36 lines).

---

> **Note — unrelated change:** `ios/Podfile.lock` carries a checksum refresh for five prebuilt pods (`hermes-engine`, `Pdfium`, `React-Core-prebuilt`, `react-native-executorch`, `ReactNativeDependencies`) picked up from a local `pod install` while building for a device. It is not part of this fix and can be split out if it should land separately.
