### PR TITLE
fix(chat): keep the header mask opaque while a chat reveals

### DIFF
--- a/components/chat-screen/Messages.tsx
+++ b/components/chat-screen/Messages.tsx
@@ -789,145 +789,147 @@ const Messages = ({
   lastAssistantMeasurementKey.current = assistantMeasurementKey();
 
   return (
-    <Reanimated.View style={[styles.container, animatedContainerStyle]}>
-      <KeyboardChatScrollView
-        ref={scrollRef}
-        keyboardLiftBehavior="whenAtEnd"
-        offset={bottomOffset}
-        extraContentPadding={extraContentPadding}
-        blankSpace={blankSpace}
-        freeze={freeze}
-        applyWorkaroundForContentInsetHitTestBug
-        keyboardShouldPersistTaps="handled"
-        contentContainerStyle={contentContainerStyle}
-        scrollIndicatorInsets={scrollIndicatorInsets}
-        onLayout={handleContainerLayout}
-        onScroll={handleScroll}
-        onScrollBeginDrag={handleScrollBeginDrag}
-        onTouchStart={handleScrollTouchStart}
-        onContentSizeChange={handleContentSizeChange}
-        scrollEventThrottle={16}
-        style={styles.container}
-      >
-        {chatHistory.map((message, index) => {
-          const isLastMessage = index === chatHistory.length - 1;
-          const userQuestion = questionForAssistantAt[index];
-          // Streaming assistant placeholder has id: -1 until persisted; fall
-          // back to role+index for that single in-flight row.
-          const key =
-            message.id && message.id > 0
-              ? `msg-${message.id}`
-              : `pending-${message.role}-${index}`;
+    <View style={styles.container}>
+      <Reanimated.View style={[styles.container, animatedContainerStyle]}>
+        <KeyboardChatScrollView
+          ref={scrollRef}
+          keyboardLiftBehavior="whenAtEnd"
+          offset={bottomOffset}
+          extraContentPadding={extraContentPadding}
+          blankSpace={blankSpace}
+          freeze={freeze}
+          applyWorkaroundForContentInsetHitTestBug
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={contentContainerStyle}
+          scrollIndicatorInsets={scrollIndicatorInsets}
+          onLayout={handleContainerLayout}
+          onScroll={handleScroll}
+          onScrollBeginDrag={handleScrollBeginDrag}
+          onTouchStart={handleScrollTouchStart}
+          onContentSizeChange={handleContentSizeChange}
+          scrollEventThrottle={16}
+          style={styles.container}
+        >
+          {chatHistory.map((message, index) => {
+            const isLastMessage = index === chatHistory.length - 1;
+            const userQuestion = questionForAssistantAt[index];
+            // Streaming assistant placeholder has id: -1 until persisted; fall
+            // back to role+index for that single in-flight row.
+            const key =
+              message.id && message.id > 0
+                ? `msg-${message.id}`
+                : `pending-${message.role}-${index}`;
 
-          const onLayout =
-            index === lastUserIndex
-              ? (event: LayoutChangeEvent) => handleLastUserLayout(key, event)
-              : index === lastAssistantIndex
-                ? () => handleLastAssistantLayout(key)
-                : undefined;
-          const branchMarker = latestBranchMarkerByMessageId.get(message.id);
-          const { showActions, showForkAction } =
-            getMessageActionsState(message);
+            const onLayout =
+              index === lastUserIndex
+                ? (event: LayoutChangeEvent) => handleLastUserLayout(key, event)
+                : index === lastAssistantIndex
+                  ? () => handleLastAssistantLayout(key)
+                  : undefined;
+            const branchMarker = latestBranchMarkerByMessageId.get(message.id);
+            const { showActions, showForkAction } =
+              getMessageActionsState(message);
 
-          const item = (
-            <View style={styles.messageRow} collapsable={false}>
-              <MessageItem
-                message={message}
-                content={message.content}
-                modelName={message.modelName}
-                role={message.role}
-                tokensPerSecond={message.tokensPerSecond}
-                timeToFirstToken={message.timeToFirstToken}
-                isLastMessage={isLastMessage}
-                imagePath={message.imagePath}
-                documentName={message.documentName}
-                sourceDocuments={message.sourceDocuments}
-                userQuestion={userQuestion}
-                onShowSources={handleShowSources}
-                showActions={showActions}
-                showForkAction={showForkAction}
-                onCopy={handleCopyMessage}
-                onFork={handleForkMessage}
-              />
-              {branchMarker && (
-                <BranchMarker
-                  key={`branch-${branchMarker.id}`}
-                  marker={branchMarker}
-                  onPress={onBranchMarkerPress}
+            const item = (
+              <View style={styles.messageRow} collapsable={false}>
+                <MessageItem
+                  message={message}
+                  content={message.content}
+                  modelName={message.modelName}
+                  role={message.role}
+                  tokensPerSecond={message.tokensPerSecond}
+                  timeToFirstToken={message.timeToFirstToken}
+                  isLastMessage={isLastMessage}
+                  imagePath={message.imagePath}
+                  documentName={message.documentName}
+                  sourceDocuments={message.sourceDocuments}
+                  userQuestion={userQuestion}
+                  onShowSources={handleShowSources}
+                  showActions={showActions}
+                  showForkAction={showForkAction}
+                  onCopy={handleCopyMessage}
+                  onFork={handleForkMessage}
                 />
-              )}
-            </View>
-          );
+                {branchMarker && (
+                  <BranchMarker
+                    key={`branch-${branchMarker.id}`}
+                    marker={branchMarker}
+                    onPress={onBranchMarkerPress}
+                  />
+                )}
+              </View>
+            );
 
-          const shouldHandleUserLongPress =
-            SUPPORTS_USER_ACTION_MENU &&
-            message.role === 'user' &&
-            message.id > 0;
+            const shouldHandleUserLongPress =
+              SUPPORTS_USER_ACTION_MENU &&
+              message.role === 'user' &&
+              message.id > 0;
 
-          if (onLayout) {
-            if (!shouldHandleUserLongPress) {
+            if (onLayout) {
+              if (!shouldHandleUserLongPress) {
+                return (
+                  <View key={key} onLayout={onLayout} collapsable={false}>
+                    {item}
+                  </View>
+                );
+              }
+
               return (
                 <View key={key} onLayout={onLayout} collapsable={false}>
-                  {item}
+                  <LongPressableMessage
+                    messageId={message.id}
+                    onLongPress={handleUserLongPress}
+                  >
+                    {item}
+                  </LongPressableMessage>
                 </View>
               );
             }
 
-            return (
-              <View key={key} onLayout={onLayout} collapsable={false}>
-                <LongPressableMessage
-                  messageId={message.id}
-                  onLongPress={handleUserLongPress}
-                >
-                  {item}
-                </LongPressableMessage>
-              </View>
-            );
-          }
-
-          if (!shouldHandleUserLongPress) {
-            return <React.Fragment key={key}>{item}</React.Fragment>;
-          }
-
-          return (
-            <LongPressableMessage
-              key={key}
-              messageId={message.id}
-              onLongPress={handleUserLongPress}
-            >
-              {item}
-            </LongPressableMessage>
-          );
-        })}
-        {generationError && (
-          <View
-            onLayout={() =>
-              handleLastAssistantLayout(GENERATION_ERROR_MEASUREMENT_KEY)
+            if (!shouldHandleUserLongPress) {
+              return <React.Fragment key={key}>{item}</React.Fragment>;
             }
-            collapsable={false}
-            style={styles.generationError}
-            testID="generation-error"
-          >
-            <Text style={styles.generationErrorText}>{generationError}</Text>
-            <Pressable
-              onPress={onRetryGeneration}
-              accessibilityRole="button"
-              accessibilityLabel="Retry response generation"
-              style={({ pressed }) => [
-                styles.retryButton,
-                pressed && styles.retryButtonPressed,
-              ]}
+
+            return (
+              <LongPressableMessage
+                key={key}
+                messageId={message.id}
+                onLongPress={handleUserLongPress}
+              >
+                {item}
+              </LongPressableMessage>
+            );
+          })}
+          {generationError && (
+            <View
+              onLayout={() =>
+                handleLastAssistantLayout(GENERATION_ERROR_MEASUREMENT_KEY)
+              }
+              collapsable={false}
+              style={styles.generationError}
+              testID="generation-error"
             >
-              <RotateLeftIcon
-                width={16}
-                height={16}
-                style={styles.retryButtonIcon}
-              />
-              <Text style={styles.retryButtonText}>Retry</Text>
-            </Pressable>
-          </View>
-        )}
-      </KeyboardChatScrollView>
+              <Text style={styles.generationErrorText}>{generationError}</Text>
+              <Pressable
+                onPress={onRetryGeneration}
+                accessibilityRole="button"
+                accessibilityLabel="Retry response generation"
+                style={({ pressed }) => [
+                  styles.retryButton,
+                  pressed && styles.retryButtonPressed,
+                ]}
+              >
+                <RotateLeftIcon
+                  width={16}
+                  height={16}
+                  style={styles.retryButtonIcon}
+                />
+                <Text style={styles.retryButtonText}>Retry</Text>
+              </Pressable>
+            </View>
+          )}
+        </KeyboardChatScrollView>
+      </Reanimated.View>
 
       {hasMessages && <TopFade anchor={fadeAnchor} />}
       {hasMessages && (
@@ -960,7 +962,7 @@ const Messages = ({
       )}
 
       <SourcesSheet ref={sourcesSheetRef} />
-    </Reanimated.View>
+    </View>
   );
 };
 


### PR DESCRIPTION
## Problem

Opening a chat from the drawer search on Android flashed the message content through the transparent header: the header read correctly for a moment, then the content underneath bled over it, then it settled. Reported as "najpierw prawidłowo widać header, później znowu miga i finalnie widać go stabilnie".

## Cause

The chat route uses `headerTransparent: true`, so messages scroll *under* the header and `TopFade` is the mask that hides them. `Messages` reveals itself with a 200 ms `opacity` 0 → 1 animation — and `TopFade` was rendered **inside** that fading container.

So the mask was not missing, it was **translucent**: for the first ~120 ms it sat at 18–88 % opacity while the content it must hide was already painted. Instrumented release build on a Galaxy S20 FE:

```
[FLK] render hasMessages=true   t=1786650902725   ← mask mounts, on time
[FLK] reveal start dur=200      t=1786650902878
[FLK] opacity=0.18              t=1786650902960
[FLK] opacity=0.51              t=1786650903002
[FLK] opacity=0.88              t=1786650903052
```

That also explains why the bug does not reproduce when picking a chat from the plain drawer list — that path does not restart the reveal animation.

## Fix

Only the scroll view fades now. `TopFade`, the bottom fade, the scroll-to-bottom button and `SourcesSheet` moved into a plain `View` above it, so the mask is fully opaque from its first frame while the messages still fade in.

## Verification

- `yarn test` — 802/802
- `npx tsc --noEmit` — no new errors (remaining ones are pre-existing, all in `__tests__`)
- release build installed on a physical Galaxy S20 FE

🤖 Generated with [Claude Code](https://claude.com/claude-code)