### PR TITLE
fix(android): drop READ_MEDIA_IMAGES, rely on the system photo picker

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" tools:replace="android:maxSdkVersion"/>
-  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
   <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.VIBRATE"/>

--- a/hooks/useAttachment.ts
+++ b/hooks/useAttachment.ts
@@ -2,7 +2,6 @@ import { useState, useRef, useCallback, useEffect } from 'react';
 import { launchImageLibrary, launchCamera } from 'react-native-image-picker';
 import * as DocumentPicker from 'expo-document-picker';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
-import { Platform, PermissionsAndroid } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { useSourceStore } from '../store/sourceStore';
 import { useVectorStore } from '../context/VectorStoreContext';
@@ -27,21 +26,6 @@ interface ClearAllOptions {
 interface ClearAllOptions {
   cleanupSources?: boolean;
 }
-
-const requestAndroidGalleryPermission = async (): Promise<boolean> => {
-  if (Platform.OS !== 'android') return true;
-
-  const permission =
-    Number(Platform.Version) >= 33
-      ? PermissionsAndroid.PERMISSIONS.READ_MEDIA_IMAGES
-      : PermissionsAndroid.PERMISSIONS.READ_EXTERNAL_STORAGE;
-
-  const status = await PermissionsAndroid.check(permission);
-  if (status) return true;
-
-  const result = await PermissionsAndroid.request(permission);
-  return result === PermissionsAndroid.RESULTS.GRANTED;
-};
 
 const IMAGE_EXTENSIONS = [
   'jpg',
@@ -97,14 +81,6 @@ export const useAttachment = () => {
   }, []);
 
   const pickFromLibrary = useCallback(async () => {
-    const granted = await requestAndroidGalleryPermission();
-    if (!granted) {
-      Toast.show({
-        type: 'defaultToast',
-        text1: 'Photo library permission is required to attach images.',
-      });
-      return;
-    }
     const result = await launchImageLibrary({ mediaType: 'photo', quality: 1 });
     if (!result.didCancel && result.assets && result.assets.length > 0) {
       const uri = result.assets[0].uri;


### PR DESCRIPTION
## Why

Google Play flagged versionCode 64 under the **Photo and Video Permissions** policy. An app targeting API 33+ may request `READ_MEDIA_IMAGES` only when the system pickers are technically insufficient for its core functionality — which is not our case.

The flag is correct and should not be appealed.

## What

`react-native-image-picker@8.2.1` builds its gallery intent with `PickVisualMedia` ([`ImagePickerModuleImpl.java#L139-L152`](https://github.com/react-native-image-picker/react-native-image-picker/blob/main/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java)), which never consults app permissions. It returns a per-URI grant from one of three paths, all permission-free:

| Android | Intent |
|---|---|
| API 33+ | native photo picker (`ACTION_PICK_IMAGES`) |
| API 30–32 with the MediaProvider backport | same intent via backport |
| no picker available | `ACTION_OPEN_DOCUMENT` (SAF) |

So the permission was already unnecessary — requesting it only put a dialog in front of the picker that users had to dismiss.

This PR removes:
- the `READ_MEDIA_IMAGES` entry from `AndroidManifest.xml`
- `requestAndroidGalleryPermission()` and its call in `pickFromLibrary`, which was **the only `PermissionsAndroid` call left in the app**

`READ_EXTERNAL_STORAGE` stays — it is declared by `expo-file-system` / `@dr.pogodin/react-native-fs` — but it is inert: it carries `maxSdkVersion="32"` and nothing requests it anymore.

## Verification

Full attach flow (`+` → Photo Library → pick → attachment lands in the chat bar), with `dumpsys package` checked before and after:

| Level | Device | Picker used | Result |
|---|---|---|---|
| API 30 | emulator, `google_apis` (no Play Store) | `ACTION_OPEN_DOCUMENT` (SAF fallback) | no dialog; `READ_EXTERNAL_STORAGE` stayed `granted=false` |
| API 33 | physical Samsung SM-G781B | native photo picker | no dialog; no media permission granted |
| API 37 | emulator Pixel_10 | native photo picker | no dialog; `READ_MEDIA_IMAGES` absent from the package |

The API 30 image was deliberately chosen **without** Play Store, so the picker backport is unavailable and the SAF fallback is exercised — the worst case, and the only place a regression could hide.

Additional checks:
- The **merged manifest contains 0 occurrences** of `READ_MEDIA_IMAGES` after every merge phase, so no dependency reintroduces it.
- On API 33 the package manager itself confirms the removal: `pm revoke READ_MEDIA_IMAGES` fails with `SecurityException: Package com.swmansion.privatemind has not requested permission android.permission.READ_MEDIA_IMAGES`.
- With permissions reset to the "never asked" state, the picker still opens with no dialog, while `RECORD_AUDIO` correctly prompts again — confirming the reset worked and the absence of a photo prompt is by design, not a broken test.
- Nothing else depends on the removed grant: export writes to `Paths.document` and shares via `expo-sharing`; import uses `DocumentPicker` with `copyToCacheDirectory: true`.

## Not covered

- **API 24–29.** `minSdk` is 24 and testing started at 30. The SAF fallback is the same mechanism verified on API 30 and `ACTION_OPEN_DOCUMENT` has existed since API 19, so the extrapolation is strong — but it is an extrapolation.
- **The in-place update path.** Everything above was a clean install; updating over a store build that declared (and possibly had granted) the permission is tracked in #274.

## iOS

Unaffected. The removed helper returned `true` immediately on iOS, and `launchImageLibrary` uses `PHPickerViewController`, which never required a permission. Note `NSPhotoLibraryUsageDescription` in `Info.plist` is now vestigial — harmless, but it no longer corresponds to anything the app does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
