### PR TITLE
fix(web): check the scheme where a source link is opened, not four layers up

### DIFF
--- a/__tests__/chatRepository.test.ts
+++ b/__tests__/chatRepository.test.ts
@@ -445,6 +445,37 @@ describe('getChatMessages source provenance', () => {
     ]);
   });
 
+  it('drops a stored url that is not an http page, so a tap cannot fire another app', async () => {
+    const getAllAsync = jest.fn().mockResolvedValue([
+      {
+        id: 4,
+        chatId: 1,
+        role: 'assistant',
+        content: 'Answer.',
+        sourceDocuments: JSON.stringify([
+          { name: 'Real', url: 'https://example.com/a', kind: 'web' },
+          { name: 'Script', url: 'javascript:alert(1)', kind: 'web' },
+          {
+            name: 'Intent',
+            url: 'intent://scan/#Intent;scheme=zxing;end',
+            kind: 'web',
+          },
+          { name: 'File', url: 'file:///etc/passwd', kind: 'web' },
+        ]),
+      },
+    ]);
+    const mockDb = { getAllAsync } as Partial<SQLiteDatabase> as SQLiteDatabase;
+
+    const messages = await getChatMessages(mockDb, 1);
+
+    expect(messages[0].sourceDocuments?.map((source) => source.url)).toEqual([
+      'https://example.com/a',
+      undefined,
+      undefined,
+      undefined,
+    ]);
+  });
+
   it('keeps the query that found each web source, so the saved trace can replay the searches', async () => {
     const getAllAsync = jest.fn().mockResolvedValue([
       {

--- a/__tests__/openExternalUrl.test.ts
+++ b/__tests__/openExternalUrl.test.ts
@@ -1,0 +1,64 @@
+import * as WebBrowser from 'expo-web-browser';
+import Toast from 'react-native-toast-message';
+import { openExternalUrl } from '../utils/web/openExternalUrl';
+
+jest.mock('expo-web-browser', () => ({
+  openBrowserAsync: jest.fn(() => Promise.resolve()),
+}));
+jest.mock('react-native-toast-message', () => ({
+  show: jest.fn(),
+}));
+
+const openBrowserAsync = WebBrowser.openBrowserAsync as jest.Mock;
+const toast = Toast.show as jest.Mock;
+
+describe('openExternalUrl', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    openBrowserAsync.mockResolvedValue(undefined);
+  });
+
+  it('opens an http and an https page', () => {
+    openExternalUrl('https://example.com/a');
+    openExternalUrl('http://example.com/b');
+    expect(openBrowserAsync.mock.calls).toEqual([
+      ['https://example.com/a'],
+      ['http://example.com/b'],
+    ]);
+    expect(toast).not.toHaveBeenCalled();
+  });
+
+  const REFUSED = [
+    'javascript:alert(1)',
+    'intent://scan/#Intent;scheme=zxing;end',
+    'file:///etc/passwd',
+    'content://com.android.providers/1',
+    'data:text/html,<script>alert(1)</script>',
+    'mailto:someone@example.com',
+    'app-scheme://open',
+    ' https://example.com',
+    '',
+  ];
+
+  it.each(REFUSED)('refuses %p', (url) => {
+    openExternalUrl(url);
+    expect(openBrowserAsync).not.toHaveBeenCalled();
+  });
+
+  it('refuses a url that is missing altogether', () => {
+    openExternalUrl(undefined);
+    expect(openBrowserAsync).not.toHaveBeenCalled();
+  });
+
+  it('says so rather than looking like a dead button when it refuses', () => {
+    openExternalUrl('javascript:alert(1)');
+    expect(toast).toHaveBeenCalledTimes(1);
+  });
+
+  it('says so when the device has nothing that can open the page', async () => {
+    openBrowserAsync.mockRejectedValue(new Error('NoMatchingActivity'));
+    openExternalUrl('https://example.com');
+    await Promise.resolve();
+    expect(toast).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/chat-screen/DominantSourceBadge.tsx
+++ b/components/chat-screen/DominantSourceBadge.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { View, Text, Pressable, StyleSheet } from 'react-native';
-import * as WebBrowser from 'expo-web-browser';
+import { openExternalUrl } from '../../utils/web/openExternalUrl';
 import { useThemedStyles } from '../../hooks/useThemedStyles';
 import { Theme } from '../../styles/colors';
 import { fontFamily, fontSizes, lineHeights } from '../../styles/fontStyles';
@@ -15,10 +15,7 @@ const DominantSourceBadge = ({ source }: Props) => {
   const { styles } = useThemedStyles(createStyles);
 
   const handlePress = useCallback(() => {
-    if (!source?.url) return;
-    WebBrowser.openBrowserAsync(source.url).catch((error) =>
-      console.warn('Failed to open browser', error)
-    );
+    openExternalUrl(source?.url);
   }, [source?.url]);
 
   if (!source) return null;

--- a/components/chat-screen/SourceRow.tsx
+++ b/components/chat-screen/SourceRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, Pressable, type LayoutChangeEvent } from 'react-native';
-import * as WebBrowser from 'expo-web-browser';
+import { openExternalUrl } from '../../utils/web/openExternalUrl';
 import { space } from '../../constants/design-system';
 import RowChevron from './RowChevron';
 import SourceIcon from '../../assets/icons/source.svg';
@@ -63,11 +63,7 @@ const SourceRow = ({
     return (
       <Pressable
         style={[styles.webRow, isHighlighted && styles.sourceRowHighlighted]}
-        onPress={() => {
-          WebBrowser.openBrowserAsync(source.url!).catch((error) =>
-            console.warn('Failed to open browser', error)
-          );
-        }}
+        onPress={() => openExternalUrl(source.url)}
         onLayout={onLayout}
         accessibilityRole="link"
         accessibilityLabel={source.name}

--- a/components/chat-screen/WebSearchBlock.tsx
+++ b/components/chat-screen/WebSearchBlock.tsx
@@ -12,7 +12,7 @@ import Animated, {
   FadeOut,
   LinearTransition,
 } from 'react-native-reanimated';
-import * as WebBrowser from 'expo-web-browser';
+import { openExternalUrl } from '../../utils/web/openExternalUrl';
 import { useThemedStyles } from '../../hooks/useThemedStyles';
 import { fontFamily, fontSizes } from '../../styles/fontStyles';
 import { Theme } from '../../styles/colors';
@@ -100,9 +100,7 @@ const WebSearchBlock = memo(({ isSearching, trace, results }: Props) => {
 
   const openPage = useCallback((url?: string) => {
     if (!url) return;
-    WebBrowser.openBrowserAsync(url).catch((error) =>
-      console.warn('Failed to open browser', error)
-    );
+    openExternalUrl(url);
   }, []);
 
   if (rows.length === 0 && !isSearching) return null;

--- a/database/chatRepository.ts
+++ b/database/chatRepository.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { SQLiteDatabase } from 'expo-sqlite';
+import { isHttpUrl } from '../utils/web/security/outboundFetch';
 
 const DEFAULT_CHAT_SETTINGS_KEY = 'default_chat_settings';
 
@@ -125,7 +126,9 @@ const parseSourceDocuments = (
           typeof source.similarity === 'number' ? source.similarity : undefined,
         kind: source.kind === 'web' ? 'web' : undefined,
         url:
-          source.kind === 'web' && typeof source.url === 'string'
+          source.kind === 'web' &&
+          typeof source.url === 'string' &&
+          isHttpUrl(source.url)
             ? source.url
             : undefined,
         query:

--- a/utils/web/openExternalUrl.ts
+++ b/utils/web/openExternalUrl.ts
@@ -1,0 +1,17 @@
+import * as WebBrowser from 'expo-web-browser';
+import Toast from 'react-native-toast-message';
+import { isHttpUrl } from './security/outboundFetch';
+
+const UNOPENABLE_MESSAGE = 'This link cannot be opened.';
+
+const refuse = (): void => {
+  Toast.show({ type: 'defaultToast', text1: UNOPENABLE_MESSAGE });
+};
+
+export const openExternalUrl = (url: string | undefined): void => {
+  if (!url || !isHttpUrl(url)) {
+    refuse();
+    return;
+  }
+  WebBrowser.openBrowserAsync(url).catch(refuse);
+};


### PR DESCRIPTION
## What

Three buttons handed a stored string straight to `WebBrowser.openBrowserAsync` with no check of their own — the dominant-source badge, a source row, and a trace row. They now all go through one `openExternalUrl` helper that runs `isHttpUrl` at the point of use.

## Why, when nothing bad reaches them today

Nothing bad reaches them *only* because every producer upstream happens to filter: SERP records pass `isWebSearchResult`, which requires `isHttpUrl`; a pasted link is matched by an `https?`-only pattern; enrichment carries `result.url` through without rewriting it from page content. That invariant is real, load-bearing, and written down nowhere. Any new producer of `SourceDocument.url` inherits the trust silently, and the type — `url?: string` — promises nothing.

**It also does not survive a round trip.** `parseSourceDocuments` rehydrated `url` on `typeof === 'string'` alone. That is the deserialization boundary, which is exactly where a check belongs: whatever once reached that JSON comes back on every open of the conversation, past every upstream filter that has since been added.

**On Android the consequence is not theoretical.** Expo sets `intent.data = url.toUri()` on an ACTION_VIEW `CustomTabsIntent` and only refuses once *nothing* can handle the intent, so a scheme that some installed app registered for would be launched. iOS is narrower — `SFSafariViewController` accepts http and https only.

## What changed

- `utils/web/openExternalUrl.ts` — one helper, `isHttpUrl` before opening. The predicate already exists and is already used by the fetch and navigation guards; this puts it where the link is actually opened.
- The three call sites go through it.
- `parseSourceDocuments` applies the same predicate when reading a web source back out of SQLite.

A refusal is no longer silent, either. The old `.catch((error) => console.warn(...))` is stripped from release builds, so a link that could not open — an Android device with no browser raising `NoMatchingActivityException`, for instance — simply looked like a dead button. Both the refusal and a failed open now surface a toast.

`MessageItem` keeps its own separate guard on purpose: it also admits `mailto:`, which is legitimate for a link the model wrote into an answer, and which has nothing to do with opening a retrieved source.

## Tests

`__tests__/openExternalUrl.test.ts` — an http and an https url open; a `javascript:`, a `file://` and a custom-scheme url are refused without reaching the browser; an undefined url is refused; a rejected open surfaces the same refusal.

`__tests__/chatRepository.test.ts` — a stored web source with a non-http url comes back with `url: undefined`, so a value that predates this check cannot be replayed out of history.

`tsc --noEmit` clean; `jest` 136 suites / 2341 tests green; eslint clean on every touched file.
