### PR TITLE
feat(web): default web search off for a model too small to have been measured

### DIFF
--- a/__tests__/chatScreenWebSearchState.test.ts
+++ b/__tests__/chatScreenWebSearchState.test.ts
@@ -1,0 +1,99 @@
+import { renderHook } from '@testing-library/react-native';
+
+const mockToast = jest.fn();
+jest.mock('react-native-toast-message', () => ({
+  show: (...args: unknown[]) => mockToast(...args),
+}));
+jest.mock('../store/chatStore', () => ({
+  useChatStore: () => ({
+    phantomChat: null,
+    setPhantomChatSettings: jest.fn(),
+  }),
+}));
+jest.mock('../store/llmStore', () => ({
+  useLLMStore: () => ({ model: null, loadModel: jest.fn() }),
+}));
+jest.mock('../store/modelStore', () => ({
+  useModelStore: () => ({ getModelById: jest.fn() }),
+}));
+jest.mock('../database/chatRepository', () => ({
+  checkIfChatExists: jest.fn(),
+  setChatSettings: jest.fn(),
+}));
+jest.mock('../utils/modelCompatibility', () => ({
+  hasMemoryForWebSearch: () => true,
+}));
+
+import { useChatScreenActions } from '../components/chat-screen/useChatScreenActions';
+import type { Model } from '../database/modelRepository';
+
+const modelNamed = (modelName: string, parameters: number): Model =>
+  ({
+    id: 1,
+    modelName,
+    parameters,
+    source: 'built-in',
+    isDownloaded: true,
+    modelPath: '',
+    tokenizerPath: '',
+    tokenizerConfigPath: '',
+  }) as Model;
+
+const setSetting = jest.fn();
+
+const actionsFor = (model: Model, webSearchEnabled: boolean) =>
+  renderHook(() =>
+    useChatScreenActions({
+      chatId: 1,
+      chat: undefined,
+      model,
+      chatSettings: {
+        systemPrompt: '',
+        thinkingEnabled: false,
+        webSearchEnabled,
+      },
+      setSetting,
+      db: {} as never,
+      inputRef: { current: null },
+    })
+  ).result.current;
+
+describe('web search state follows the model that has to run it', () => {
+  beforeEach(() => {
+    setSetting.mockClear();
+    mockToast.mockClear();
+  });
+
+  it('reads as off once the chat moves to a model that cannot search', () => {
+    const actions = actionsFor(modelNamed('Qwen 2.5 - 0.5B', 0.49), true);
+    expect(actions.webSearchEnabled).toBe(false);
+  });
+
+  it('reads as on for a model that can', () => {
+    const actions = actionsFor(modelNamed('Qwen 3 - 1.7B', 2.03), true);
+    expect(actions.webSearchEnabled).toBe(true);
+  });
+
+  it('explains itself instead of silently clearing the setting', () => {
+    const actions = actionsFor(modelNamed('Qwen 2.5 - 0.5B', 0.49), true);
+
+    expect(actions.handleWebSearchToggle()).toBe(false);
+    expect(setSetting).not.toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalled();
+  });
+
+  it('keeps the setting, so going back to a capable model restores it', () => {
+    const gated = actionsFor(modelNamed('Qwen 2.5 - 0.5B', 0.49), true);
+    gated.handleWebSearchToggle();
+
+    const capable = actionsFor(modelNamed('Qwen 3 - 1.7B', 2.03), true);
+    expect(capable.webSearchEnabled).toBe(true);
+  });
+
+  it('still turns off on demand for a model that can search', () => {
+    const actions = actionsFor(modelNamed('Qwen 3 - 1.7B', 2.03), true);
+
+    expect(actions.handleWebSearchToggle()).toBe(true);
+    expect(setSetting).toHaveBeenCalledWith('webSearchEnabled', false);
+  });
+});

