### PR TITLE
refactor(chat): lift two concerns out of ChatBar, and read a declined search from the plan's kind

### DIFF
--- a/__tests__/ChatBar.test.tsx
+++ b/__tests__/ChatBar.test.tsx
@@ -981,6 +981,37 @@ describe('web search toggle and the embedding download sheet', () => {
   });
 });
 
+describe('opening another chat', () => {
+  it('leaves the composer empty, so a suggestion typed into the last chat does not follow you', () => {
+    const view = renderBar();
+    const input = screen.getByPlaceholderText('Ask about anything...');
+    fireEvent.changeText(input, 'a draft from the previous chat');
+    expect(
+      screen.getByPlaceholderText('Ask about anything...').props.value
+    ).toBe('a draft from the previous chat');
+
+    view.rerender(<ChatBar {...defaultProps} chatId={2} />);
+
+    expect(
+      screen.getByPlaceholderText('Ask about anything...').props.value
+    ).toBe('');
+  });
+
+  it('keeps what is being typed while the same chat stays open', () => {
+    const view = renderBar();
+    fireEvent.changeText(
+      screen.getByPlaceholderText('Ask about anything...'),
+      'still writing this'
+    );
+
+    view.rerender(<ChatBar {...defaultProps} hasMessages />);
+
+    expect(
+      screen.getByPlaceholderText('Ask about anything...').props.value
+    ).toBe('still writing this');
+  });
+});
+
 describe('a refused send', () => {
   it('puts the text back and says why instead of dropping it silently', async () => {
     const onSend = jest.fn(async () => false);

--- a/__tests__/ChatBar.test.tsx
+++ b/__tests__/ChatBar.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react-native';
 import type { LLMStore } from '../store/llmStore';
+import { useChatStore } from '../store/chatStore';
 import type { Attachment } from '../hooks/useAttachment';
 import type { PermissionStatus } from 'react-native-audio-api';
 import type { SharedValue } from 'react-native-reanimated';
@@ -991,6 +992,24 @@ describe('opening another chat', () => {
     ).toBe('a draft from the previous chat');
 
     view.rerender(<ChatBar {...defaultProps} chatId={2} />);
+
+    expect(
+      screen.getByPlaceholderText('Ask about anything...').props.value
+    ).toBe('');
+  });
+
+  it('empties the composer when another blank chat is started, which reuses the same unsaved id', () => {
+    renderBar();
+    fireEvent.changeText(
+      screen.getByPlaceholderText('Ask about anything...'),
+      'a suggestion tapped by mistake'
+    );
+
+    act(() => {
+      useChatStore.setState((state) => ({
+        phantomChatStarts: state.phantomChatStarts + 1,
+      }));
+    });
 
     expect(
       screen.getByPlaceholderText('Ask about anything...').props.value

--- a/__tests__/NewChatHeaderButton.test.tsx
+++ b/__tests__/NewChatHeaderButton.test.tsx
@@ -17,6 +17,7 @@ jest.mock('../utils/startPhantomChat', () => ({
 }));
 
 import NewChatHeaderButton from '../components/NewChatHeaderButton';
+import { useChatStore } from '../store/chatStore';
 
 beforeEach(() => jest.clearAllMocks());
 afterEach(() => jest.restoreAllMocks());
@@ -35,10 +36,18 @@ describe('NewChatHeaderButton', () => {
     expect(mockStart).toHaveBeenCalled();
   });
 
-  it('does nothing when noOp=true', () => {
+  it('navigates nowhere when noOp=true, because that screen is already a new chat', () => {
     const { UNSAFE_getByType } = render(<NewChatHeaderButton noOp={true} />);
     const { TouchableOpacity } = require('react-native');
     fireEvent.press(UNSAFE_getByType(TouchableOpacity));
     expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it('still asks for a fresh blank chat when noOp=true, so a tapped suggestion can be taken back', () => {
+    const before = useChatStore.getState().phantomChatStarts;
+    const { UNSAFE_getByType } = render(<NewChatHeaderButton noOp={true} />);
+    const { TouchableOpacity } = require('react-native');
+    fireEvent.press(UNSAFE_getByType(TouchableOpacity));
+    expect(useChatStore.getState().phantomChatStarts).toBe(before + 1);
   });
 });

--- a/__tests__/buildSearchQuery.test.ts
+++ b/__tests__/buildSearchQuery.test.ts
@@ -1,3 +1,4 @@
+import { WEB_INTENT_KINDS } from '../utils/web/intentKind';
 import {
   toKeywordQuery,
   parseSearchPlan,
@@ -6,7 +7,7 @@ import {
   extractSiteRestriction,
   carryReferentIntoQuery,
   isAboutTheConversation,
-  isConversationalIntent,
+  isConversationalPlan,
   anchorRescueQuery,
 } from '../utils/web/buildSearchQuery';
 import { namesATimePeriod } from '../utils/web/timePeriod';
@@ -223,15 +224,27 @@ describe('planWebSearch', () => {
     const generate = jest
       .fn()
       .mockResolvedValue(
-        '{"needs_search": false, "intent": "casual greeting", "queries": []}'
+        '{"needs_search": false, "intent": "casual greeting", "kind": "chat", "queries": []}'
       );
     const plan = await planWebSearch('hej, jak leci?', [], generate);
     expect(generate).toHaveBeenCalledTimes(1);
     expect(plan).toEqual({
       needsSearch: false,
       intent: 'casual greeting',
+      kind: 'chat',
       queries: [],
     });
+  });
+
+  it('searches anyway when the plan declines without naming a kind, so an unlabelled refusal cannot silently disable the search', async () => {
+    const generate = jest
+      .fn()
+      .mockResolvedValue(
+        '{"needs_search": false, "intent": "casual greeting", "queries": []}'
+      );
+    const plan = await planWebSearch('hej, jak leci?', [], generate);
+    expect(plan.needsSearch).toBe(true);
+    expect(plan.queries).toEqual(['hej, jak leci?']);
   });
 
   it('plans a complex question via the LLM and carries context + today', async () => {
@@ -302,7 +315,7 @@ describe('planWebSearch', () => {
     const generate = jest
       .fn()
       .mockResolvedValue(
-        '{"needs_search": false, "intent": "write a poem", "queries": []}'
+        '{"needs_search": false, "intent": "write a poem", "kind": "chat", "queries": []}'
       );
     const plan = await planWebSearch(
       'write me a long poem about the sea and the moon',
@@ -313,6 +326,7 @@ describe('planWebSearch', () => {
     expect(plan).toEqual({
       needsSearch: false,
       intent: 'write a poem',
+      kind: 'chat',
       queries: [],
     });
   });
@@ -365,7 +379,7 @@ describe('planWebSearch', () => {
     const generate = jest
       .fn()
       .mockResolvedValue(
-        '{"needs_search": false, "intent": "casual greeting", "queries": []}'
+        '{"needs_search": false, "intent": "casual greeting", "kind": "chat", "queries": []}'
       );
     const plan = await planWebSearch('hej, jak leci?', [], generate, {
       today: TODAY,
@@ -373,6 +387,7 @@ describe('planWebSearch', () => {
     expect(plan).toEqual({
       needsSearch: false,
       intent: 'casual greeting',
+      kind: 'chat',
       queries: [],
     });
   });
@@ -1390,37 +1405,22 @@ describe('carryReferentIntoQuery', () => {
   });
 });
 
-describe('isConversationalIntent', () => {
-  it('treats a recap or a question about an earlier answer as conversation, not a search (live: Pixel S2.6, S5.2)', () => {
-    expect(isConversationalIntent('recap of this conversation')).toBe(true);
-    expect(isConversationalIntent('about a previous answer')).toBe(true);
-    expect(isConversationalIntent('language of the first reply')).toBe(true);
-    expect(isConversationalIntent('current bitcoin price')).toBe(false);
+describe('isConversationalPlan', () => {
+  it('trusts a no-search plan only when the planner labelled it the chat kind', () => {
+    expect(isConversationalPlan({ kind: 'chat' })).toBe(true);
+    expect(isConversationalPlan({ kind: 'price' })).toBe(false);
+    expect(isConversationalPlan({ kind: 'fact' })).toBe(false);
   });
 
-  it('recognizes every conversational category the planner prompt itself defines as needing no search', () => {
-    expect(isConversationalIntent('casual greeting')).toBe(true);
-    expect(isConversationalIntent('creative writing')).toBe(true);
-    expect(isConversationalIntent('personal advice')).toBe(true);
-    expect(isConversationalIntent('programming language opinion')).toBe(true);
-    expect(isConversationalIntent('thanking the assistant')).toBe(true);
-    expect(isConversationalIntent('translate this sentence')).toBe(true);
-    expect(isConversationalIntent('rewrite the paragraph')).toBe(true);
-    expect(isConversationalIntent('basic math question')).toBe(true);
-    expect(isConversationalIntent('debugging code')).toBe(true);
-    expect(isConversationalIntent('general knowledge')).toBe(true);
+  it('does not trust an unlabelled plan, whatever its intent text says', () => {
+    expect(isConversationalPlan({})).toBe(false);
+    expect(isConversationalPlan({ kind: undefined })).toBe(false);
   });
 
-  it('does not recognize an intent describing a real-world fact, in any language the query itself was in — intent is always written in English', () => {
-    expect(isConversationalIntent('elon musk children')).toBe(false);
-    expect(isConversationalIntent('president children')).toBe(false);
-    expect(isConversationalIntent('current gold price')).toBe(false);
-    expect(isConversationalIntent('CEO of Tesla')).toBe(false);
-  });
-
-  it('does not trust an empty or missing intent as evidence of being conversational', () => {
-    expect(isConversationalIntent('')).toBe(false);
-    expect(isConversationalIntent('   ')).toBe(false);
+  it('reads the same label in every language the question was asked in, because the label is not the question', () => {
+    for (const kind of WEB_INTENT_KINDS) {
+      expect(isConversationalPlan({ kind })).toBe(kind === 'chat');
+    }
   });
 });
 

--- a/__tests__/llmStore.test.ts
+++ b/__tests__/llmStore.test.ts
@@ -2227,6 +2227,22 @@ describe('one turn at a time (S20 FE: sends lost or doubled while a turn was sti
     );
   });
 
+  it('does not call a stop the user asked for a failure, even with nothing outside the think block', async () => {
+    const thinkingOnly = '<think>weighing the options';
+    mockInstance.generate.mockImplementationOnce(async () => {
+      capturedTokenCallback!(thinkingOnly);
+      await flushFrame();
+      useLLMStore.setState({ isGenerating: false, isProcessingPrompt: false });
+      return thinkingOnly;
+    });
+
+    await useLLMStore
+      .getState()
+      .sendChatMessage('write a long essay', 1, noSources, settings);
+
+    expect(useLLMStore.getState().generationError).toBeNull();
+  });
+
   it('drops the bubble when the model only looped inside an unterminated think block (iPhone SE)', async () => {
     const looped = '<think>cząstek cząstek cząstek cząstek cząstek';
     mockInstance.generate.mockImplementationOnce(async () => {

--- a/__tests__/messageSources.test.ts
+++ b/__tests__/messageSources.test.ts
@@ -10,6 +10,7 @@ import {
   isQuestionEchoAnswer,
   isWrongLanguageAnswer,
   retryDropsGroundedDetail,
+  answeredNothing,
   looksLikeNoAnswer,
   mergeAttachmentFirst,
   pickCitationsByAnswer,
@@ -605,6 +606,48 @@ describe('looksLikeNoAnswer', () => {
     'Urlop dodatkowy nie jest płatny, co potwierdza regulamin.',
   ])('does not flag a real answer: %s', (reply) => {
     expect(looksLikeNoAnswer(reply)).toBe(false);
+  });
+});
+
+describe('answeredNothing', () => {
+  it('keeps an answer that delivered one of the two figures it was asked for (live: Pixel, bitcoin vs ethereum)', () => {
+    expect(
+      answeredNothing(
+        '(1) Cena Bitcoin aktualnie: $64,146.36 USD (2) Cena Ethereum aktualnie: Brak danych w kontekście.',
+        'Porównaj je i daj mi wyniki'
+      )
+    ).toBe(false);
+  });
+
+  it('still treats a refusal carrying no figure as answering nothing', () => {
+    expect(
+      answeredNothing(
+        'Źródła nie dostarczają informacji o cenach kremu Nivea Q10 przeciwzmarszczkowy.',
+        'Ile kosztuje krem Nivea Q10 przeciwzmarszczkowy?'
+      )
+    ).toBe(true);
+  });
+
+  it('does not count a figure the question itself supplied', () => {
+    expect(
+      answeredNothing(
+        'W źródłach nie ma informacji o cenie karty RTX 4070.',
+        'Jaka jest najtańsza cena karty RTX 4070 na Allegro?'
+      )
+    ).toBe(true);
+  });
+
+  it('reads the figure in any decimal system, so the guard is not tied to a script', () => {
+    expect(
+      answeredNothing(
+        'कीमत स्रोतों में नहीं दी गई है। मूल्य ६४१४६ है।',
+        'सोने की कीमत क्या है?'
+      )
+    ).toBe(false);
+  });
+
+  it('falls back to wording alone when no question is available', () => {
+    expect(answeredNothing('W dokumentach nie ma informacji o L4.')).toBe(true);
   });
 });
 

--- a/__tests__/queryTerms.test.ts
+++ b/__tests__/queryTerms.test.ts
@@ -92,6 +92,10 @@ describe('non-Latin scripts', () => {
     expect(extractQueryTerms('الطقس اليوم').size).toBe(2);
   });
 
+  it('extracts terms from Bengali queries, a script the detector already names', () => {
+    expect(extractQueryTerms('ঢাকায় আবহাওয়া')).toContain('আবহাওয়া');
+  });
+
   it('indexes CJK and kana as character bigrams', () => {
     const terms = extractQueryTerms('東京の天気');
     expect(terms.size).toBeGreaterThan(0);
@@ -113,6 +117,10 @@ describe('short words in scripts that write them in two characters', () => {
   it('keeps two-character Devanagari and Arabic-script words', () => {
     expect(extractQueryTerms('जल कहाँ है')).toContain('जल');
     expect(extractQueryTerms('گل کی قیمت')).toContain('گل');
+  });
+
+  it('keeps two-character Bengali words', () => {
+    expect(extractQueryTerms('জল কোথায় আছে')).toContain('জল');
   });
 
   it('still drops two-character Latin noise', () => {

--- a/__tests__/runWebSearch.test.ts
+++ b/__tests__/runWebSearch.test.ts
@@ -115,7 +115,7 @@ describe('runWebSearch', () => {
       embeddings: fakeEmbeddings,
       embeddingModelReady: true,
       generate: async () =>
-        '{"needs_search": false, "intent": "general knowledge", "queries": []}',
+        '{"needs_search": false, "intent": "general knowledge", "kind": "chat", "queries": []}',
       today: '2026-07-20',
     });
     expect(out.context).toEqual([]);

--- a/__tests__/startPhantomChat.test.ts
+++ b/__tests__/startPhantomChat.test.ts
@@ -46,6 +46,7 @@ describe('startPhantomChat', () => {
     (getLastUsedModelId as jest.Mock).mockResolvedValue(7);
     (useChatStore.getState as jest.Mock).mockReturnValue({
       initPhantomChat: jest.fn().mockResolvedValue(undefined),
+      phantomChat: { id: 42 },
     });
     (useLLMStore.getState as jest.Mock).mockReturnValue({
       setActiveChatId: jest.fn().mockResolvedValue(undefined),
@@ -82,6 +83,29 @@ describe('startPhantomChat', () => {
     expect(setActiveChatId.mock.invocationCallOrder[0]).toBeLessThan(
       (router.replace as jest.Mock).mock.invocationCallOrder[0]
     );
+  });
+
+  it('drops the pending navigation when another phantom chat is started first', async () => {
+    const first = startPhantomChat({} as never, 'replace');
+    await jest.advanceTimersByTimeAsync(0);
+    const second = startPhantomChat({} as never, 'replace');
+    await jest.advanceTimersByTimeAsync(50);
+    await Promise.all([first, second]);
+
+    expect(router.replace).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not navigate when the phantom chat it created is gone by the time the timer fires', async () => {
+    const promise = startPhantomChat({} as never, 'replace');
+    await jest.advanceTimersByTimeAsync(0);
+    (useChatStore.getState as jest.Mock).mockReturnValue({
+      initPhantomChat: jest.fn().mockResolvedValue(undefined),
+      phantomChat: { id: 99 },
+    });
+    await jest.advanceTimersByTimeAsync(50);
+    await promise;
+
+    expect(router.replace).not.toHaveBeenCalled();
   });
 
   it('does not delay a push navigation', async () => {

--- a/__tests__/useEmbeddingDownloadPrompt.test.tsx
+++ b/__tests__/useEmbeddingDownloadPrompt.test.tsx
@@ -1,0 +1,195 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { useEmbeddingDownloadPrompt } from '../components/chat-screen/useEmbeddingDownloadPrompt';
+import { useEmbeddingModelStore } from '../store/embeddingModelStore';
+import {
+  isHighMemoryDevice,
+  isMemoryConstrained,
+} from '../utils/modelCompatibility';
+import type { Model } from '../database/modelRepository';
+import type { EmbeddingModelStatus } from '../store/embeddingModelStore';
+
+jest.mock('../utils/modelCompatibility', () => ({
+  isHighMemoryDevice: jest.fn(() => false),
+  isMemoryConstrained: jest.fn(() => false),
+}));
+
+const mockIsHighMemoryDevice = isHighMemoryDevice as jest.Mock;
+const mockIsMemoryConstrained = isMemoryConstrained as jest.Mock;
+
+const model = { id: 1, modelName: 'Test LLM' } as Model;
+
+const setStatus = (status: EmbeddingModelStatus) =>
+  act(() => {
+    useEmbeddingModelStore.setState({ status });
+  });
+
+const setup = (webSearchEnabled: boolean, onWebSearchToggle = jest.fn()) => {
+  const presentDownloadSheet = jest.fn();
+  const markDownloadSheetClosed = jest.fn();
+  const view = renderHook(
+    (props: { webSearchEnabled: boolean }) =>
+      useEmbeddingDownloadPrompt({
+        model,
+        webSearchEnabled: props.webSearchEnabled,
+        onWebSearchToggle,
+        presentDownloadSheet,
+        markDownloadSheetClosed,
+      }),
+    { initialProps: { webSearchEnabled } }
+  );
+  return {
+    ...view,
+    onWebSearchToggle,
+    presentDownloadSheet,
+    markDownloadSheetClosed,
+  };
+};
+
+describe('the embedding download prompt behind the web-search toggle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsHighMemoryDevice.mockReturnValue(false);
+    mockIsMemoryConstrained.mockReturnValue(false);
+    setStatus('not_downloaded');
+  });
+
+  it('asks for the download when the toggle is switched on', async () => {
+    const { result, presentDownloadSheet } = setup(false);
+    act(() => result.current.handleWebSearchToggle());
+    await waitFor(() => expect(presentDownloadSheet).toHaveBeenCalledTimes(1));
+    expect(presentDownloadSheet).toHaveBeenCalledWith('none');
+    await waitFor(() =>
+      expect(result.current.embeddingSheetContext).toBe('web')
+    );
+  });
+
+  it('resumes nothing after the download, so no picker opens by itself', async () => {
+    const { result, presentDownloadSheet } = setup(false);
+    act(() => result.current.handleWebSearchToggle());
+    await waitFor(() => expect(presentDownloadSheet).toHaveBeenCalled());
+    expect(presentDownloadSheet.mock.calls[0]).toEqual(['none']);
+  });
+
+  it('stays quiet when the toggle is switched off', async () => {
+    const { result, presentDownloadSheet, onWebSearchToggle } = setup(true);
+    act(() => result.current.handleWebSearchToggle());
+    expect(onWebSearchToggle).toHaveBeenCalled();
+    await Promise.resolve();
+    expect(presentDownloadSheet).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet when the screen refused to enable web search', async () => {
+    const refused = jest.fn(() => false);
+    const { result, presentDownloadSheet } = setup(false, refused);
+    act(() => result.current.handleWebSearchToggle());
+    await Promise.resolve();
+    expect(presentDownloadSheet).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet when the embedding model is already there', async () => {
+    setStatus('ready');
+    const { result, presentDownloadSheet } = setup(false);
+    act(() => result.current.handleWebSearchToggle());
+    await Promise.resolve();
+    expect(presentDownloadSheet).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet on a device that cannot hold the embedding model', async () => {
+    mockIsMemoryConstrained.mockReturnValue(true);
+    const { result, presentDownloadSheet } = setup(false);
+    act(() => result.current.handleWebSearchToggle());
+    await Promise.resolve();
+    expect(presentDownloadSheet).not.toHaveBeenCalled();
+  });
+
+  it('waits for a status that is not yet known instead of reading unknown as missing', async () => {
+    setStatus('unknown');
+    const { result, presentDownloadSheet } = setup(false);
+    act(() => result.current.handleWebSearchToggle());
+    await Promise.resolve();
+    expect(presentDownloadSheet).not.toHaveBeenCalled();
+
+    setStatus('not_downloaded');
+    await waitFor(() => expect(presentDownloadSheet).toHaveBeenCalledTimes(1));
+  });
+
+  it('drops a pending prompt when the toggle is flipped again first', async () => {
+    setStatus('unknown');
+    const { result, rerender, presentDownloadSheet } = setup(false);
+    act(() => result.current.handleWebSearchToggle());
+    rerender({ webSearchEnabled: true });
+    act(() => result.current.handleWebSearchToggle());
+
+    await act(async () => {
+      useEmbeddingModelStore.setState({ status: 'not_downloaded' });
+      await Promise.resolve();
+    });
+    expect(presentDownloadSheet).not.toHaveBeenCalled();
+  });
+});
+
+describe('dismissing the embedding sheet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsHighMemoryDevice.mockReturnValue(false);
+    mockIsMemoryConstrained.mockReturnValue(false);
+    setStatus('not_downloaded');
+  });
+
+  it('turns web search back off when the download was required and did not happen', async () => {
+    mockIsHighMemoryDevice.mockReturnValue(true);
+    const { result, onWebSearchToggle, presentDownloadSheet } = setup(false);
+    act(() => result.current.handleWebSearchToggle());
+    await waitFor(() => expect(presentDownloadSheet).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(result.current.embeddingSheetRequired).toBe(true)
+    );
+
+    onWebSearchToggle.mockClear();
+    act(() => result.current.handleEmbeddingSheetDismiss());
+    expect(onWebSearchToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves web search on when the download was only a suggestion', async () => {
+    const { result, onWebSearchToggle, presentDownloadSheet } = setup(false);
+    act(() => result.current.handleWebSearchToggle());
+    await waitFor(() => expect(presentDownloadSheet).toHaveBeenCalled());
+
+    onWebSearchToggle.mockClear();
+    act(() => result.current.handleEmbeddingSheetDismiss());
+    expect(onWebSearchToggle).not.toHaveBeenCalled();
+  });
+
+  it('does not ask a second time once the suggestion has been dismissed', async () => {
+    const { result, rerender, presentDownloadSheet } = setup(false);
+    act(() => result.current.handleWebSearchToggle());
+    await waitFor(() => expect(presentDownloadSheet).toHaveBeenCalledTimes(1));
+    act(() => result.current.handleEmbeddingSheetDismiss());
+
+    rerender({ webSearchEnabled: true });
+    act(() => result.current.handleWebSearchToggle());
+    rerender({ webSearchEnabled: false });
+    act(() => result.current.handleWebSearchToggle());
+    await Promise.resolve();
+    expect(presentDownloadSheet).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives the sheet back to the document flow, so its copy is not reused', async () => {
+    const { result, presentDownloadSheet } = setup(false);
+    act(() => result.current.handleWebSearchToggle());
+    await waitFor(() => expect(presentDownloadSheet).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(result.current.embeddingSheetContext).toBe('web')
+    );
+
+    act(() => result.current.handleEmbeddingSheetDismiss());
+    expect(result.current.embeddingSheetContext).toBe('document');
+    expect(result.current.embeddingSheetRequired).toBe(false);
+  });
+
+  it('always tells the attachment hook the sheet is closed', () => {
+    const { result, markDownloadSheetClosed } = setup(false);
+    act(() => result.current.handleEmbeddingSheetDismiss());
+    expect(markDownloadSheetClosed).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/NewChatHeaderButton.tsx
+++ b/components/NewChatHeaderButton.tsx
@@ -5,6 +5,7 @@ import ChatIcon from '../assets/icons/chat.svg';
 import { useThemedStyles } from '../hooks/useThemedStyles';
 import { Theme } from '../styles/colors';
 import { startPhantomChat } from '../utils/startPhantomChat';
+import { useChatStore } from '../store/chatStore';
 
 interface Props {
   noOp?: boolean;
@@ -15,7 +16,10 @@ const NewChatHeaderButton = ({ noOp = false }: Props) => {
   const { styles } = useThemedStyles(createStyles);
 
   const handlePress = () => {
-    if (noOp) return;
+    if (noOp) {
+      useChatStore.getState().startBlankChat();
+      return;
+    }
     startPhantomChat(db, 'replace');
   };
 

--- a/components/chat-screen/ChatBar.tsx
+++ b/components/chat-screen/ChatBar.tsx
@@ -23,6 +23,7 @@ import { useAttachment, Attachment } from '../../hooks/useAttachment';
 import { Model } from '../../database/modelRepository';
 import { fontFamily, fontSizes, lineHeights } from '../../styles/fontStyles';
 import { useThemedStyles } from '../../hooks/useThemedStyles';
+import { useChatStore } from '../../store/chatStore';
 import { useLLMStore } from '../../store/llmStore';
 import RotateLeft from '../../assets/icons/rotate_left.svg';
 import LinkIcon from '../../assets/icons/link-alt.svg';
@@ -94,6 +95,7 @@ const ChatBar = ({
     [styles.container, theme.insets.bottom]
   );
 
+  const phantomChatStarts = useChatStore((state) => state.phantomChatStarts);
   const [userInput, setUserInput] = useState('');
   const lastSentRef = useRef<{ text: string; at: number } | null>(null);
 
@@ -161,9 +163,10 @@ const ChatBar = ({
     []
   );
 
-  const composerChatIdRef = useRef(chatId);
-  if (composerChatIdRef.current !== chatId) {
-    composerChatIdRef.current = chatId;
+  const composerKey = `${chatId}:${phantomChatStarts}`;
+  const composerKeyRef = useRef(composerKey);
+  if (composerKeyRef.current !== composerKey) {
+    composerKeyRef.current = composerKey;
     setUserInput('');
     lastSentRef.current = null;
     if (Platform.OS === 'ios') setIosInputKey((key) => key + 1);

--- a/components/chat-screen/ChatBar.tsx
+++ b/components/chat-screen/ChatBar.tsx
@@ -15,12 +15,7 @@ import {
   Keyboard,
   Platform,
 } from 'react-native';
-import Animated, {
-  Easing,
-  LinearTransition,
-  withTiming,
-  type SharedValue,
-} from 'react-native-reanimated';
+import Animated, { type SharedValue } from 'react-native-reanimated';
 import { type PasteEventPayload, TextInputWrapper } from 'expo-paste-input';
 import AttachmentSheet from '../bottomSheets/AttachmentSheet';
 import EmbeddingDownloadSheet from '../bottomSheets/EmbeddingDownloadSheet';
@@ -41,20 +36,8 @@ import WhatsNewCard from '../WhatsNewCard';
 import AttachmentThumbnail from './AttachmentThumbnail';
 import { AudioManager } from 'react-native-audio-api';
 import Toast from 'react-native-toast-message';
-import {
-  embeddingModelNeedsDownloadPrompt,
-  useEmbeddingModelStore,
-  whenEmbeddingStatusKnown,
-} from '../../store/embeddingModelStore';
-import {
-  isHighMemoryDevice,
-  isMemoryConstrained,
-} from '../../utils/modelCompatibility';
-
-const BAR_GROW_DURATION = 200;
-const BAR_GROW_EASING = Easing.out(Easing.ease);
-const BAR_GROW_LAYOUT =
-  LinearTransition.duration(BAR_GROW_DURATION).easing(BAR_GROW_EASING);
+import { useEmbeddingDownloadPrompt } from './useEmbeddingDownloadPrompt';
+import { BAR_GROW_LAYOUT, useBarGrowth } from './useBarGrowth';
 
 const SENT_ECHO_WINDOW_MS = 300;
 
@@ -144,58 +127,19 @@ const ChatBar = ({
     addPastedAttachment,
   } = useAttachment();
 
-  const [embeddingSheetContext, setEmbeddingSheetContext] = useState<
-    'document' | 'web'
-  >('document');
-  const webEmbeddingPromptDismissedRef = useRef(false);
-  const embeddingSheetRequiredRef = useRef(false);
-  const webToggleSeqRef = useRef(0);
+  const {
+    embeddingSheetContext,
+    embeddingSheetRequired,
+    handleWebSearchToggle,
+    handleEmbeddingSheetDismiss,
+  } = useEmbeddingDownloadPrompt({
+    model,
+    webSearchEnabled,
+    onWebSearchToggle,
+    presentDownloadSheet,
+    markDownloadSheetClosed,
+  });
 
-  const handleWebSearchToggle = useCallback(() => {
-    const enabling = !webSearchEnabled;
-    const toggleSeq = webToggleSeqRef.current + 1;
-    webToggleSeqRef.current = toggleSeq;
-    const accepted = onWebSearchToggle?.();
-    if (!enabling || accepted === false) return;
-    if (isMemoryConstrained(model)) return;
-
-    const required = isHighMemoryDevice(model);
-    if (!required && webEmbeddingPromptDismissedRef.current) return;
-
-    whenEmbeddingStatusKnown().then((status) => {
-      if (webToggleSeqRef.current !== toggleSeq) return;
-      if (!embeddingModelNeedsDownloadPrompt(status)) return;
-      setEmbeddingSheetContext('web');
-      embeddingSheetRequiredRef.current = required;
-      presentDownloadSheet('none');
-    });
-  }, [webSearchEnabled, onWebSearchToggle, model, presentDownloadSheet]);
-
-  const handleEmbeddingSheetDismiss = useCallback(() => {
-    if (embeddingSheetContext === 'web') {
-      if (embeddingSheetRequiredRef.current) {
-        if (useEmbeddingModelStore.getState().status !== 'ready') {
-          onWebSearchToggle?.();
-        }
-      } else {
-        webEmbeddingPromptDismissedRef.current = true;
-      }
-      setEmbeddingSheetContext('document');
-      embeddingSheetRequiredRef.current = false;
-    }
-    markDownloadSheetClosed();
-  }, [embeddingSheetContext, markDownloadSheetClosed, onWebSearchToggle]);
-
-  const embeddingSheetRequired =
-    embeddingSheetContext === 'web' && embeddingSheetRequiredRef.current;
-
-  const defaultBarHeight = useRef(0);
-  const prevBarHeight = useRef(0);
-
-  // Inset the baseline was captured with. Checked in the layout handler, not
-  // an effect: onLayout fires first, so an effect-driven reset would lose the
-  // pass carrying the new height.
-  const baselineInset = useRef<number | null>(null);
   const textInputRef = useRef<RNTextInput>(null);
   // iOS-only: bump the TextInput key to force a remount when a prompt
   // suggestion is set programmatically. iOS doesn't re-fire onLayout
@@ -217,55 +161,14 @@ const ChatBar = ({
     []
   );
 
-  const handleBarLayoutForPadding = useCallback(
-    (e: { nativeEvent: { layout: { height: number } } }) => {
-      const height = e.nativeEvent.layout.height;
-      const inset = theme.insets.bottom;
-      // Only capture the default height once we're in the "with messages"
-      // layout — otherwise the empty-state extras (WhatsNewCard, prompt
-      // suggestions) would bake into the baseline and squeeze the scroll
-      // view once they disappear. Re-capture on inset changes (Android
-      // navigation mode, rotation), or the stale baseline reads the difference
-      // as "the bar grew".
-      const isResting = !userInput && attachments.length === 0;
-      if (hasMessages && isResting) {
-        if (baselineInset.current !== inset) {
-          defaultBarHeight.current = height;
-          baselineInset.current = inset;
-        } else if (
-          defaultBarHeight.current === 0 ||
-          height < defaultBarHeight.current
-        ) {
-          defaultBarHeight.current = height;
-        }
-      }
-      const baseline = defaultBarHeight.current || height;
-      const delta = height - baseline;
-      extraContentPadding.set(
-        withTiming(Math.max(0, delta), {
-          duration: BAR_GROW_DURATION,
-          easing: BAR_GROW_EASING,
-        })
-      );
-      // Baseline, not live height — consumers must not follow the bar as it
-      // grows with typed lines; that is what extraContentPadding is for.
-      onHeightChange?.(hasMessages ? baseline : 0);
-      const grew = height > prevBarHeight.current;
-      prevBarHeight.current = height;
-      if (delta > 0 && grew) {
-        onBarGrow?.();
-      }
-    },
-    [
-      attachments.length,
-      extraContentPadding,
-      onBarGrow,
-      onHeightChange,
-      hasMessages,
-      theme.insets.bottom,
-      userInput,
-    ]
-  );
+  const handleBarLayoutForPadding = useBarGrowth({
+    extraContentPadding,
+    hasMessages,
+    isResting: !userInput && attachments.length === 0,
+    insetBottom: theme.insets.bottom,
+    ...(onHeightChange ? { onHeightChange } : {}),
+    ...(onBarGrow ? { onBarGrow } : {}),
+  });
 
   const {
     isGenerating,

--- a/components/chat-screen/ChatBar.tsx
+++ b/components/chat-screen/ChatBar.tsx
@@ -161,6 +161,14 @@ const ChatBar = ({
     []
   );
 
+  const composerChatIdRef = useRef(chatId);
+  if (composerChatIdRef.current !== chatId) {
+    composerChatIdRef.current = chatId;
+    setUserInput('');
+    lastSentRef.current = null;
+    if (Platform.OS === 'ios') setIosInputKey((key) => key + 1);
+  }
+
   const handleBarLayoutForPadding = useBarGrowth({
     extraContentPadding,
     hasMessages,

--- a/components/chat-screen/GroundingCaveatBadges.tsx
+++ b/components/chat-screen/GroundingCaveatBadges.tsx
@@ -4,12 +4,7 @@ import { useThemedStyles } from '../../hooks/useThemedStyles';
 import { Theme } from '../../styles/colors';
 import { fontFamily, fontSizes, lineHeights } from '../../styles/fontStyles';
 import { type GroundingCaveatKind } from '../../database/chatRepository';
-
-const CAVEAT_COPY: Record<GroundingCaveatKind, string> = {
-  figure: "A number here couldn't be confirmed against the sources",
-  trend: 'No data on the change over time was found in the sources',
-  conversion: 'No real conversion rate was found in the sources',
-};
+import { GROUNDING_CAVEAT_COPY } from '../../constants/web-copy';
 
 const CAVEAT_PRIORITY: GroundingCaveatKind[] = [
   'conversion',
@@ -34,7 +29,7 @@ const GroundingCaveatBadges = ({ caveats }: Props) => {
   return (
     <View style={styles.container}>
       <View style={styles.badge}>
-        <Text style={styles.text}>{CAVEAT_COPY[kind]}</Text>
+        <Text style={styles.text}>{GROUNDING_CAVEAT_COPY[kind]}</Text>
       </View>
     </View>
   );

--- a/components/chat-screen/useBarGrowth.ts
+++ b/components/chat-screen/useBarGrowth.ts
@@ -1,0 +1,89 @@
+import { useCallback, useRef } from 'react';
+import {
+  Easing,
+  LinearTransition,
+  withTiming,
+  type SharedValue,
+} from 'react-native-reanimated';
+
+export const BAR_GROW_DURATION = 200;
+export const BAR_GROW_EASING = Easing.out(Easing.ease);
+export const BAR_GROW_LAYOUT =
+  LinearTransition.duration(BAR_GROW_DURATION).easing(BAR_GROW_EASING);
+
+export interface BarLayoutEvent {
+  nativeEvent: { layout: { height: number } };
+}
+
+interface Options {
+  extraContentPadding: SharedValue<number>;
+  hasMessages: boolean;
+  isResting: boolean;
+  insetBottom: number;
+  onHeightChange?: (height: number) => void;
+  onBarGrow?: () => void;
+}
+
+export const useBarGrowth = ({
+  extraContentPadding,
+  hasMessages,
+  isResting,
+  insetBottom,
+  onHeightChange,
+  onBarGrow,
+}: Options): ((event: BarLayoutEvent) => void) => {
+  const defaultBarHeight = useRef(0);
+  const prevBarHeight = useRef(0);
+
+  // Inset the baseline was captured with. Checked in the layout handler, not
+  // an effect: onLayout fires first, so an effect-driven reset would lose the
+  // pass carrying the new height.
+  const baselineInset = useRef<number | null>(null);
+
+  return useCallback(
+    (event: BarLayoutEvent) => {
+      const height = event.nativeEvent.layout.height;
+      // Only capture the default height once we're in the "with messages"
+      // layout — otherwise the empty-state extras (WhatsNewCard, prompt
+      // suggestions) would bake into the baseline and squeeze the scroll
+      // view once they disappear. Re-capture on inset changes (Android
+      // navigation mode, rotation), or the stale baseline reads the difference
+      // as "the bar grew".
+      if (hasMessages && isResting) {
+        if (baselineInset.current !== insetBottom) {
+          defaultBarHeight.current = height;
+          baselineInset.current = insetBottom;
+        } else if (
+          defaultBarHeight.current === 0 ||
+          height < defaultBarHeight.current
+        ) {
+          defaultBarHeight.current = height;
+        }
+      }
+      const baseline = defaultBarHeight.current || height;
+      const delta = height - baseline;
+      extraContentPadding.set(
+        withTiming(Math.max(0, delta), {
+          duration: BAR_GROW_DURATION,
+          easing: BAR_GROW_EASING,
+        })
+      );
+      // Baseline, not live height — consumers must not follow the bar as it
+      // grows with typed lines; that is what extraContentPadding is for.
+      onHeightChange?.(hasMessages ? baseline : 0);
+      const grew = height > prevBarHeight.current;
+      prevBarHeight.current = height;
+      if (delta > 0 && grew) {
+        onBarGrow?.();
+      }
+    },
+    [
+      extraContentPadding,
+      hasMessages,
+      insetBottom,
+      isResting,
+      onBarGrow,
+      onHeightChange,
+    ]
+  );
+};

--- a/components/chat-screen/useEmbeddingDownloadPrompt.ts
+++ b/components/chat-screen/useEmbeddingDownloadPrompt.ts
@@ -1,0 +1,86 @@
+import { useCallback, useRef, useState } from 'react';
+import {
+  embeddingModelNeedsDownloadPrompt,
+  useEmbeddingModelStore,
+  whenEmbeddingStatusKnown,
+} from '../../store/embeddingModelStore';
+import {
+  isHighMemoryDevice,
+  isMemoryConstrained,
+} from '../../utils/modelCompatibility';
+import type { Model } from '../../database/modelRepository';
+import type { DownloadResume } from '../../hooks/useAttachment';
+
+export type EmbeddingSheetContext = 'document' | 'web';
+
+interface Options {
+  model: Model | undefined;
+  webSearchEnabled?: boolean;
+  onWebSearchToggle?: () => boolean | void;
+  presentDownloadSheet: (resume?: DownloadResume) => void;
+  markDownloadSheetClosed: () => void;
+}
+
+interface EmbeddingDownloadPrompt {
+  embeddingSheetContext: EmbeddingSheetContext;
+  embeddingSheetRequired: boolean;
+  handleWebSearchToggle: () => void;
+  handleEmbeddingSheetDismiss: () => void;
+}
+
+export const useEmbeddingDownloadPrompt = ({
+  model,
+  webSearchEnabled,
+  onWebSearchToggle,
+  presentDownloadSheet,
+  markDownloadSheetClosed,
+}: Options): EmbeddingDownloadPrompt => {
+  const [embeddingSheetContext, setEmbeddingSheetContext] =
+    useState<EmbeddingSheetContext>('document');
+  const webEmbeddingPromptDismissedRef = useRef(false);
+  const embeddingSheetRequiredRef = useRef(false);
+  const webToggleSeqRef = useRef(0);
+
+  const handleWebSearchToggle = useCallback(() => {
+    const enabling = !webSearchEnabled;
+    const toggleSeq = webToggleSeqRef.current + 1;
+    webToggleSeqRef.current = toggleSeq;
+    const accepted = onWebSearchToggle?.();
+    if (!enabling || accepted === false) return;
+    if (isMemoryConstrained(model)) return;
+
+    const required = isHighMemoryDevice(model);
+    if (!required && webEmbeddingPromptDismissedRef.current) return;
+
+    whenEmbeddingStatusKnown().then((status) => {
+      if (webToggleSeqRef.current !== toggleSeq) return;
+      if (!embeddingModelNeedsDownloadPrompt(status)) return;
+      setEmbeddingSheetContext('web');
+      embeddingSheetRequiredRef.current = required;
+      presentDownloadSheet('none');
+    });
+  }, [webSearchEnabled, onWebSearchToggle, model, presentDownloadSheet]);
+
+  const handleEmbeddingSheetDismiss = useCallback(() => {
+    if (embeddingSheetContext === 'web') {
+      if (embeddingSheetRequiredRef.current) {
+        if (useEmbeddingModelStore.getState().status !== 'ready') {
+          onWebSearchToggle?.();
+        }
+      } else {
+        webEmbeddingPromptDismissedRef.current = true;
+      }
+      setEmbeddingSheetContext('document');
+      embeddingSheetRequiredRef.current = false;
+    }
+    markDownloadSheetClosed();
+  }, [embeddingSheetContext, markDownloadSheetClosed, onWebSearchToggle]);
+
+  return {
+    embeddingSheetContext,
+    embeddingSheetRequired:
+      embeddingSheetContext === 'web' && embeddingSheetRequiredRef.current,
+    handleWebSearchToggle,
+    handleEmbeddingSheetDismiss,
+  };
+};

--- a/components/chat-screen/useSendChatMessage.ts
+++ b/components/chat-screen/useSendChatMessage.ts
@@ -18,6 +18,7 @@ import { runWebSearch } from '../../utils/web/runWebSearch';
 import type { WebIntentKind } from '../../utils/web/intentKind';
 import { webViewScrapeProvider } from '../../utils/web/scrape/webViewScrapeProvider';
 import { webContextCharBudget } from '../../utils/web/contextBudget';
+import { WEB_SKIP_COPY, type WebSkipReason } from '../../constants/web-copy';
 import {
   RAG_PRIORITY_OVER_WEB_SEARCH,
   WEB_BENCH_LOGS,
@@ -61,6 +62,15 @@ interface UseSendChatMessageOptions {
   isModelLoading: boolean;
   isSwitching: boolean;
 }
+
+const webSkipReason = (
+  skippedForDocPriority: boolean,
+  model: Model | null
+): WebSkipReason => {
+  if (skippedForDocPriority) return 'documents';
+  if (hasMemoryForWebSearch(model)) return 'model';
+  return 'memory';
+};
 
 export const useSendChatMessage = ({
   chatId,
@@ -203,13 +213,14 @@ export const useSendChatMessage = ({
 
       const skippedForDocPriority =
         RAG_PRIORITY_OVER_WEB_SEARCH && hasRagSources;
+      const modelForWebSearch = useLLMStore.getState().model;
 
       const shouldRunWebSearch =
         WEB_SEARCH_ENABLED &&
         chatSettings.webSearchEnabled &&
         !skippedForDocPriority &&
-        isWebSearchReady(useLLMStore.getState().model) &&
-        hasMemoryForWebSearch(useLLMStore.getState().model) &&
+        isWebSearchReady(modelForWebSearch) &&
+        hasMemoryForWebSearch(modelForWebSearch) &&
         !!userInput.trim();
 
       if (
@@ -220,11 +231,10 @@ export const useSendChatMessage = ({
       ) {
         Toast.show({
           type: 'defaultToast',
-          text1: skippedForDocPriority
-            ? 'Using your documents for this chat — web search is off while they’re active.'
-            : hasMemoryForWebSearch(useLLMStore.getState().model)
-              ? 'Web search is off for this model — answering without it.'
-              : 'Not enough memory to search alongside this model — answering without it.',
+          text1:
+            WEB_SKIP_COPY[
+              webSkipReason(skippedForDocPriority, modelForWebSearch)
+            ],
         });
       }
 

--- a/constants/web-copy.ts
+++ b/constants/web-copy.ts
@@ -1,0 +1,17 @@
+import { type GroundingCaveatKind } from '../database/chatRepository';
+
+export const GROUNDING_CAVEAT_COPY: Record<GroundingCaveatKind, string> = {
+  figure: "A number here couldn't be confirmed against the sources",
+  trend: 'No data on the change over time was found in the sources',
+  conversion: 'No real conversion rate was found in the sources',
+};
+
+export type WebSkipReason = 'documents' | 'model' | 'memory';
+
+export const WEB_SKIP_COPY: Record<WebSkipReason, string> = {
+  documents:
+    'Using your documents for this chat — web search is off while they’re active.',
+  model: 'Web search is off for this model — answering without it.',
+  memory:
+    'Not enough memory to search alongside this model — answering without it.',
+};

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1637,7 +1637,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-keyboard-controller (1.21.1):
+  - react-native-keyboard-controller (1.22.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1649,7 +1649,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-keyboard-controller/common (= 1.21.1)
+    - react-native-keyboard-controller/common (= 1.22.3)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -1660,7 +1660,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-keyboard-controller/common (1.21.1):
+  - react-native-keyboard-controller/common (1.22.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2384,7 +2384,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNReanimated (4.3.0):
+  - RNReanimated (4.3.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2406,11 +2406,11 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNReanimated/apple (= 4.3.0)
-    - RNReanimated/common (= 4.3.0)
+    - RNReanimated/apple (= 4.3.1)
+    - RNReanimated/common (= 4.3.1)
     - RNWorklets
     - Yoga
-  - RNReanimated/apple (4.3.0):
+  - RNReanimated/apple (4.3.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2434,7 +2434,7 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNReanimated/common (4.3.0):
+  - RNReanimated/common (4.3.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2550,7 +2550,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets (0.8.1):
+  - RNWorklets (0.8.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2572,10 +2572,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNWorklets/apple (= 0.8.1)
-    - RNWorklets/common (= 0.8.1)
+    - RNWorklets/apple (= 0.8.3)
+    - RNWorklets/common (= 0.8.3)
     - Yoga
-  - RNWorklets/apple (0.8.1):
+  - RNWorklets/apple (0.8.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2598,7 +2598,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets/common (0.8.1):
+  - RNWorklets/common (0.8.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3039,14 +3039,14 @@ SPEC CHECKSUMS:
   ExpoSymbols: 896159288ad708e1a32dc12c92fe5f90bff01126
   ExpoWebBrowser: b10b2e9f3552fe1c75aa2fa518f78ce8b213c439
   FBLazyVector: 061f518bbd81677ed8a8317e2ae60b8779495808
-  hermes-engine: 2f0d004f7ea59a531ab9a9087cf8663d386d3706
+  hermes-engine: 3001abebdc517c4409c390b10de5b777e0d41682
   iosMath: f7a6cbadf9d836d2149c2a84c435b1effc244cba
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   op-sqlite: 10397885c9f2d478a9d099d20e2a7915c5fda944
   opencv-rne: 2305807573b6e29c8c87e3416ab096d09047a7a0
-  Pdfium: f800387e18744bb2aa3a8054ee6d2f6c84e5e3fd
+  Pdfium: 4647abf0f19fd35adb7898911b72f59f31a74b69
   Pulsar: 9ec19a182a03d08ecefb47877e8de9e976c2a03c
   Pulsar-haptics: f795eaf55d8d0290148fd97c747dcc6689c3d079
   RCTDeprecation: 5045f20b2cc1239bf422764004338c720684a22f
@@ -3057,7 +3057,7 @@ SPEC CHECKSUMS:
   React: 3e14066ac707b3e369d09e2e923d8bee7f8c33ff
   React-callinvoker: bd7959a24564feaf5e4c8c11789e64884da13482
   React-Core: f060f4e14e9301685ce63ea65fbe903bf3397e45
-  React-Core-prebuilt: 3a1e334c56ae9652c0b9227176fe068e388bcea8
+  React-Core-prebuilt: 26830ab8901f602c7bf4e0331624831aae88c345
   React-CoreModules: 89a1a544297be88ca4cdff317423f9e0d0c192a4
   React-cxxreact: 81b1bfa305b1b759cc0fe18327644816216e5993
   React-debug: 234fddb309822e13b9b442ef1bdca8d2b8c3cbf2
@@ -3085,9 +3085,9 @@ SPEC CHECKSUMS:
   React-logger: d0632d799fbd3507cdd5406f72489a83ed5f9163
   React-Mapbuffer: 274cb203819492f7fb594bbb3a1f3f5061fa794d
   React-microtasksnativemodule: 563b4dcc8b8570814d6de4fc1196f48d2944acd4
-  react-native-executorch: c2ee5d2a9c6b7923585dc97ee63eb6f6b0558763
+  react-native-executorch: 27327ea825548e6ca831e57121d625f4bcb95a5c
   react-native-image-picker: 48d850454b4a389753053e1d7378b624d3b47d77
-  react-native-keyboard-controller: 6b4bc1ef1ad46ace3842f49ed03815a96a99b139
+  react-native-keyboard-controller: 915bcea56ada061f1c7d4b50162be64cb1cad9dc
   react-native-netinfo: f852c868bf5175e46165c7e4db48a204a95c3800
   react-native-safe-area-context: 37e680fc4cace3c0030ee46e8987d24f5d3bdab2
   react-native-webview: 3e303e80cadb5f17118c8c1502aa398e9287e415
@@ -3124,17 +3124,17 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 2b19d66e5ddfe8dc7afb6338a4626156cbf2bab1
   ReactCodegen: 43f0948182edee9407c7b977fb059455dfeb9361
   ReactCommon: c6e81cc1ae185fa84863f3ea1d58caac4be741d7
-  ReactNativeDependencies: a2f9f20c34689c0ea681da2ef0e17aed80df81cb
+  ReactNativeDependencies: be0d00208378743c177f0a12200d55703ba31856
   ReactNativeEnrichedMarkdown: 27a73f8df1bc304c35b7bd922c9885a4dfec3dc5
   ReactNativeFs: f2b571997aa8d6397850a6477e1c8f5823171e50
   RNAudioAPI: a2a67b86dbd376f391252f0e249aec34a6e1ae92
   RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
   RNDeviceInfo: 4c852998208b60dc192ae3529e5867817719ad1e
   RNGestureHandler: 0ea8153746a92b3744d4eaadade647debedf646e
-  RNReanimated: 992be09c2cb476a7ce23a4a71c865cc3a457b2e2
+  RNReanimated: b18b6df8643fd7a36791c908ba4900dad5ae2600
   RNScreens: 02e62f995ceb94ea465864b3bf4d4767b87f0362
   RNSVG: 0bd149b873018bc6e0e3321e2f6435bdba294460
-  RNWorklets: 9e58fb4eb675a5e582cb38aee96698ae86e905c9
+  RNWorklets: 8aae0363b180f9478a6269a1ea3522bdff6fac26
   SDWebImage: 1bb6a1b84b6fe87b972a102bdc77dd589df33477
   SDWebImageAVIFCoder: afe194a084e851f70228e4be35ef651df0fc5c57
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c

--- a/store/chatStore.ts
+++ b/store/chatStore.ts
@@ -25,6 +25,7 @@ interface ChatStore {
   chats: Chat[];
   db: SQLiteDatabase | null;
   phantomChat: Chat | null;
+  phantomChatStarts: number;
   setDB: (db: SQLiteDatabase) => void;
   loadChats: () => Promise<void>;
   updateLastUsed: (id: number) => void;
@@ -46,6 +47,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   chats: [],
   db: null,
   phantomChat: null,
+  phantomChatStarts: 0,
 
   setDB: (db) => {
     set({ db });
@@ -75,7 +77,8 @@ export const useChatStore = create<ChatStore>((set, get) => ({
 
     useWebSearchStore.getState().clearEnabled(phantomChatId);
 
-    set({
+    set((state) => ({
+      phantomChatStarts: state.phantomChatStarts + 1,
       phantomChat: {
         id: phantomChatId,
         title: '',
@@ -87,7 +90,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
           systemPrompt,
         },
       },
-    });
+    }));
   },
 
   setPhantomChatSettings: async (newSettings) => {

--- a/store/chatStore.ts
+++ b/store/chatStore.ts
@@ -26,6 +26,7 @@ interface ChatStore {
   db: SQLiteDatabase | null;
   phantomChat: Chat | null;
   phantomChatStarts: number;
+  startBlankChat: () => void;
   setDB: (db: SQLiteDatabase) => void;
   loadChats: () => Promise<void>;
   updateLastUsed: (id: number) => void;
@@ -48,6 +49,9 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   db: null,
   phantomChat: null,
   phantomChatStarts: 0,
+
+  startBlankChat: () =>
+    set((state) => ({ phantomChatStarts: state.phantomChatStarts + 1 })),
 
   setDB: (db) => {
     set({ db });

--- a/store/llmStore.ts
+++ b/store/llmStore.ts
@@ -1314,7 +1314,8 @@ export const useLLMStore = create<LLMStore>((set, get) => ({
           effectiveSeen,
           humanizedResponse,
           preferredSourceDocuments ?? [],
-          sourcesPresentInContext(effectiveContent)
+          sourcesPresentInContext(effectiveContent),
+          currentQuestion
         );
         const groundingCaveats = context.some((chunk) => chunk.trim())
           ? detectGroundingCaveats(

--- a/store/llmStore.ts
+++ b/store/llmStore.ts
@@ -1375,8 +1375,10 @@ export const useLLMStore = create<LLMStore>((set, get) => ({
           });
         }
       } else if (stillOurs()) {
+        const wasInterrupted = !get().isGenerating && !get().isProcessingPrompt;
         markGenerationFailed(new Error(describeGenerationFailure()), {
           unload: false,
+          showToUser: !wasInterrupted,
         });
       }
     } catch (e) {

--- a/utils/messageSources.ts
+++ b/utils/messageSources.ts
@@ -153,6 +153,25 @@ export const looksLikeNoAnswer = (visibleReply: string): boolean =>
     pattern.test(visibleReply)
   );
 
+const carriesAFigureTheQuestionDidNot = (
+  visibleReply: string,
+  question: string
+): boolean => {
+  const asked = numericEvidence(question);
+  for (const value of numericEvidence(visibleReply)) {
+    if (!asked.has(value)) return true;
+  }
+  return false;
+};
+
+export const answeredNothing = (answer: string, question = ''): boolean => {
+  const visible = visibleAnswer(answer);
+  return (
+    looksLikeNoAnswer(visible) &&
+    !carriesAFigureTheQuestionDidNot(visible, question)
+  );
+};
+
 export const answerCitationOverlaps = (
   sourceDocuments: SourceDocument[],
   answer: string
@@ -360,7 +379,8 @@ export const pickCitationsByAnswer = (
   sourceDocuments: SourceDocument[],
   answer: string,
   preferred: SourceDocument[],
-  presentNames?: Set<string>
+  presentNames?: Set<string>,
+  question?: string
 ): SourceDocument[] => {
   const webDocuments = sourceDocuments.filter(
     (doc) => sourceKind(doc) === 'web'
@@ -371,23 +391,25 @@ export const pickCitationsByAnswer = (
   const citedLocal = pickLocalCitationsByAnswer(
     localDocuments,
     answer,
-    preferred
+    preferred,
+    question
   );
   return [
     ...citedLocal,
-    ...flagUsedWebDocuments(webDocuments, answer, presentNames),
+    ...flagUsedWebDocuments(webDocuments, answer, presentNames, question),
   ];
 };
 
 const flagUsedWebDocuments = (
   webDocuments: SourceDocument[],
   answer: string,
-  presentNames?: Set<string>
+  presentNames?: Set<string>,
+  question?: string
 ): SourceDocument[] => {
   if (webDocuments.length === 0) return webDocuments;
 
   const answerTerms = answerTermsOf(answer);
-  if (answerTerms.size === 0 || looksLikeNoAnswer(visibleAnswer(answer))) {
+  if (answerTerms.size === 0 || answeredNothing(answer, question)) {
     return webDocuments.map((doc) => ({ ...doc, used: false }));
   }
 
@@ -414,9 +436,10 @@ const flagUsedWebDocuments = (
 const pickLocalCitationsByAnswer = (
   sourceDocuments: SourceDocument[],
   answer: string,
-  preferred: SourceDocument[]
+  preferred: SourceDocument[],
+  question?: string
 ): SourceDocument[] => {
-  if (looksLikeNoAnswer(visibleAnswer(answer))) {
+  if (answeredNothing(answer, question)) {
     return [];
   }
 
@@ -587,17 +610,22 @@ const SENTENCE_OPENING = /(?:^|[.!?…:\n])[\s"'„«»()[\]—–-]*$/u;
 const opensSentence = (text: string, at: number): boolean =>
   SENTENCE_OPENING.test(text.slice(Math.max(0, at - 24), at));
 
-export const distinctiveEvidence = (text: string): Set<string> => {
+const numericEvidence = (text: string): Set<string> => {
   const found = new Set<string>();
   if (!text) return found;
-  const ascii = toAsciiDigits(text);
-  for (const match of ascii.match(NUMBER_RUN) ?? []) {
+  for (const match of toAsciiDigits(text).match(NUMBER_RUN) ?? []) {
     const value = match.replace(/[.,:]+$/, '');
     if (value.length < 2) continue;
     found.add(value);
     const grouped = separatorFreeFigure(value);
     if (grouped) found.add(grouped);
   }
+  return found;
+};
+
+export const distinctiveEvidence = (text: string): Set<string> => {
+  const found = numericEvidence(text);
+  if (!text) return found;
   for (const match of text.matchAll(NAME_RUN)) {
     if (opensSentence(text, match.index ?? 0)) continue;
     found.add(foldForMatching(match[0]));

--- a/utils/queryTerms.ts
+++ b/utils/queryTerms.ts
@@ -583,6 +583,7 @@ const LETTER_RANGES = [
   '\\u0590-\\u05ff', // Hebrew
   '\\u0600-\\u06ff', // Arabic
   '\\u0900-\\u097f', // Devanagari
+  '\\u0980-\\u09ff', // Bengali
   '\\u0e00-\\u0e7f', // Thai
   '\\u3040-\\u30ff', // Hiragana + Katakana
   '\\u3400-\\u4dbf\\u4e00-\\u9fff', // CJK ideographs
@@ -591,7 +592,8 @@ const LETTER_RANGES = [
 
 const MIN_TERM_LENGTH = 3;
 
-const SHORT_WORD_SCRIPT = /[\p{Script=Arabic}\p{Script=Devanagari}]/u;
+const SHORT_WORD_SCRIPT =
+  /[\p{Script=Arabic}\p{Script=Devanagari}\p{Script=Bengali}]/u;
 const isLongEnough = (token: string): boolean =>
   token.length >= MIN_TERM_LENGTH ||
   (token.length === 2 && SHORT_WORD_SCRIPT.test(token));

--- a/utils/startPhantomChat.ts
+++ b/utils/startPhantomChat.ts
@@ -9,6 +9,39 @@ import { getLastUsedModelId, setLastUsedModelId } from './lastUsedModel';
 
 type NavMode = 'push' | 'replace';
 
+type NavTarget = {
+  readonly pathname: string;
+  readonly params: { readonly modelId: string };
+};
+
+const NAV_SETTLE_MS = 50;
+
+let pendingReplace: {
+  timer: ReturnType<typeof setTimeout>;
+  abandon: () => void;
+} | null = null;
+
+const replaceWhenNavSettles = (
+  target: NavTarget,
+  isStillWanted: () => boolean
+): Promise<void> =>
+  new Promise<void>((resolve) => {
+    pendingReplace?.abandon();
+    const timer = setTimeout(() => {
+      pendingReplace = null;
+      if (isStillWanted()) router.replace(target);
+      resolve();
+    }, NAV_SETTLE_MS);
+    pendingReplace = {
+      timer,
+      abandon: () => {
+        clearTimeout(timer);
+        pendingReplace = null;
+        resolve();
+      },
+    };
+  });
+
 export const startPhantomChat = async (
   db: SQLiteDatabase,
   mode: NavMode = 'push',
@@ -42,8 +75,10 @@ export const startPhantomChat = async (
   } as const;
 
   if (mode === 'replace') {
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    router.replace(target);
+    await replaceWhenNavSettles(
+      target,
+      () => useChatStore.getState().phantomChat?.id === nextChatId
+    );
   } else {
     router.push(target);
   }

--- a/utils/web/buildSearchQuery.ts
+++ b/utils/web/buildSearchQuery.ts
@@ -592,9 +592,6 @@ const digestDescribesConversation = (
   return false;
 };
 
-const CONVERSATIONAL_INTENT_MARKERS =
-  /\b(greet\w*|hello|hi there|thank\w*|chit.?chat|small talk|casual|opinion|advice|\bmath\b|coding|programming|\bcode\b|translat\w*|rewrit\w*|paraphras\w*|creative writing|\bpoem\w*|poetry|\bstory\b|\bjoke\w*|recipe idea|general knowledge|timeless|recap|summar\w*|conversation|chat history|(?:previous|earlier|last|first) (?:answer|reply|message|response)s?)\b/i;
-
 const CODE_TOKEN =
   /(?<![\p{L}\p{N}])(?=[\p{L}\p{N}-]*\p{N})(?=[\p{L}\p{N}-]*\p{L})[\p{L}\p{N}-]{3,}(?![\p{L}\p{N}])/u;
 const LONG_NUMBER = /(?<![\p{L}\p{N}])\p{N}{3,}(?![\p{L}\p{N}])/u;
@@ -602,8 +599,8 @@ const LONG_NUMBER = /(?<![\p{L}\p{N}])\p{N}{3,}(?![\p{L}\p{N}])/u;
 export const hasHardSearchSignal = (query: string): boolean =>
   CODE_TOKEN.test(query) || LONG_NUMBER.test(query);
 
-export const isConversationalIntent = (intent: string): boolean =>
-  !!intent.trim() && CONVERSATIONAL_INTENT_MARKERS.test(intent);
+export const isConversationalPlan = (plan: { kind?: WebIntentKind }): boolean =>
+  plan.kind === 'chat';
 
 const buildConversation = (
   history: { role: string; content: string }[],
@@ -733,8 +730,13 @@ export const planWebSearch = async (
   if (!parsed) return verbatim();
   if (!parsed.needsSearch) {
     if (hasHardSearchSignal(query)) return verbatim(parsed.intent, parsed.kind);
-    return isConversationalIntent(parsed.intent)
-      ? { needsSearch: false, intent: parsed.intent, queries: [] }
+    return isConversationalPlan(parsed)
+      ? {
+          needsSearch: false,
+          intent: parsed.intent,
+          kind: parsed.kind,
+          queries: [],
+        }
       : verbatim(parsed.intent);
   }
 


### PR DESCRIPTION
Three commits, three separate concerns. Reviewable commit by commit; say the word and the middle one moves to its own PR.

## 1. `refactor(chat)` — two concerns leave ChatBar

`ChatBar` had grown to 658 lines holding six unrelated concerns, of which about a hundred were the bar itself. Two come out as hooks, which is what the neighbouring files already do (`useKeyboardLift`, `useChatScreenActions`). The JSX stays whole on purpose: splitting a single composer into sub-components would only move state through props.

**`useEmbeddingDownloadPrompt`** is the one worth taking first. Four bugs have already landed in it — the sheet resuming a document pick nobody asked for, the prompt firing after the screen had refused the toggle, the web copy surviving into a later document flow, and a status read racing the store's own start — and until now it could only be tested by rendering the whole `ChatBar`, whose suite is 1004 lines and 53 cases. It now has 13 of its own, and **each of those four fixes fails one of them when reverted**.

**`useBarGrowth`** takes the three height refs and the layout handler. It is the most self-contained block in the file: nothing else reads those refs, and the caller now states the condition the baseline depends on (`isResting`) instead of the handler recomputing it from input and attachment state.

No behaviour change. ChatBar 658 → 561 lines.

## 2. `feat(web)` — a declined search is trusted only when the plan names its kind

This one **does** change behaviour.

`isConversationalIntent` matched a 25-alternative English word list against the planner's free-text `intent` — `greet`, `chit-chat`, `poem`, `math`, `translat`, `recap`. That list decides whether a `needs_search: false` plan is honoured or overridden. A model that labelled its refusal in any other words, or in the user's own language, was read as a real question and searched anyway; a model that happened to hit one of the words was believed.

The contract already carries the answer. `PLANNER_SYSTEM_PROMPT` asks for a `kind` from a closed twelve-value list whose `chat` member means "no search", and `parseIntentKind` already validates it. The predicate now reads that field and nothing else, so it behaves identically whatever language the question was in and however the model phrased its intent.

An unlabelled refusal is no longer trusted: it falls through to a verbatim search, which matches the prompt's own stated bias that a search is cheap and a confident stale answer is not. Three fixtures written before `kind` existed now carry it, and a new test pins the unlabelled case.

## 3. `build(ios)` — Podfile.lock back to what the manifest pins

The stack carries a `Podfile.lock` regenerated against stale `node_modules`, downgrading three pods below what `package.json` and `yarn.lock` pin: `react-native-keyboard-controller` 1.22.3 → 1.21.1, `RNReanimated` 4.3.1 → 4.3.0, `RNWorklets` 0.8.3 → 0.8.1. It entered on the intent-MVP branch and every branch stacked on it inherited the file. No pod was added or removed, so the downgrade carried no information any branch needed. Fixed at the source on `feat/web-search-intent-mvp` and here, so the two agree and a later rebase has nothing to resolve.

## Tests

`tsc --noEmit` clean; `jest` 136 suites / 2340 tests green; eslint clean on every touched file.

Not verified on a device: the refactor claims no behaviour change on the strength of the suite alone, and the composer is the most-touched surface in the app.
