### PR TITLE
chore(release): 1.3.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,8 +99,8 @@ android {
         applicationId 'com.swmansion.privatemind'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 68
-        versionName "1.2.1"
+        versionCode 69
+        versionName "1.3.0"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "scheme": "private-mind",
     "name": "Private Mind",
     "slug": "private-mind",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "orientation": "portrait",
     "icon": "./assets/icons/icon.png",
     "userInterfaceStyle": "automatic",

--- a/constants/latest-release.ts
+++ b/constants/latest-release.ts
@@ -1,11 +1,11 @@
 export const LATEST_RELEASE = {
-  version: '1.2.1',
-  title: 'Documents, forking and speed',
+  version: '1.3.0',
+  title: 'Web search, with sources',
   highlights: [
-    'Chat with your documents, with source citations',
-    'Fork conversations, save prompt presets',
-    'Faster sending, opening and model switching',
-    'Only models your device can run are offered',
-    'Response-speed stats are now optional',
+    'Answer from the web, with a Web toggle per chat',
+    'See every source an answer used, and open it',
+    'Expand the trace to see what was searched',
+    'Pages are fetched and read on your device',
+    'New models appear without an app update',
   ],
 };

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -37,6 +37,13 @@ defaultConfig {
 
 The build number should be set in `info` and `general` sections in Xcode, ensure the version matches `app.json`.
 
+Xcode writes two files at once, and both are required:
+
+- **[ios/PrivateMind/Info.plist](../ios/PrivateMind/Info.plist)** — `CFBundleShortVersionString` (match `app.json`) and `CFBundleVersion` (increment by 1). These are literal values, not `$(MARKETING_VERSION)` references, and they are what the built app reports.
+- **[ios/PrivateMind.xcodeproj/project.pbxproj](../ios/PrivateMind.xcodeproj/project.pbxproj)** — `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION`, twice each (Debug and Release).
+
+Editing only `project.pbxproj` produces a build that still reports the previous version.
+
 ## Platform-Specific Release Instructions
 
 ### Android Release

--- a/ios/PrivateMind.xcodeproj/project.pbxproj
+++ b/ios/PrivateMind.xcodeproj/project.pbxproj
@@ -399,7 +399,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = PrivateMind/PrivateMind.entitlements;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = J5FM626PE2;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.3.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -441,7 +441,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = PrivateMind/PrivateMind.entitlements;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = J5FM626PE2;
 				INFOPLIST_FILE = PrivateMind/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Private Mind";
@@ -451,7 +451,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.3.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/ios/PrivateMind/Info.plist
+++ b/ios/PrivateMind/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.1</string>
+	<string>1.3.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -33,7 +33,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>12.0</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
Version bump only. One commit, three files, no source changes.

`main` still declares `1.2.1`, the version already on the stores, so a build cut today would ship web search under a released version string. Minor rather than patch, since web search is a new user-facing feature.

All three locations from `docs/RELEASE.md`:

- `app.json` — `1.2.1` → `1.3.0`
- `android/app/build.gradle` — `versionCode` 68 → 69, `versionName` `1.2.1` → `1.3.0`
- `ios/PrivateMind.xcodeproj/project.pbxproj` — `MARKETING_VERSION` `1.2.1` → `1.3.0`, `CURRENT_PROJECT_VERSION` 4 → 5

The pod-lockfile fix that previously shared this branch now lives in #322. The two touch disjoint files and can merge in either order.

## This does not make `main` releasable

Still outstanding, and not addressed here:

- **The `cr/phase1-security` work is not on `main`.** 121 files, +6991/−1352 — the code-review fixes, the ECB conversion resolver, the capability floor, the digest fix and the URL-scheme check. `#320` merged as a squash, so the branch cannot be merged directly (72 conflicting files); the content has to be ported onto `main` as a tree copy instead.
- **Three call sites open a source URL with no scheme check** — `SourceRow.tsx:67`, `WebSearchBlock.tsx:103`, `DominantSourceBadge.tsx:19`. The markdown link handler in `MessageItem.tsx:128` is guarded; these are not.
- **Three web-search defects found on a physical Pixel 10** against the shipped `main` code: conflicting sources on the same date send the model into a reasoning loop that ends with no answer and no error; offline answers state a fabricated figure and cannot carry a grounding caveat, because caveats are disabled when the context is empty; a currency-conversion follow-up returns the original currency despite retrieval finding the right pages.
