### PR TITLE
fix(web): drop a digest that is the digest prompt's own example

### DIFF
--- a/__tests__/conversationDigest.test.ts
+++ b/__tests__/conversationDigest.test.ts
@@ -1,7 +1,7 @@
 import {
   buildDigestPrompt,
   DIGEST_MAX_CHARS,
-  echoesItsOwnPrompt,
+  looksLikePromptEcho,
   looksLikeAnswerEcho,
   stripMetaFrame,
   updateConversationDigest,
@@ -322,19 +322,19 @@ describe('a small model can hand back the prompt it was given', () => {
   const EXAMPLE = 'parzenie kawy w kawiarce, stopien zmielenia';
 
   it('recognises the example the prompt itself spells out', () => {
-    expect(echoesItsOwnPrompt(EXAMPLE)).toBe(true);
+    expect(looksLikePromptEcho(EXAMPLE)).toBe(true);
   });
 
   it('recognises a fragment of the instructions copied out verbatim', () => {
-    expect(echoesItsOwnPrompt('Output ONLY that phrase')).toBe(true);
+    expect(looksLikePromptEcho('Output ONLY that phrase')).toBe(true);
   });
 
   it('leaves a real topic alone', () => {
-    expect(echoesItsOwnPrompt('Warsaw weather tomorrow')).toBe(false);
+    expect(looksLikePromptEcho('Warsaw weather tomorrow')).toBe(false);
   });
 
   it('judges nothing on a single word, which could land anywhere', () => {
-    expect(echoesItsOwnPrompt('phrase')).toBe(false);
+    expect(looksLikePromptEcho('phrase')).toBe(false);
   });
 
   it('stores the question instead of the example it was shown', async () => {

--- a/__tests__/conversationDigest.test.ts
+++ b/__tests__/conversationDigest.test.ts
@@ -1,6 +1,7 @@
 import {
   buildDigestPrompt,
   DIGEST_MAX_CHARS,
+  echoesItsOwnPrompt,
   looksLikeAnswerEcho,
   stripMetaFrame,
   updateConversationDigest,
@@ -314,5 +315,47 @@ describe('the echo fallback must not throw away the subject (live-found)', () =>
       'A jaki ma aparat?'
     );
     expect(digest).toBe('A jaki ma aparat?');
+  });
+});
+
+describe('a small model can hand back the prompt it was given', () => {
+  const EXAMPLE = 'parzenie kawy w kawiarce, stopien zmielenia';
+
+  it('recognises the example the prompt itself spells out', () => {
+    expect(echoesItsOwnPrompt(EXAMPLE)).toBe(true);
+  });
+
+  it('recognises a fragment of the instructions copied out verbatim', () => {
+    expect(echoesItsOwnPrompt('Output ONLY that phrase')).toBe(true);
+  });
+
+  it('leaves a real topic alone', () => {
+    expect(echoesItsOwnPrompt('Warsaw weather tomorrow')).toBe(false);
+  });
+
+  it('judges nothing on a single word, which could land anywhere', () => {
+    expect(echoesItsOwnPrompt('phrase')).toBe(false);
+  });
+
+  it('stores the question instead of the example it was shown', async () => {
+    const digest = await updateConversationDigest(
+      jest.fn(async () => EXAMPLE),
+      null,
+      'What is the weather in Warsaw today?',
+      'Warsaw is 21°C and mostly sunny.'
+    );
+
+    expect(digest).toBe('What is the weather in Warsaw today?');
+  });
+
+  it('keeps a topic the model actually wrote', async () => {
+    const digest = await updateConversationDigest(
+      jest.fn(async () => 'Warsaw weather, today and tomorrow'),
+      null,
+      'What is the weather in Warsaw today?',
+      'Warsaw is 21°C and mostly sunny.'
+    );
+
+    expect(digest).toBe('Warsaw weather, today and tomorrow');
   });
 });

--- a/utils/conversationDigest.ts
+++ b/utils/conversationDigest.ts
@@ -98,6 +98,16 @@ const clampDigest = (text: string): string =>
     ? text
     : `${text.slice(0, DIGEST_MAX_CHARS).trimEnd()}…`;
 
+const PROMPT_ECHO_MIN_WORDS = 2;
+
+export const echoesItsOwnPrompt = (digest: string): boolean => {
+  const summary = normalizeForEcho(digest);
+  if (summary.split(' ').filter(Boolean).length < PROMPT_ECHO_MIN_WORDS) {
+    return false;
+  }
+  return normalizeForEcho(DIGEST_SYSTEM_PROMPT).includes(summary);
+};
+
 export const updateConversationDigest = async (
   generate: QueryRewriteFn,
   previousDigest: string | null,
@@ -111,8 +121,9 @@ export const updateConversationDigest = async (
     );
     const trimmed = visibleDigestText(raw);
     if (!trimmed) return previousDigest ?? '';
-    if (!looksLikeAnswerEcho(trimmed, answer)) {
-      return clampDigest(stripMetaFrame(trimmed));
+    const summary = clampDigest(stripMetaFrame(trimmed));
+    if (!looksLikeAnswerEcho(trimmed, answer) && !echoesItsOwnPrompt(summary)) {
+      return summary;
     }
     const fallback = clampDigest(question.trim());
     return keepsMoreSubject(previousDigest, fallback)

--- a/utils/conversationDigest.ts
+++ b/utils/conversationDigest.ts
@@ -75,6 +75,16 @@ export const looksLikeAnswerEcho = (
   );
 };
 
+const PROMPT_ECHO_MIN_WORDS = 2;
+
+export const looksLikePromptEcho = (digest: string): boolean => {
+  const summary = normalizeForEcho(digest);
+  if (summary.split(' ').filter(Boolean).length < PROMPT_ECHO_MIN_WORDS) {
+    return false;
+  }
+  return normalizeForEcho(DIGEST_SYSTEM_PROMPT).includes(summary);
+};
+
 const META_FRAME =
   /^\s*(?:the\s+)?(?:user|conversation|discussion|topic|assistant)\b[^.:]{0,60}?\b(?:is|was|are|about|asking|asks|wants|asked|discussing)\b[^.:]{0,30}?(?:about|is|:)\s*/i;
 const META_TAIL = /\s*(?:the\s+)?key entities?\b[^.]*\.?\s*$/i;
@@ -98,16 +108,6 @@ const clampDigest = (text: string): string =>
     ? text
     : `${text.slice(0, DIGEST_MAX_CHARS).trimEnd()}…`;
 
-const PROMPT_ECHO_MIN_WORDS = 2;
-
-export const echoesItsOwnPrompt = (digest: string): boolean => {
-  const summary = normalizeForEcho(digest);
-  if (summary.split(' ').filter(Boolean).length < PROMPT_ECHO_MIN_WORDS) {
-    return false;
-  }
-  return normalizeForEcho(DIGEST_SYSTEM_PROMPT).includes(summary);
-};
-
 export const updateConversationDigest = async (
   generate: QueryRewriteFn,
   previousDigest: string | null,
@@ -122,7 +122,10 @@ export const updateConversationDigest = async (
     const trimmed = visibleDigestText(raw);
     if (!trimmed) return previousDigest ?? '';
     const summary = clampDigest(stripMetaFrame(trimmed));
-    if (!looksLikeAnswerEcho(trimmed, answer) && !echoesItsOwnPrompt(summary)) {
+    if (
+      !looksLikeAnswerEcho(trimmed, answer) &&
+      !looksLikePromptEcho(summary)
+    ) {
       return summary;
     }
     const fallback = clampDigest(question.trim());


### PR DESCRIPTION
## What

`DIGEST_SYSTEM_PROMPT` shows the model what a topic phrase should look like by spelling one out: `parzenie kawy w kawiarce, stopien zmielenia`. Small models hand that example back as their answer. It is then stored as the chat's digest and framed into the planner prompt on every later turn.

A digest whose whole text appears in the prompt it was generated from is now discarded at the source, and the turn falls back to the question.

## Evidence

From the cross-model pass on the Pixel, all three in an **English** conversation whose previous turn was "What is the weather in Warsaw today?":

| model | `sourceQuery` recorded in the DB |
| --- | --- |
| Qwen 3 - 0.6B | `What about tomorrow? parzenie kawy w kawiarce, stopien zmielenia` |
| Bielik - v3.0 | `weather tomorrow Warsaw parzenie kawy w kawiarce, stopien zmielenia` |
| LFM 2.5 - 1.2B | same suffix; the answer then attributed a fabricated "rain today" to a source that was never read |

Qwen 3 - 0.6B's turn returned five live Polish coffee-brewing pages and cited one of them as a weather source. The compatibility round reads this as a cache or embedding collision; it is neither.

## The stored digest, on a second device

The evidence above is the digest leaking into a query. Pulling `executorch.db` off a Samsung S20 FE shows the value itself, sitting in `chatSettings.digest`:

| chat | digest |
| --- | --- |
| 31 | `parzenie kawy w kawiarce, stopien zmielenia` |
| 32 | `parzenie kawy w kawiarce, stopien zmielenia` |
| 33 | `gold price` |

Chat 31 is "Ile kosztuje Samsung Galaxy S25 w Polsce?" → "And how much is it in Germany?" → "Wie ist das Wetter heute in Berlin?" → "What did I ask about first?". Chat 32 opens the same way. Neither mentions coffee, grinding, or a moka pot anywhere. Chat 33 is a turn run on this branch — "What is the current price of gold per ounce in USD?" — and its digest is the topic, not the example.

Chat 31's last answer reads `The source that you are most likely to be referring to is thoughtcatalog.com: "400+ First Date Questions…"`. That is the kind of retrieval drift a poisoned digest would produce on a referent question, but no build writes the digest to a trace: `recordWebSearchTrace` stores `planQueries`, the planner's output, not its input. Recorded as consistent with the hypothesis, not as proof of it.

## Why the query path was not enough

`carryReferentIntoQuery` already refuses a digest that shares no content stems with the conversation, so the coffee phrase no longer reaches a query. The digest itself was never filtered: it still goes into `buildConversation` as `Conversation summary so far: …`, into `topicAnchorer`, and into `languageReferenceFor`. This closes it at the point where the bad value is created rather than at one of its readers.

## Why this shape and not the obvious one

The first attempt required a digest to share vocabulary with the exchange it summarises. It failed an existing test, and the test was right: a model may summarise a Polish exchange in English, and that digest is still good. Comparing the digest against the prompt instead has no such failure mode, and it generalises — any example or instruction fragment we ever put in that prompt is covered, in any language.

`looksLikePromptEcho` sits next to `looksLikeAnswerEcho`, which drops a digest that copies the model's own answer. Same defect, two sources; the two predicates read as a pair.

## Tests

Six cases in `__tests__/conversationDigest.test.ts`: the example is recognised, an instruction fragment copied verbatim is recognised, a real topic is left alone, a single word is never judged, the stored digest falls back to the question, and a topic the model actually wrote survives. The pre-existing case that keeps an English digest of a Polish exchange still passes.

`tsc --noEmit` clean; `jest` 132 suites / 2297 tests green; eslint no errors.

## Not in this PR

Removing the literal example from the prompt would delete the cause outright rather than filter its effect, which is the better shape. It also changes format compliance for every model and needs its own measurement, so it is left separate.

A third way into the digest stays open, and this PR does not narrow it: when the visible text is empty, `visibleDigestText` falls back to an **unterminated** `think` block and returns the model's internal reasoning as the topic, provided it fits `DIGEST_MAX_CHARS`. That is P1-10 in the code-review plan. The guard added here rejects a digest that copies the prompt; it does not reject one that copies the model's scratchpad.