--- a/__tests__/modelProfiles.test.ts
+++ b/__tests__/modelProfiles.test.ts
@@ -6,6 +6,7 @@ import {
   PROFILE_BY_MODEL,
   WEB_ANSWER_EVIDENCE,
   WEB_PLANNER_MATRIX,
+  WEB_SEARCH_MIN_PARAMETERS_B,
   getModelProfile,
   getWebSearchMinDeviceMemoryGB,
   isWebSearchReady,
@@ -159,6 +160,61 @@ describe('web search memory requirement', () => {
     for (const [name, profile] of Object.entries(PROFILE_BY_MODEL)) {
       if (profile.webSearchMinDeviceMemoryGB === undefined) continue;
       expect(catalogue.has(name)).toBe(true);
+    }
+  });
+});
+
+describe('web search capability floor', () => {
+  it('turns web search off for an uncatalogued model below the floor', () => {
+    expect(
+      isWebSearchReady({ modelName: 'Tiny Import - 300M', parameters: 0.3 })
+    ).toBe(false);
+  });
+
+  it('leaves an uncatalogued model at the floor enabled', () => {
+    expect(
+      isWebSearchReady({
+        modelName: 'Small Import - 700M',
+        parameters: WEB_SEARCH_MIN_PARAMETERS_B,
+      })
+    ).toBe(true);
+  });
+
+  it('leaves a model of unknown size enabled, having no evidence either way', () => {
+    expect(isWebSearchReady({ modelName: 'Unlabelled Import' })).toBe(true);
+  });
+
+  it('admits the smallest catalogued model the corpus scored as usable', () => {
+    const qwen3 = DEFAULT_MODELS.find(
+      (model) => model.modelName === 'Qwen 3 - 0.6B'
+    );
+    expect(qwen3?.parameters).toBeGreaterThanOrEqual(
+      WEB_SEARCH_MIN_PARAMETERS_B
+    );
+    expect(isWebSearchReady(qwen3!)).toBe(true);
+  });
+
+  it('leaves every catalogued verdict exactly where its evidence put it', () => {
+    const gated = DEFAULT_MODELS.filter((model) => !isWebSearchReady(model))
+      .map((model) => model.modelName)
+      .sort();
+    expect(gated).toEqual(
+      [
+        'LFM 2.5 VL - 450M',
+        'Qwen 2.5 - 0.5B',
+        'Qwen 2.5 - 1.5B',
+        'Qwen 2.5 - 3B',
+      ].sort()
+    );
+  });
+
+  it('never gates a catalogued model without recording why', () => {
+    for (const model of DEFAULT_MODELS) {
+      if (isWebSearchReady(model)) continue;
+      expect(
+        WEB_ANSWER_EVIDENCE[model.modelName] ??
+          PLANNER_EVIDENCE[model.modelName]
+      ).toBeDefined();
     }
   });
 });

--- a/components/chat-screen/ChatScreen.tsx
+++ b/components/chat-screen/ChatScreen.tsx
@@ -211,16 +211,20 @@ export default function ChatScreen({
     isSwitching,
   });
 
-  const { handleThinkingToggle, handleWebSearchToggle, handleSelectPrompt } =
-    useChatScreenActions({
-      chatId,
-      chat,
-      model,
-      chatSettings,
-      setSetting,
-      db,
-      inputRef,
-    });
+  const {
+    handleThinkingToggle,
+    handleWebSearchToggle,
+    handleSelectPrompt,
+    webSearchEnabled,
+  } = useChatScreenActions({
+    chatId,
+    chat,
+    model,
+    chatSettings,
+    setSetting,
+    db,
+    inputRef,
+  });
 
   const chatGenerationError =
     generationError?.chatId === chatId ? generationError.message : undefined;
