### PR TITLE
fix(chat): cut a reply that collapsed into a repeated clause (#255)

### DIFF
--- a/__tests__/llmStore.test.ts
+++ b/__tests__/llmStore.test.ts
@@ -447,6 +447,27 @@ describe('sendChatMessage', () => {
     expect(mockPersistMessage).not.toHaveBeenCalled();
   });
 
+  it('cuts a reply that collapsed into a repeated clause before persisting it (#255)', async () => {
+    mockInstance.generate.mockResolvedValue(
+      'Czapka kosztuje 45 zł. Czapka kosztuje 45 zł. Czapka kosztuje 45 zł. Czapka kosztuje 45 zł.'
+    );
+    useLLMStore.setState({
+      model: baseModel,
+      activeChatId: 1,
+      activeChatMessages: [],
+    });
+
+    await useLLMStore
+      .getState()
+      .sendChatMessage('ile kosztuje czapka?', 1, noSources, settings);
+
+    const persisted = mockPersistMessage.mock.calls
+      .map((call) => call[1] as { role: string; content: string })
+      .find((message) => message.role === 'assistant');
+    expect(persisted?.content).toContain('45 zł');
+    expect(persisted?.content.split('Czapka kosztuje').length - 1).toBe(1);
+  });
+
   it('persists user message and assistant response', async () => {
     useLLMStore.setState({
       model: baseModel,

--- a/__tests__/loopDetection.test.ts
+++ b/__tests__/loopDetection.test.ts
@@ -1,0 +1,213 @@
+import { truncateAtRepeatedClause } from '../utils/loopDetection';
+
+describe('truncateAtRepeatedClause', () => {
+  it('cuts the answer where a clause starts repeating back-to-back', () => {
+    const text =
+      'Najważniejsze wydarzenia na świecie w tym tygodniu obejmują: ' +
+      'wzrost wzajemnych wymagań w Wietnie, zwiększenie opadów deszczów w Wyspach, ' +
+      'wypadek w Szwecji, wypadek w Szwecji, a także wypadek w Szwecji.';
+    const result = truncateAtRepeatedClause(text);
+    expect(result).not.toContain('wypadek w Szwecji, wypadek w Szwecji');
+    expect(result.endsWith('opadów deszczów w Wyspach,')).toBe(true);
+  });
+
+  it('leaves normal prose with no repeated clause untouched', () => {
+    const text =
+      'Cena bitcoina to $64,146.36, a cena ethereum to $1,899.62. ' +
+      'Bitcoin zyskał więcej procentowo w tym miesiącu.';
+    expect(truncateAtRepeatedClause(text)).toBe(text);
+  });
+
+  it('does not flag two different clauses that merely share a short prefix', () => {
+    const text =
+      'Zwiększ aktywność fizyczną każdego dnia, zmniejsz spożycie cukru w diecie.';
+    expect(truncateAtRepeatedClause(text)).toBe(text);
+  });
+
+  it('does not flag short clauses below the minimum length', () => {
+    const text = 'Nie, nie, to nieprawda.';
+    expect(truncateAtRepeatedClause(text)).toBe(text);
+  });
+
+  it('tolerates the same fact restated later in different wording', () => {
+    const text =
+      'Cena bitcoina to $64,146.36. Podsumowując, aktualna cena bitcoina wynosi $64,146.36.';
+    expect(truncateAtRepeatedClause(text)).toBe(text);
+  });
+
+  it('catches a loop across newline-separated list items', () => {
+    const text =
+      'Podsumowanie:\n' +
+      'Wzrost cen paliw w regionie,\n' +
+      'Wzrost cen paliw w regionie,\n' +
+      'Nowe informacje wkrótce.';
+    const result = truncateAtRepeatedClause(text);
+    expect(result).toBe('Podsumowanie:');
+  });
+
+  it('cuts a padded list where whole items come back later, keeping the distinct ones (live-found)', () => {
+    const text =
+      'Oto lista 6 rzeczy, które powinieneś zabrać na tygodniowy wyjazd do Londynu:\n' +
+      '1. Paliwo – wymagane do podróży.\n' +
+      '2. Ochłonienie – np. kawa, herbatka, czekolada.\n' +
+      '3. Oświetlenie – np. lampa, lampka, kajuta.\n' +
+      '4. Ogół – np. lód, krem, krem na twarz.\n' +
+      '5. Oświetlenie – np. lampa, lampka, kajuta.\n' +
+      '6. Ochłonienie – np. kawa, herbatka, czekolada.';
+    const result = truncateAtRepeatedClause(text);
+    expect(result).toContain('1. Paliwo');
+    expect(result).toContain('2. Ochłonienie');
+    expect(result).toContain('3. Oświetlenie');
+    expect(result).toContain('4. Ogół');
+    expect(result).not.toContain('5. Oświetlenie');
+    expect(result).not.toContain('6. Ochłonienie');
+  });
+
+  it('does not cut an answer that merely names the same thing twice (live-found regression)', () => {
+    const text =
+      'To bake a chocolate cake, you need flour, sugar, cocoa powder, eggs, milk, and baking powder.\n' +
+      '1. Sift the flour and the cocoa powder into a bowl.\n' +
+      '2. Add the sugar and the baking powder, then mix.\n' +
+      '3. Beat in the eggs and the milk until smooth.\n' +
+      '4. Bake for 30 minutes and let it cool before serving.';
+    expect(truncateAtRepeatedClause(text)).toBe(text);
+  });
+
+  it('needs a third occurrence before a repeated clause counts as a loop', () => {
+    const twice =
+      'Rynek krypto zachowuje się dziś stabilnie. Cena bitcoina wynosi dzisiaj 64146 dolarów. ' +
+      'Ethereum zyskało więcej w tym miesiącu. Cena bitcoina wynosi dzisiaj 64146 dolarów.';
+    expect(truncateAtRepeatedClause(twice)).toBe(twice);
+
+    const thrice = `${twice} Rynek jest spokojny. Cena bitcoina wynosi dzisiaj 64146 dolarów.`;
+    const result = truncateAtRepeatedClause(thrice);
+    expect(result.match(/Cena bitcoina/g)).toHaveLength(1);
+    expect(result).toContain('Ethereum zyskało');
+    expect(result).not.toContain('Rynek jest spokojny');
+  });
+
+  it('cuts where the repetition starts, not where the content was first said', () => {
+    const text =
+      'Alfa to pierwszy istotny punkt tej odpowiedzi.\n' +
+      'Beta to drugi istotny punkt tej odpowiedzi.\n' +
+      'Gamma to trzeci istotny punkt tej odpowiedzi.\n' +
+      'Delta to czwarty istotny punkt tej odpowiedzi.\n' +
+      'Gamma to trzeci istotny punkt tej odpowiedzi.\n' +
+      'Alfa to pierwszy istotny punkt tej odpowiedzi.';
+    const result = truncateAtRepeatedClause(text);
+    expect(result).toContain('Alfa to pierwszy');
+    expect(result).toContain('Delta to czwarty');
+    expect(result.match(/Alfa to pierwszy/g)).toHaveLength(1);
+    expect(result.match(/Gamma to trzeci/g)).toHaveLength(1);
+  });
+
+  it('does not flag a list of genuinely distinct items with no duplicates', () => {
+    const text =
+      'Rzeczy do spakowania:\n' +
+      '1. Paszport i dokumenty podróży.\n' +
+      '2. Ładowarka do telefonu i powerbank.\n' +
+      '3. Wygodne buty na długie spacery.\n' +
+      '4. Lekka kurtka na chłodniejsze wieczory.';
+    expect(truncateAtRepeatedClause(text)).toBe(text);
+  });
+
+  it('does not flag two list items restating the same idea in different wording', () => {
+    const text =
+      '1. Zabierz ciepłą kurtkę na wieczory.\n' +
+      '2. Pamiętaj o cieplejszym okryciu, gdy zrobi się chłodniej wieczorem.';
+    expect(truncateAtRepeatedClause(text)).toBe(text);
+  });
+
+  it('catches a loop across numbered list items whose marker resets clause memory (F22)', () => {
+    const text =
+      'Dokonał wielu reform, w tym:\n' +
+      '1. **Reforma administracyjna** – zainicjował nowy podział kraju na województwa.\n' +
+      '2. **Reforma administracyjna** – zainicjował nowy podział kraju na województwa.\n' +
+      '3. **Reforma administracyjna** – zainicjował nowy podział kraju na województwa.';
+    const result = truncateAtRepeatedClause(text);
+    expect(result).not.toContain('2. **Reforma administracyjna**');
+    expect(result).not.toContain('3. **Reforma administracyjna**');
+    expect(result).toBe('Dokonał wielu reform, w tym:');
+  });
+
+  it('catches a loop across numbered list items containing an internal comma (F23)', () => {
+    const text =
+      'Dokonał wielu ważnych działań i reform. W tym zakresie:\n' +
+      '1. **Dokonał reform w systemie polskiego rządu** – zbudował system rządu, który był bardziej centralny i efektywny.\n' +
+      '2. **Dokonał reform w systemie polskiego rządu** – zbudował system rządu, który był bardziej centralny i efektywny.\n' +
+      '3. **Dokonał reform w systemie polskiego rządu** – zbudował system rządu, który był bardziej centralny i efektywny.\n\n' +
+      'Wszystkie te działania przyczyniły się do rozwoju.';
+    const result = truncateAtRepeatedClause(text);
+    expect(result).not.toContain('2. **Dokonał reform');
+    expect(result).not.toContain('3. **Dokonał reform');
+    expect(result.endsWith('W tym zakresie:')).toBe(true);
+  });
+
+  it('catches a cycling rotation of several different short clauses, not just an exact repeat (F24)', () => {
+    const text =
+      'Kameralar (Kimlik Kartı) genellikle resmi hizmetlerde bulunur: ' +
+      'devlet merkezleri, kaza hizmetleri, sosyal güvenlik, sağlık hizmetleri, ' +
+      'itibarlı kurumlar, kaza hizmetleri, sosyal güvenlik, sağlık hizmetleri, ' +
+      'itibarlı kurumlar, kaza hizmetleri, sosyal güvenlik, sağlık hizmetleri, ' +
+      'itibarlı kurumlar.';
+    const result = truncateAtRepeatedClause(text);
+    const secondCycleStart = result.indexOf(
+      'kaza hizmetleri, sosyal güvenlik, sağlık hizmetleri, itibarlı kurumlar, kaza'
+    );
+    expect(secondCycleStart).toBe(-1);
+    expect(result.endsWith('devlet merkezleri,')).toBe(true);
+  });
+
+  it('returns the original text unchanged when nothing repeats', () => {
+    const text = 'To jest krótka, normalna odpowiedź bez powtórzeń.';
+    expect(truncateAtRepeatedClause(text)).toBe(text);
+  });
+
+  it('cuts a single word looping with no punctuation between copies (F4)', () => {
+    const text =
+      'Zalecana dawka to witamina D w formie dostosowanego ' +
+      'dostosowanego dostosowanego dostosowanego dostosowanego dostosowanego.';
+    const result = truncateAtRepeatedClause(text);
+    expect(result).not.toContain('dostosowanego dostosowanego');
+    expect(result.endsWith('w formie')).toBe(true);
+  });
+
+  it('does not flag a word repeated only twice or three times', () => {
+    const text = 'Bardzo bardzo bardzo lubię tę odpowiedź.';
+    expect(truncateAtRepeatedClause(text)).toBe(text);
+  });
+
+  it('does not flag short connector words repeated across normal prose', () => {
+    const text =
+      'Dawka zależy od wieku, a wiek to jeden z wielu czynników w tej sprawie.';
+    expect(truncateAtRepeatedClause(text)).toBe(text);
+  });
+
+  it('cuts a multi-word phrase looping with no punctuation between copies (F10)', () => {
+    const text =
+      'Odpowiedź brzmi: bardzo dobrze bardzo dobrze bardzo dobrze bardzo dobrze.';
+    const result = truncateAtRepeatedClause(text);
+    expect(result).not.toContain('bardzo dobrze bardzo dobrze');
+    expect(result.endsWith('Odpowiedź brzmi:')).toBe(true);
+  });
+
+  it('cuts a three-word phrase looping with no punctuation between copies', () => {
+    const text =
+      'Wynik to: na pewno tak na pewno tak na pewno tak na pewno tak.';
+    const result = truncateAtRepeatedClause(text);
+    expect(result).not.toContain('na pewno tak na pewno tak');
+    expect(result.endsWith('Wynik to:')).toBe(true);
+  });
+
+  it('does not flag a short two-word phrase repeated only twice', () => {
+    const text = 'Bardzo dobrze bardzo dobrze to naprawdę świetna wiadomość.';
+    expect(truncateAtRepeatedClause(text)).toBe(text);
+  });
+
+  it('does not flag common short connector phrases reused across normal prose', () => {
+    const text =
+      'Tak jak wspomniano wcześniej, tak jak w poprzednim akapicie, dawka ' +
+      'zależy od wieku pacjenta i tak jak zawsze warto skonsultować się z lekarzem.';
+    expect(truncateAtRepeatedClause(text)).toBe(text);
+  });
+});

--- a/__tests__/loopTruncationKeepsAnswer.test.ts
+++ b/__tests__/loopTruncationKeepsAnswer.test.ts
@@ -1,0 +1,41 @@
+import { truncateAtRepeatedClause } from '../utils/loopDetection';
+
+// Measured on device: asked what a PlayStation Plus subscription costs, the
+// model produced one correct sentence and then repeated it. Truncation returned
+// an empty string, llmStore saw no response, and the user got
+// "Failed to generate a response" — the usable sentence was thrown away.
+describe('truncation never destroys the whole answer', () => {
+  const SENTENCE =
+    'Nie jest możliwe podanie ostatecznej ceny abonamentu, ponieważ źródła prezentują różne opcje.';
+
+  it('keeps one copy when the model says the same sentence twice', () => {
+    const out = truncateAtRepeatedClause(`${SENTENCE}\n\n${SENTENCE}`);
+    expect(out.trim().length).toBeGreaterThan(0);
+    expect(out).toContain('Nie jest możliwe podanie ostatecznej ceny');
+    // and only one copy of it
+    expect(out.split('ostatecznej ceny').length - 1).toBe(1);
+  });
+
+  it('keeps the content that follows a repeated word run', () => {
+    const out = truncateAtRepeatedClause('Cena Cena Cena Cena wynosi 100 zł.');
+    expect(out.trim().length).toBeGreaterThan(0);
+  });
+
+  it('still cuts a tail that repeats after real content', () => {
+    const out = truncateAtRepeatedClause(
+      `Bilet kosztuje 45 zł.\n${SENTENCE}\n${SENTENCE}`
+    );
+    expect(out).toContain('45 zł');
+    expect(out.split('ostatecznej ceny').length - 1).toBeLessThanOrEqual(1);
+  });
+
+  it('leaves text without repetition untouched', () => {
+    const clean = 'Bilet normalny kosztuje 45 zł, a ulgowy 30 zł.';
+    expect(truncateAtRepeatedClause(clean)).toBe(clean);
+  });
+
+  it('returns empty only for input that was empty', () => {
+    expect(truncateAtRepeatedClause('')).toBe('');
+    expect(truncateAtRepeatedClause('   ').trim()).toBe('');
+  });
+});

--- a/store/llmStore.ts
+++ b/store/llmStore.ts
@@ -22,6 +22,7 @@ import {
 } from '../utils/messageSources';
 import { useSettingsStore } from './settingsStore';
 import { getGenerationConfigForModel } from '../constants/default-models';
+import { truncateAtRepeatedClause } from '../utils/loopDetection';
 
 export interface LLMStore {
   isLoading: boolean;
@@ -628,8 +629,11 @@ export const useLLMStore = create<LLMStore>((set, get) => ({
 
       // Set generation state and generate response
       updateChatStateForGeneration(set, 'generating');
-      const { response: finalResponse, performance: responsePerformance } =
+      const { response: rawResponse, performance: responsePerformance } =
         await generateLLMResponse(messagesWithSystemPrompt, get);
+      const finalResponse = rawResponse
+        ? truncateAtRepeatedClause(rawResponse)
+        : rawResponse;
       // Handle successful response
       if (finalResponse) {
         const citedSourceDocuments = pickCitationsByAnswer(

--- a/utils/loopDetection.ts
+++ b/utils/loopDetection.ts
@@ -1,0 +1,213 @@
+const MIN_CLAUSE_CHARS = 12;
+const CLAUSE_SPLIT = /(?<=[,;.\n])/;
+const ALPHANUMERIC = /[\p{L}\p{N}]/u;
+const TRAILING_PUNCTUATION = /[,;.!?]+$/;
+
+const normalizeClause = (clause: string): string =>
+  clause.trim().replace(TRAILING_PUNCTUATION, '').toLowerCase();
+
+const MAX_CLAUSE_CYCLE = 6;
+const CLAUSE_CYCLE_REPEATS = 2;
+const CLAUSE_REPEAT_LIMIT = 3;
+const LINE_REPEAT_LIMIT = 2;
+
+const secondOccurrences = (
+  units: { norm: string; start: number }[],
+  limit: number
+): number | null => {
+  const starts = new Map<string, number[]>();
+  for (const { norm, start } of units) {
+    const seen = starts.get(norm);
+    if (seen) seen.push(start);
+    else starts.set(norm, [start]);
+  }
+  let cut: number | null = null;
+  for (const occurrences of starts.values()) {
+    if (occurrences.length < limit) continue;
+    const repeat = occurrences[1]!;
+    if (cut === null || repeat < cut) cut = repeat;
+  }
+  return cut;
+};
+
+const findRepeatedClauseCut = (text: string): number | null => {
+  const clauses = text.split(CLAUSE_SPLIT);
+  const substantial: { norm: string; start: number }[] = [];
+  let cursor = 0;
+
+  for (const clause of clauses) {
+    const start = cursor;
+    cursor += clause.length;
+
+    const norm = normalizeClause(clause);
+    if (norm.length >= MIN_CLAUSE_CHARS && ALPHANUMERIC.test(norm)) {
+      substantial.push({ norm, start });
+    }
+  }
+
+  let earliestCut: number | null = null;
+  for (let period = 1; period <= MAX_CLAUSE_CYCLE; period++) {
+    const span = period * CLAUSE_CYCLE_REPEATS;
+    for (let i = 0; i + span <= substantial.length; i++) {
+      if (earliestCut !== null && substantial[i]!.start >= earliestCut) break;
+      let cycles = true;
+      for (let k = 0; k < period; k++) {
+        if (substantial[i + k]!.norm !== substantial[i + period + k]!.norm) {
+          cycles = false;
+          break;
+        }
+      }
+      if (cycles) {
+        earliestCut = substantial[i]!.start;
+        break;
+      }
+    }
+  }
+
+  const repeated = secondOccurrences(substantial, CLAUSE_REPEAT_LIMIT);
+  if (repeated !== null && (earliestCut === null || repeated < earliestCut)) {
+    earliestCut = repeated;
+  }
+
+  return earliestCut;
+};
+
+const MIN_LINE_CHARS = 12;
+const LIST_MARKER = /^\s*(?:\d+[.)]|[-*•])\s*/;
+
+const findRepeatedLineCut = (text: string): number | null => {
+  const lines = text.split('\n');
+  const substantial: { norm: string; start: number }[] = [];
+  let cursor = 0;
+  let previousNorm: string | null = null;
+  let previousStart = 0;
+  let adjacentCut: number | null = null;
+
+  for (const line of lines) {
+    const start = cursor;
+    cursor += line.length + 1;
+
+    const norm = normalizeClause(line.replace(LIST_MARKER, ''));
+    if (norm.length < MIN_LINE_CHARS || !ALPHANUMERIC.test(norm)) continue;
+
+    substantial.push({ norm, start });
+    if (adjacentCut === null && norm === previousNorm)
+      adjacentCut = previousStart;
+    previousNorm = norm;
+    previousStart = start;
+  }
+
+  const repeated = secondOccurrences(substantial, LINE_REPEAT_LIMIT);
+  if (adjacentCut === null) return repeated;
+  if (repeated === null) return adjacentCut;
+  return Math.min(adjacentCut, repeated);
+};
+
+const MIN_WORD_CHARS = 3;
+const WORD_REPEAT_THRESHOLD = 4;
+const WORD_SPLIT = /(\s+)/;
+const ONLY_WHITESPACE = /^\s*$/;
+
+const findRepeatedWordRun = (text: string): number | null => {
+  let cursor = 0;
+  let runStart = 0;
+  let runWord: string | null = null;
+  let runCount = 0;
+
+  for (const token of text.split(WORD_SPLIT)) {
+    if (!ONLY_WHITESPACE.test(token)) {
+      const norm = normalizeClause(token);
+      if (norm.length >= MIN_WORD_CHARS && ALPHANUMERIC.test(norm)) {
+        if (norm === runWord) {
+          runCount++;
+          if (runCount >= WORD_REPEAT_THRESHOLD) return runStart;
+        } else {
+          runWord = norm;
+          runCount = 1;
+          runStart = cursor;
+        }
+      } else {
+        runWord = null;
+        runCount = 0;
+      }
+    }
+    cursor += token.length;
+  }
+
+  return null;
+};
+
+const MAX_PHRASE_WORDS = 5;
+const PHRASE_REPEAT_THRESHOLD = 3;
+const MIN_PHRASE_CHARS = 8;
+
+const findRepeatedPhraseRun = (text: string): number | null => {
+  const words: { norm: string; start: number }[] = [];
+  let cursor = 0;
+  for (const token of text.split(WORD_SPLIT)) {
+    if (!ONLY_WHITESPACE.test(token)) {
+      const norm = normalizeClause(token);
+      if (norm.length > 0 && ALPHANUMERIC.test(norm)) {
+        words.push({ norm, start: cursor });
+      }
+    }
+    cursor += token.length;
+  }
+
+  const windowEquals = (a: number, b: number, len: number): boolean => {
+    for (let k = 0; k < len; k++) {
+      if (words[a + k]!.norm !== words[b + k]!.norm) return false;
+    }
+    return true;
+  };
+  const phraseChars = (start: number, len: number): number =>
+    words.slice(start, start + len).reduce((sum, w) => sum + w.norm.length, 0);
+
+  let earliestCut: number | null = null;
+  for (let phraseLen = 2; phraseLen <= MAX_PHRASE_WORDS; phraseLen++) {
+    let i = 0;
+    while (i + phraseLen * PHRASE_REPEAT_THRESHOLD <= words.length) {
+      if (phraseChars(i, phraseLen) < MIN_PHRASE_CHARS) {
+        i++;
+        continue;
+      }
+      let repeats = 1;
+      while (
+        i + (repeats + 1) * phraseLen <= words.length &&
+        windowEquals(i, i + repeats * phraseLen, phraseLen)
+      ) {
+        repeats++;
+      }
+      if (repeats >= PHRASE_REPEAT_THRESHOLD) {
+        const cut = words[i]!.start;
+        if (earliestCut === null || cut < earliestCut) earliestCut = cut;
+        i += repeats * phraseLen;
+      } else {
+        i++;
+      }
+    }
+  }
+
+  return earliestCut;
+};
+
+const SALVAGE_UNIT = /[^.!?\n。！？।॥۔؟]+(?:[.!?\n。！？।॥۔؟]+|$)/;
+
+const salvageFirstUnit = (text: string): string => {
+  const sentence = text.trim().match(SALVAGE_UNIT)?.[0]?.trim();
+  if (sentence) return sentence;
+  return text.trim();
+};
+
+export const truncateAtRepeatedClause = (text: string): string => {
+  const cuts = [
+    findRepeatedClauseCut(text),
+    findRepeatedLineCut(text),
+    findRepeatedWordRun(text),
+    findRepeatedPhraseRun(text),
+  ].filter((cut): cut is number => cut !== null);
+  if (cuts.length === 0) return text;
+  const kept = text.slice(0, Math.min(...cuts)).trimEnd();
+  if (kept.trim()) return kept;
+  return text.trim() ? salvageFirstUnit(text) : kept;
+};


### PR DESCRIPTION
## Problem

#289 reverted the blanket `repetitionPenalty` from #258: ExecuTorch applies the penalty over the whole prompt with no sliding window, so retrieved context suppressed its own words and grounded answers turned to gibberish (2/2 in a controlled A/B). That reopened #255 — a small quantized model can still collapse into `czapki, czapki, czapki…` and run until the token limit.

## Fix

A guard on the finished text instead of on sampling: `truncateAtRepeatedClause` cuts at the first repetition it can prove (a cycle of up to six clauses repeated twice, one clause three times, a line twice, a word four times in a row, a phrase of up to five words three times). If the cut would eat the whole reply, the first sentence is kept. It reads repetition, not words, so it holds in every language.

Wired at the one place `sendChatMessage` finalizes the reply on `main`.

## Evidence

Qwen 3 1.7B, 259 stored answers: three of the four longest replies were loops this cuts. The remaining cost is time — the loop has already run before it is cut; stopping generation mid-stream on a detected cycle is the follow-up.

## Provenance

The same guard has been running on the `web-search-compact` branch since 2026-08-21 (`a3f64af`). It is extracted here so it can be reviewed and land on its own; once this merges, that branch's diff against `main` no longer carries it. Device testing of `web-search-compact` treats loop-guard behaviour as out of scope for that branch.

## Tests

- `__tests__/loopDetection.test.ts`, `__tests__/loopTruncationKeepsAnswer.test.ts` — the guard's rules and the "never destroy the whole answer" invariant
- `__tests__/llmStore.test.ts` — a reply that repeats one clause four times is persisted with one copy (red without the wiring)
