### PR TITLE
feat(web): answer a currency conversion from the ECB reference rate, not from a scraped page

### DIFF
--- a/__tests__/currencyQuote.test.ts
+++ b/__tests__/currencyQuote.test.ts
@@ -57,9 +57,25 @@ describe('reading a conversion out of a question, whatever language it is in', (
     });
   });
 
-  it('refuses a question that names a third currency, so a word like "try" cannot hijack it', () => {
+  it('ignores a lowercase word that happens to spell a currency code', () => {
+    expect(
+      readCurrencyRequest('Ron sent me 100 EUR, is that a lot?')
+    ).toBeUndefined();
+    expect(
+      readCurrencyRequest('How much should I try to save, 100 EUR?')
+    ).toBeUndefined();
     expect(
       readCurrencyRequest('Can you try to convert 100 USD to EUR?')
+    ).toEqual({ amount: 100, from: 'USD', to: 'EUR' });
+  });
+
+  it('gives up the fast path rather than guess at a code written in lowercase', () => {
+    expect(readCurrencyRequest('100 usd in eur')).toBeUndefined();
+  });
+
+  it('refuses a question that names a third currency', () => {
+    expect(
+      readCurrencyRequest('Convert 100 USD to EUR or GBP?')
     ).toBeUndefined();
   });
 

--- a/__tests__/currencyQuote.test.ts
+++ b/__tests__/currencyQuote.test.ts
@@ -1,0 +1,169 @@
+import {
+  parseAmount,
+  readCurrencyRequest,
+} from '../utils/web/resolvers/currencyRequest';
+import {
+  formatMoney,
+  resolveCurrencyQuote,
+} from '../utils/web/resolvers/currencyQuote';
+
+describe('reading a conversion out of a question, whatever language it is in', () => {
+  it('reads the same request from English, Polish, German and Hindi', () => {
+    const expected = { amount: 100, from: 'USD', to: 'EUR' };
+    expect(readCurrencyRequest('How much is 100 USD in EUR?')).toEqual(
+      expected
+    );
+    expect(readCurrencyRequest('Ile to jest 100 USD w EUR?')).toEqual(expected);
+    expect(readCurrencyRequest('Wie viel sind 100 USD in EUR?')).toEqual(
+      expected
+    );
+    expect(readCurrencyRequest('100 USD से EUR कितना है?')).toEqual(expected);
+  });
+
+  it('takes the currency the amount is attached to as the source, not the first one named', () => {
+    expect(readCurrencyRequest('How many EUR is 100 USD?')).toEqual({
+      amount: 100,
+      from: 'USD',
+      to: 'EUR',
+    });
+  });
+
+  it('accepts the amount on either side of the code', () => {
+    expect(readCurrencyRequest('USD 100 to EUR')).toEqual({
+      amount: 100,
+      from: 'USD',
+      to: 'EUR',
+    });
+  });
+
+  it('reads a symbol that can only mean one currency', () => {
+    expect(readCurrencyRequest('100 zł w EUR')).toEqual({
+      amount: 100,
+      from: 'PLN',
+      to: 'EUR',
+    });
+    expect(readCurrencyRequest('£50 in PLN')).toEqual({
+      amount: 50,
+      from: 'GBP',
+      to: 'PLN',
+    });
+  });
+
+  it('falls back to a rate for one unit when no amount is given', () => {
+    expect(readCurrencyRequest('USD EUR')).toEqual({
+      amount: 1,
+      from: 'USD',
+      to: 'EUR',
+    });
+  });
+
+  it('refuses a question that names a third currency, so a word like "try" cannot hijack it', () => {
+    expect(
+      readCurrencyRequest('Can you try to convert 100 USD to EUR?')
+    ).toBeUndefined();
+  });
+
+  it('refuses a question with fewer than two currencies', () => {
+    expect(readCurrencyRequest('How much is 100 USD?')).toBeUndefined();
+    expect(readCurrencyRequest('What is the weather today?')).toBeUndefined();
+    expect(readCurrencyRequest('Convert 100 USD into USD')).toBeUndefined();
+  });
+
+  it('does not read a code out of a longer word', () => {
+    expect(readCurrencyRequest('Is USDA part of EUR policy?')).toBeUndefined();
+    expect(readCurrencyRequest('USDA reports 100 USD in EUR')).toEqual({
+      amount: 100,
+      from: 'USD',
+      to: 'EUR',
+    });
+  });
+});
+
+describe('reading an amount written the way each locale writes it', () => {
+  it('treats a lone separator with three trailing digits as grouping', () => {
+    expect(parseAmount('1,500')).toBe(1500);
+    expect(parseAmount('1.500')).toBe(1500);
+  });
+
+  it('treats a lone separator with one or two trailing digits as a decimal point', () => {
+    expect(parseAmount('1,5')).toBe(1.5);
+    expect(parseAmount('1.75')).toBe(1.75);
+  });
+
+  it('takes the last separator as the decimal point when both appear', () => {
+    expect(parseAmount('1.234,56')).toBe(1234.56);
+    expect(parseAmount('1,234.56')).toBe(1234.56);
+  });
+
+  it('ignores spaces and apostrophes used as digit grouping', () => {
+    expect(parseAmount('1 234 567')).toBe(1234567);
+    expect(parseAmount("1'234'567")).toBe(1234567);
+  });
+
+  it('rejects an amount that is not a positive number', () => {
+    expect(parseAmount('0')).toBeUndefined();
+  });
+});
+
+describe('answering a conversion from the reference rate instead of a search page', () => {
+  const payload = JSON.stringify({
+    amount: 1,
+    base: 'USD',
+    date: '2026-09-09',
+    rates: { EUR: 0.85822 },
+  });
+
+  it('asks the rate service for exactly the pair the question named', async () => {
+    const fetchText = jest.fn().mockResolvedValue(payload);
+    await resolveCurrencyQuote('How much is 100 USD in EUR?', { fetchText });
+    expect(fetchText).toHaveBeenCalledWith(
+      'https://api.frankfurter.dev/v1/latest?base=USD&symbols=EUR'
+    );
+  });
+
+  it('states the converted amount, the unit rate and the day the rate is from', async () => {
+    const quote = await resolveCurrencyQuote('How much is 100 USD in EUR?', {
+      fetchText: () => Promise.resolve(payload),
+    });
+    expect(quote?.text).toBe(
+      '100 USD = 85.82 EUR at the European Central Bank reference rate published 2026-09-09 (1 USD = 0.8582 EUR).'
+    );
+    expect(quote?.asOf).toBe('2026-09-09');
+    expect(quote?.sourceUrl).toBe('https://frankfurter.dev');
+  });
+
+  it('never calls out for a question that names no pair', async () => {
+    const fetchText = jest.fn();
+    expect(
+      await resolveCurrencyQuote('What is the weather today?', { fetchText })
+    ).toBeUndefined();
+    expect(fetchText).not.toHaveBeenCalled();
+  });
+
+  it('gives up quietly when the service fails, so the search path still runs', async () => {
+    expect(
+      await resolveCurrencyQuote('100 USD in EUR', {
+        fetchText: () => Promise.reject(new Error('offline')),
+      })
+    ).toBeUndefined();
+  });
+
+  it('gives up quietly when the payload is not the shape it expects', async () => {
+    expect(
+      await resolveCurrencyQuote('100 USD in EUR', {
+        fetchText: () => Promise.resolve('{"rates":{"EUR":"soon"}}'),
+      })
+    ).toBeUndefined();
+  });
+});
+
+describe('showing a converted amount', () => {
+  it('keeps whole numbers whole and money to two places', () => {
+    expect(formatMoney(1500)).toBe('1500');
+    expect(formatMoney(85.8216)).toBe('85.82');
+  });
+
+  it('keeps enough digits for a rate far below one', () => {
+    expect(formatMoney(0.0067123)).toBe('0.006712');
+  });
+});

--- a/__tests__/runWebSearch.test.ts
+++ b/__tests__/runWebSearch.test.ts
@@ -140,6 +140,50 @@ describe('runWebSearch', () => {
     expect(provider.calls).toHaveLength(0);
   });
 
+  it('answers a currency conversion from the rate service without asking the planner', async () => {
+    const provider = new MockProvider({});
+    const generate = jest.fn(async () => '');
+    const out = await runWebSearch({
+      query: 'How much is 100 USD in EUR?',
+      history: [],
+      provider,
+      embeddings: fakeEmbeddings,
+      embeddingModelReady: true,
+      generate,
+      today: '2026-07-20',
+      resolveQuote: async () => ({
+        id: 'currency',
+        text: '100 USD = 85.82 EUR',
+        sourceUrl: 'https://frankfurter.dev',
+        sourceTitle: 'Frankfurter',
+        asOf: '2026-07-20',
+      }),
+    });
+    expect(out.context).toEqual(['100 USD = 85.82 EUR']);
+    expect(out.sourceDocuments[0].url).toBe('https://frankfurter.dev');
+    expect(out.telemetry.finalLabel).toBe('correct');
+    expect(generate).not.toHaveBeenCalled();
+    expect(provider.calls).toHaveLength(0);
+  });
+
+  it('falls through to the search path when no quote can be resolved', async () => {
+    const provider = new MockProvider({});
+    const generate = jest.fn(
+      async () => '{"needs_search": true, "intent": "weather", "queries": []}'
+    );
+    await runWebSearch({
+      query: 'warsaw weather',
+      history: [],
+      provider,
+      embeddings: fakeEmbeddings,
+      embeddingModelReady: true,
+      generate,
+      today: '2026-07-20',
+      resolveQuote: async () => undefined,
+    });
+    expect(generate).toHaveBeenCalled();
+  });
+
   it('skips when the provider is not ready', async () => {
     const provider = new MockProvider({}, false);
     const out = await runWebSearch({

--- a/__tests__/runWebSearch.test.ts
+++ b/__tests__/runWebSearch.test.ts
@@ -34,6 +34,7 @@ import type { WebSearchProgressEvent } from '../utils/web/runWebSearch';
 import { extractArticle } from '../utils/web/url/extractArticle';
 import { clearWebCaches } from '../utils/web/cache/webCache';
 import { WEB_SEARCH_MAX_RESULTS } from '../constants/web';
+import { sourcesPresentInContext } from '../utils/contextUtils';
 
 const axisOf = (text: string): number[] => {
   const lower = text.toLowerCase();
@@ -159,7 +160,8 @@ describe('runWebSearch', () => {
         asOf: '2026-07-20',
       }),
     });
-    expect(out.context).toEqual(['100 USD = 85.82 EUR']);
+    expect(sourcesPresentInContext(out.context[0])).toContain('Frankfurter');
+    expect(out.context[0]).toContain('100 USD = 85.82 EUR');
     expect(out.sourceDocuments[0].url).toBe('https://frankfurter.dev');
     expect(out.telemetry.finalLabel).toBe('correct');
     expect(generate).not.toHaveBeenCalled();

--- a/constants/web-quotes.ts
+++ b/constants/web-quotes.ts
@@ -1,0 +1,52 @@
+export const QUOTE_RESOLVER_TIMEOUT_MS = 4000;
+export const QUOTE_RESOLVER_MAX_BYTES = 16 * 1024;
+
+export const FRANKFURTER_LATEST_URL = 'https://api.frankfurter.dev/v1/latest';
+export const FRANKFURTER_SITE_URL = 'https://frankfurter.dev';
+
+export const ECB_CURRENCY_CODES = [
+  'AUD',
+  'BRL',
+  'CAD',
+  'CHF',
+  'CNY',
+  'CZK',
+  'DKK',
+  'EUR',
+  'GBP',
+  'HKD',
+  'HUF',
+  'IDR',
+  'ILS',
+  'INR',
+  'ISK',
+  'JPY',
+  'KRW',
+  'MXN',
+  'MYR',
+  'NOK',
+  'NZD',
+  'PHP',
+  'PLN',
+  'RON',
+  'SEK',
+  'SGD',
+  'THB',
+  'TRY',
+  'USD',
+  'ZAR',
+] as const;
+
+export const UNAMBIGUOUS_CURRENCY_SYMBOLS: Record<string, string> = {
+  '€': 'EUR',
+  '£': 'GBP',
+  '₹': 'INR',
+  '₺': 'TRY',
+  '₩': 'KRW',
+  '₪': 'ILS',
+  'R$': 'BRL',
+  'zł': 'PLN',
+  'Kč': 'CZK',
+  'Ft': 'HUF',
+  '$': 'USD',
+};

--- a/utils/web/resolvers/currencyQuote.ts
+++ b/utils/web/resolvers/currencyQuote.ts
@@ -1,0 +1,92 @@
+import {
+  FRANKFURTER_LATEST_URL,
+  FRANKFURTER_SITE_URL,
+  QUOTE_RESOLVER_MAX_BYTES,
+  QUOTE_RESOLVER_TIMEOUT_MS,
+} from '../../../constants/web-quotes';
+import { fetchTextWithLimit } from '../security/outboundFetch';
+import { readCurrencyRequest } from './currencyRequest';
+
+export interface ResolvedQuote {
+  id: string;
+  text: string;
+  sourceUrl: string;
+  sourceTitle: string;
+  asOf: string;
+}
+
+export type QuoteTextFetcher = (url: string) => Promise<string>;
+
+export interface QuoteResolverOptions {
+  signal?: AbortSignal;
+  fetchText?: QuoteTextFetcher;
+}
+
+const JSON_CONTENT_TYPE = /json/i;
+
+const DECIMALS_FOR_LARGE_VALUES = 2;
+const SIGNIFICANT_DIGITS_FOR_SMALL_VALUES = 4;
+
+const defaultFetchText =
+  (signal?: AbortSignal): QuoteTextFetcher =>
+  (url) =>
+    fetchTextWithLimit(url, {
+      timeoutMs: QUOTE_RESOLVER_TIMEOUT_MS,
+      maxBytes: QUOTE_RESOLVER_MAX_BYTES,
+      contentTypePattern: JSON_CONTENT_TYPE,
+      ...(signal ? { signal } : {}),
+    });
+
+export const formatMoney = (value: number): string => {
+  if (Number.isInteger(value)) return String(value);
+  if (value >= 1) return value.toFixed(DECIMALS_FOR_LARGE_VALUES);
+  return Number(
+    value.toPrecision(SIGNIFICANT_DIGITS_FOR_SMALL_VALUES)
+  ).toString();
+};
+
+const rateFrom = (payload: string, target: string): number | undefined => {
+  const parsed: unknown = JSON.parse(payload);
+  if (typeof parsed !== 'object' || parsed === null) return undefined;
+  const { rates, date } = parsed as { rates?: unknown; date?: unknown };
+  if (typeof date !== 'string') return undefined;
+  if (typeof rates !== 'object' || rates === null) return undefined;
+  const rate = (rates as Record<string, unknown>)[target];
+  return typeof rate === 'number' && Number.isFinite(rate) ? rate : undefined;
+};
+
+const dateFrom = (payload: string): string | undefined => {
+  const parsed: unknown = JSON.parse(payload);
+  const { date } = (parsed ?? {}) as { date?: unknown };
+  return typeof date === 'string' ? date : undefined;
+};
+
+export const resolveCurrencyQuote = async (
+  question: string,
+  options: QuoteResolverOptions = {}
+): Promise<ResolvedQuote | undefined> => {
+  const request = readCurrencyRequest(question);
+  if (!request || request.from === request.to) return undefined;
+
+  const url = `${FRANKFURTER_LATEST_URL}?base=${request.from}&symbols=${request.to}`;
+  const fetchText = options.fetchText ?? defaultFetchText(options.signal);
+
+  try {
+    const payload = await fetchText(url);
+    const rate = rateFrom(payload, request.to);
+    const asOf = dateFrom(payload);
+    if (rate === undefined || asOf === undefined) return undefined;
+
+    const converted = formatMoney(request.amount * rate);
+    const amount = formatMoney(request.amount);
+    return {
+      id: 'currency',
+      text: `${amount} ${request.from} = ${converted} ${request.to} at the European Central Bank reference rate published ${asOf} (1 ${request.from} = ${formatMoney(rate)} ${request.to}).`,
+      sourceUrl: FRANKFURTER_SITE_URL,
+      sourceTitle: 'Frankfurter — European Central Bank reference rates',
+      asOf,
+    };
+  } catch {
+    return undefined;
+  }
+};

--- a/utils/web/resolvers/currencyRequest.ts
+++ b/utils/web/resolvers/currencyRequest.ts
@@ -56,8 +56,7 @@ const codeMentions = (question: string): CurrencyMention[] => {
     const start = match.index ?? 0;
     const end = start + match[0].length;
     if (isLetter(question[start - 1]) || isLetter(question[end])) continue;
-    const code = match[0].toUpperCase();
-    if (CODES.has(code)) found.push({ code, start, end });
+    if (CODES.has(match[0])) found.push({ code: match[0], start, end });
   }
   return found;
 };

--- a/utils/web/resolvers/currencyRequest.ts
+++ b/utils/web/resolvers/currencyRequest.ts
@@ -1,0 +1,133 @@
+import {
+  ECB_CURRENCY_CODES,
+  UNAMBIGUOUS_CURRENCY_SYMBOLS,
+} from '../../../constants/web-quotes';
+
+export interface CurrencyRequest {
+  amount: number;
+  from: string;
+  to: string;
+}
+
+interface CurrencyMention {
+  code: string;
+  start: number;
+  end: number;
+}
+
+const CODES: ReadonlySet<string> = new Set(ECB_CURRENCY_CODES);
+
+const CODE_PATTERN = /\p{L}{3}/gu;
+const AMOUNT_PATTERN = /\d[\d\s.,']*\d|\d/gu;
+const GAP_BETWEEN_AMOUNT_AND_CURRENCY = /^[\s]*$/u;
+const GROUPED_TAIL = /^\d{3}$/u;
+
+const escapeForPattern = (text: string): string =>
+  text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const isLetter = (character: string | undefined): boolean =>
+  character !== undefined && /\p{L}/u.test(character);
+
+const SYMBOL_PATTERN = new RegExp(
+  Object.keys(UNAMBIGUOUS_CURRENCY_SYMBOLS)
+    .sort((a, b) => b.length - a.length)
+    .map(escapeForPattern)
+    .join('|'),
+  'gu'
+);
+
+const symbolMentions = (question: string): CurrencyMention[] => {
+  const found: CurrencyMention[] = [];
+  for (const match of question.matchAll(SYMBOL_PATTERN)) {
+    const start = match.index ?? 0;
+    const end = start + match[0].length;
+    const startsWithLetter = isLetter(match[0][0]);
+    const endsWithLetter = isLetter(match[0][match[0].length - 1]);
+    if (startsWithLetter && isLetter(question[start - 1])) continue;
+    if (endsWithLetter && isLetter(question[end])) continue;
+    found.push({ code: UNAMBIGUOUS_CURRENCY_SYMBOLS[match[0]], start, end });
+  }
+  return found;
+};
+
+const codeMentions = (question: string): CurrencyMention[] => {
+  const found: CurrencyMention[] = [];
+  for (const match of question.matchAll(CODE_PATTERN)) {
+    const start = match.index ?? 0;
+    const end = start + match[0].length;
+    if (isLetter(question[start - 1]) || isLetter(question[end])) continue;
+    const code = match[0].toUpperCase();
+    if (CODES.has(code)) found.push({ code, start, end });
+  }
+  return found;
+};
+
+export const parseAmount = (raw: string): number | undefined => {
+  const compact = raw.replace(/[\s']/gu, '');
+  const lastDot = compact.lastIndexOf('.');
+  const lastComma = compact.lastIndexOf(',');
+  const dots = (compact.match(/\./gu) ?? []).length;
+  const commas = (compact.match(/,/gu) ?? []).length;
+
+  let normalized: string;
+  if (dots > 0 && commas > 0) {
+    const decimalAt = Math.max(lastDot, lastComma);
+    normalized =
+      compact.slice(0, decimalAt).replace(/[.,]/gu, '') +
+      '.' +
+      compact.slice(decimalAt + 1);
+  } else if (dots + commas === 0) {
+    normalized = compact;
+  } else if (dots + commas > 1) {
+    normalized = compact.replace(/[.,]/gu, '');
+  } else {
+    const separatorAt = Math.max(lastDot, lastComma);
+    const tail = compact.slice(separatorAt + 1);
+    normalized = GROUPED_TAIL.test(tail)
+      ? compact.replace(/[.,]/gu, '')
+      : compact.slice(0, separatorAt) + '.' + tail;
+  }
+
+  const value = Number(normalized);
+  return Number.isFinite(value) && value > 0 ? value : undefined;
+};
+
+const amountTouching = (
+  question: string,
+  mention: CurrencyMention
+): number | undefined => {
+  for (const match of question.matchAll(AMOUNT_PATTERN)) {
+    const start = match.index ?? 0;
+    const end = start + match[0].length;
+    const before =
+      end <= mention.start &&
+      GAP_BETWEEN_AMOUNT_AND_CURRENCY.test(question.slice(end, mention.start));
+    const after =
+      start >= mention.end &&
+      GAP_BETWEEN_AMOUNT_AND_CURRENCY.test(question.slice(mention.end, start));
+    if (before || after) return parseAmount(match[0]);
+  }
+  return undefined;
+};
+
+export const readCurrencyRequest = (
+  question: string
+): CurrencyRequest | undefined => {
+  const mentions = [
+    ...codeMentions(question),
+    ...symbolMentions(question),
+  ].sort((a, b) => a.start - b.start);
+  const distinct = [...new Set(mentions.map((mention) => mention.code))];
+  if (distinct.length !== 2) return undefined;
+
+  for (const mention of mentions) {
+    const amount = amountTouching(question, mention);
+    if (amount !== undefined) {
+      const other = distinct.find((code) => code !== mention.code);
+      if (!other) return undefined;
+      return { amount, from: mention.code, to: other };
+    }
+  }
+
+  return { amount: 1, from: distinct[0], to: distinct[1] };
+};

--- a/utils/web/runWebSearch.ts
+++ b/utils/web/runWebSearch.ts
@@ -77,6 +77,8 @@ import {
   SEARCH_REGION_BY_LANGUAGE,
 } from '../../constants/web';
 import { detectQuestionLanguage } from '../questionLanguage';
+import { sourceBlock } from '../contextUtils';
+import { neutralizeDelimiters } from './security/untrustedContent';
 
 export interface WebSearchProgressEvent {
   type:
@@ -266,7 +268,13 @@ const searchWithCleanup = async (
     emit({ type: 'reading', url: quote.sourceUrl, title: quote.sourceTitle });
     emit({ type: 'done' });
     return {
-      context: [quote.text],
+      context: [
+        sourceBlock(
+          0,
+          neutralizeDelimiters(quote.sourceTitle),
+          neutralizeDelimiters(quote.text)
+        ),
+      ],
       sourceDocuments: [
         {
           kind: 'web',

--- a/utils/web/runWebSearch.ts
+++ b/utils/web/runWebSearch.ts
@@ -15,6 +15,11 @@ import {
 } from './buildSearchQuery';
 import type { ModelProfile } from '../../constants/model-profiles';
 import {
+  resolveCurrencyQuote,
+  type QuoteResolverOptions,
+  type ResolvedQuote,
+} from './resolvers/currencyQuote';
+import {
   enrichWebResults,
   type ArticleFetcher,
   type EnrichPageEvent,
@@ -116,6 +121,10 @@ export interface RunWebSearchInput {
   fetchArticle?: ArticleFetcher;
   useCache?: boolean;
   searchTimeoutMs?: number;
+  resolveQuote?: (
+    query: string,
+    options: QuoteResolverOptions
+  ) => Promise<ResolvedQuote | undefined>;
 }
 
 export interface WebRoundTelemetry {
@@ -247,6 +256,34 @@ const searchWithCleanup = async (
   if (isSmallTalk(query)) {
     emit({ type: 'skipped' });
     return empty('gated');
+  }
+
+  const resolveQuote = input.resolveQuote ?? resolveCurrencyQuote;
+  const quote = await resolveQuote(query, {
+    ...(input.signal ? { signal: input.signal } : {}),
+  });
+  if (quote) {
+    emit({ type: 'reading', url: quote.sourceUrl, title: quote.sourceTitle });
+    emit({ type: 'done' });
+    return {
+      context: [quote.text],
+      sourceDocuments: [
+        {
+          kind: 'web',
+          name: quote.sourceTitle,
+          url: quote.sourceUrl,
+          passage: quote.text,
+          used: true,
+          read: true,
+        },
+      ],
+      telemetry: {
+        ...telemetry,
+        intent: quote.id,
+        finalConfidence: 1,
+        finalLabel: 'correct',
+      },
+    };
   }
 
   emit({ type: 'objectives' });


### PR DESCRIPTION
## What

A question that names two currencies is answered from the ECB reference rate instead of from a scraped page. The resolver runs after the small-talk gate and **before the planner**, so a hit skips the planner, the SERP, the fetch and the ranking entirely.

Source: [Frankfurter](https://frankfurter.dev), keyless, no account, ECB daily reference rates, 30 currencies.

## Measured on a device

Samsung S20 FE, `LLaMA 3.2 - 1B - SpinQuant` — the model class that produced the failure this resolver exists for.

```
How much is 100 USD in EUR?

To convert 100 USD to EUR, we can use the given exchange rate of
1 USD = 0.8582 EUR. Since the exchange rate is provided on the same
day, 2026-09-09, we can directly apply it to the conversion.
100 USD × 0.8582 EUR/USD ≈ 85.82 EUR
Therefore, 100 USD is approximately 85.82 EUR.

ttft: 10981 ms, tps: 11.62 tok/s
Source: Frankfurter — European Central Bank reference rates
```

A grounded turn through the full pipeline on the same phone, an hour earlier, measured **47991 ms to first token**. This one measured **10981 ms** on a smaller model. The source badge appeared about two seconds after send, before the model had emitted anything.

## Why this class of question first

Asked for a gold price, `LLaMA 3.2 - 1B` answered `$1.1615` — the EUR/USD rate, read out of a table that happened to sit at the top of the page it was handed. The pipeline had done its job; the number next to the answer was simply a different number. Retrieval that lands on the right page still loses when a small model has to pick one figure out of a table.

A conversion has an exact answer that no page needs to be read for, so there is nothing left to pick wrongly. The second gain is time: the planner parses on 2 of 72 items for `Qwen 3 - 0.6B` and 1 of 72 for `Qwen 2.5 - 0.5B`, and it is most of the 48 s above.

## Language independence, which is the constraint that shaped it

Detection uses no vocabulary from any language. It reads only:

- **ISO 4217 codes, as written, in capitals** — a currency registry, identical in every language and script, not a word list;
- **currency symbols that can only mean one currency** on the ECB list (`€ £ ₹ ₺ ₩ ₪ R$ zł Kč Ft`, and `$` resolved to USD, which the answer states back so the assumption is visible);
- **digits**, with grouping and decimal separators read by shape rather than by locale.

The source currency is **the one the amount is written against**, not the first one named. That is a structural rule, and it holds across word orders:

| question | reads as |
| --- | --- |
| `How much is 100 USD in EUR?` | 100 USD → EUR |
| `Ile to jest 100 USD w EUR?` | 100 USD → EUR |
| `Wie viel sind 100 USD in EUR?` | 100 USD → EUR |
| `100 USD से EUR कितना है?` | 100 USD → EUR |
| `How many EUR is 100 USD?` | 100 USD → EUR |
| `USD EUR` | 1 USD → EUR |

### Why the code must be in capitals

An earlier revision accepted a three-letter word in any case and uppercased it before the lookup. `RON`, `TRY`, `PHP` and `CAD` are ECB currencies and also ordinary words or names, so this hijacked questions that ask nothing about money:

| question | read as, before |
| --- | --- |
| `Ron sent me 100 EUR, is that a lot?` | 100 EUR → RON |
| `How much should I try to save, 100 EUR?` | 100 EUR → TRY |

Requiring the code as written, in capitals, is still a notation rule and not a word list — ISO 4217 is uppercase in every language and script, so nothing about the generality changes. It costs the lowercase spelling: `100 usd in eur` gives up the fast path and falls back to search. It also *admits* a case the previous revision refused, since a lowercase verb no longer counts as a currency: `Can you try to convert 100 USD to EUR?` now resolves.

### The limit this approach cannot pass

`I want to learn PHP, how much is 100 EUR a month?` still resolves, as EUR → PHP. `PHP` is legitimately uppercase, and a notation rule cannot tell a Philippine peso from a programming language. Naming it here rather than waiting for someone to hit it: collisions between a currency code and an uppercase acronym are the boundary of detection-by-notation, not a bug in the parser.

## Failing safe

- Fewer or more than two distinct currencies → resolves nothing.
- A three-letter code inside a longer word is not a mention (`USDA` is not `USD`).
- No pair → **no network call at all**.
- A service failure, a timeout, or a payload that is not the expected shape → `undefined`, and the search path runs exactly as before.
- Only the 30 ECB currencies are recognised, so an unsupported pair never reaches the API.

The outbound call goes through `fetchTextWithLimit` with the existing private-host refusal, a 4 s timeout and a 16 KB cap.

## Keeping the answer citable

The first device turn produced a correct answer with **no source badge**. The resolved value had gone into the context as a bare sentence, so `sourcesPresentInContext` found no name, `pickCitationsByAnswer` marked the document unused, and a grounded answer lost its citation. The context now goes through `sourceBlock` like every other source, and a test pins it.

## Extending it

`resolveQuote` is an injectable field on `RunWebSearchInput`, defaulting to the currency resolver. A second resolver — commodity or crypto quotes, an almanac fact — plugs in at the same seam and returns the same `ResolvedQuote` shape. Weather is deliberately **not** here: recognising "weather" in an arbitrary language needs a word list, which is the thing this design refuses.

## Tests

`__tests__/currencyQuote.test.ts`, 22 cases — the same request read from English, Polish, German and Hindi; the amount picking the source currency rather than word order; symbols; a rate for one unit when no amount is given; the lowercase-word refusal and the case it admits; the lowercase-code cost; the third-currency refusal; codes inside longer words; separator conventions (`1,500` / `1.500` / `1.234,56` / `1'234'567`); the exact URL requested; the answer text; and each way of failing quietly.

`__tests__/runWebSearch.test.ts`, 2 cases — a conversion answers without the planner ever being asked and keeps its source name in the context, and an unresolvable question still reaches the planner.

`tsc --noEmit` clean; `jest` 132 suites / 2304 tests green; eslint clean.