@@ -288,7 +292,7 @@ export default function ChatScreen({
           extraContentPadding={extraContentPadding}
           thinkingEnabled={chatSettings?.thinkingEnabled || false}
           onThinkingToggle={handleThinkingToggle}
-          webSearchEnabled={chatSettings?.webSearchEnabled || false}
+          webSearchEnabled={webSearchEnabled}
           onWebSearchToggle={
             WEB_SEARCH_ENABLED ? handleWebSearchToggle : undefined
           }

--- a/components/chat-screen/useChatScreenActions.ts
+++ b/components/chat-screen/useChatScreenActions.ts
@@ -80,8 +80,12 @@ export const useChatScreenActions = ({
     }
   };
 
+  const webSearchUsable =
+    isWebSearchReady(model) && hasMemoryForWebSearch(model);
+  const webSearchEnabled = chatSettings.webSearchEnabled && webSearchUsable;
+
   const handleWebSearchToggle = (): boolean => {
-    if (!chatSettings.webSearchEnabled && !isWebSearchReady(model)) {
+    if (!webSearchEnabled && !isWebSearchReady(model)) {
       Toast.show({
         type: 'defaultToast',
         text1:
@@ -89,7 +93,7 @@ export const useChatScreenActions = ({
       });
       return false;
     }
-    if (!chatSettings.webSearchEnabled && !hasMemoryForWebSearch(model)) {
+    if (!webSearchEnabled && !hasMemoryForWebSearch(model)) {
       Toast.show({
         type: 'defaultToast',
         text1: `${model?.modelName ?? 'This model'} already fills this phone's memory — searching alongside it would close the app. Pick a smaller model.`,
@@ -117,5 +121,10 @@ export const useChatScreenActions = ({
     [model, loadedModel, loadModel, getModelById, chat?.modelId, inputRef]
   );
 
-  return { handleThinkingToggle, handleWebSearchToggle, handleSelectPrompt };
+  return {
+    handleThinkingToggle,
+    handleWebSearchToggle,
+    handleSelectPrompt,
+    webSearchEnabled,
+  };
 };

--- a/constants/model-profiles.ts
+++ b/constants/model-profiles.ts
@@ -141,7 +141,21 @@ export const PROFILE_BY_MODEL: Record<string, Partial<ModelProfile>> = {
   'LLaMA 3.2 - 3B - SpinQuant': { webSearchMinDeviceMemoryGB: 8 },
 };
 
-export type ProfileTarget = Pick<Model, 'modelName' | 'family'>;
+export const WEB_SEARCH_MIN_PARAMETERS_B = 0.7;
+
+export type ProfileTarget = Pick<Model, 'modelName' | 'family' | 'parameters'>;
+
+const declaresWebSearchReady = (modelName: string, family: string): boolean =>
+  PROFILE_BY_MODEL[modelName]?.webSearchReady !== undefined ||
+  PROFILE_BY_FAMILY[family]?.webSearchReady !== undefined;
+
+const isBelowWebSearchCapabilityFloor = (
+  model: ProfileTarget,
+  family: string
+): boolean =>
+  !declaresWebSearchReady(model.modelName, family) &&
+  model.parameters !== undefined &&
+  model.parameters < WEB_SEARCH_MIN_PARAMETERS_B;
 
 export const getModelProfile = (
   model: ProfileTarget | null | undefined
@@ -154,6 +168,9 @@ export const getModelProfile = (
     ...(planner ? { webPlanner: planner } : {}),
     ...(PROFILE_BY_FAMILY[family] ?? {}),
     ...(PROFILE_BY_MODEL[model.modelName] ?? {}),
+    ...(isBelowWebSearchCapabilityFloor(model, family)
+      ? { webSearchReady: false }
+      : {}),
   };
   const reserveIsExplicit =
     PROFILE_BY_MODEL[model.modelName]?.generationReserveTokens !== undefined ||


### PR DESCRIPTION
## What

Two changes, both about the same gap: nothing stopped web search from being offered on a model that cannot use it.

1. **A capability floor for unmeasured models.** `PROFILE_BY_MODEL` decides readiness only for the models the cross-model pass actually ran. Everything else — a future catalogue entry, a remote-manifest entry, a model the user imports — falls through to `DEFAULT_PROFILE`, where `webSearchReady` is `true`. `WEB_SEARCH_MIN_PARAMETERS_B = 0.7` gates a model that is both below the floor **and** has no explicit `webSearchReady`. An explicit entry still wins, so a small model that grounds well can be admitted by name; a model of unknown size is left enabled rather than guessed at.

2. **The toggle now reads what the send will actually do.** `ChatScreen` passes `chatSettings.webSearchEnabled && webSearchUsable` to `ChatBar` instead of the raw setting. The stored setting is untouched, so it comes back when the user returns to a capable model.

## Why the number, and how much weight it carries

Parameter count is a proxy for the property we actually gate on, and not a good one. Two independent facts say so.

**The measurement.** A 56-turn pass over the English protocol scores the sub-1B group at 6/10 correct against 27/46 for everything at 1B and above — no difference. The best result relative to the context it was handed belongs to `Qwen 3 - 0.6B` (4/4); the worst belongs to `Gemma 4 - 2B` (0/2), a model 4.4x its size.

**The gate list is not sorted by size.** If size were what we gate on, it would be:

| model | parameters | gated | below the 0.7 floor |
|---|---|---|---|
| `LFM 2.5 VL - 450M` | 0.45 | yes | yes |
| `Qwen 2.5 - 0.5B` | 0.49 | yes | yes |
| `Qwen 2.5 - 1.5B` | 1.54 | yes | no |
| `Qwen 2.5 - 3B` | 3.09 | yes | no |
| `Qwen 3 - 0.6B` | 0.75 | no | no |
| `LFM 2.5 - 1.2B` | 1.20 | no | no |

Four models are gated; only two of them are below the floor. `Qwen 2.5 - 3B` is gated at 3.09B while `Qwen 3 - 0.6B` runs at 0.75B. What the four gated names have in common is an entry in `WEB_ANSWER_EVIDENCE`, not a size — `Qwen 2.5 - 0.5B` answered 33% correctly with retrieval at 100%, while `Qwen 3 - 0.6B` answered 71% on the same corpus.

So the floor is a default for the case where we have no evidence at all, not a claim that size predicts grounding.

## Effect today: none

No model in the app reaches the new branch.

- No catalogue model is below 0.7 without an explicit entry. The only candidate by name, `Qwen 3 - 0.6B`, is `parameters: 0.75` in `constants/default-models.ts` — above the floor.
- A user-imported model cannot reach it either: `app/(modals)/add-local-model.tsx` `handleSave` sets `modelName`, `source`, the three paths and `modelSize`, and never sets `parameters`. The floor requires `model.parameters !== undefined`.

The floor takes effect only for a future catalogue entry or a remote-manifest model from #299. Change 2, by contrast, changes behaviour now.

## What change 2 fixes

On `cr/phase1-security`, `ChatScreen` passes the raw setting. Switch from a capable model to a gated one with web search on and the toggle keeps showing on. The `modelSwitching` guard in `ChatBar.handleSend` only closes the loading window; after loading, the send goes through and the search is dropped silently in `useSendChatMessage` where `isWebSearchReady` enters the conjunction. The user sees an on toggle, sends, and gets an ungrounded answer with no explanation.

## Verified on a device

Samsung S20 FE (SM-G781B, Android 13), debug build over Metro, `projectRoot` confirmed as this worktree.

- Bielik v3.0, web search on → switch to `Qwen 2.5 - 0.5B` → wait for the load to finish → the toggle shows off **without being touched**.
- Tapping it then shows `This model cannot use web results reliably — pick a larger one` instead of enabling a search that would not run.
- Switching back to a capable model restores the toggle to on, so the setting was preserved rather than cleared.

The toggle reflects the previous model until `loadModel` resolves, because `selectModel` is awaited after it; sends are blocked by `modelSwitching` for that whole window.

## Tests

`__tests__/modelProfiles.test.ts` — an uncatalogued model below the floor is gated; at the floor is not; of unknown size is not; `Qwen 3 - 0.6B` stays above the floor and enabled; the catalogued gate list is exactly the four evidenced names; no catalogued model is gated without an entry in `WEB_ANSWER_EVIDENCE` or `PLANNER_EVIDENCE`.

`__tests__/chatScreenWebSearchState.test.ts` — the toggle reads off after moving to a gated model; reads on for a capable one; explains itself instead of clearing the setting; keeps the setting so returning restores it; still turns off on demand.

`tsc --noEmit` clean; `jest` green; eslint clean.
