### PR TITLE
fix(ios): restore the pod versions that carry the scroll-worklet crash fix

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1637,7 +1637,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-keyboard-controller (1.21.1):
+  - react-native-keyboard-controller (1.22.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1649,7 +1649,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-keyboard-controller/common (= 1.21.1)
+    - react-native-keyboard-controller/common (= 1.22.3)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -1660,7 +1660,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-keyboard-controller/common (1.21.1):
+  - react-native-keyboard-controller/common (1.22.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2384,7 +2384,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNReanimated (4.3.0):
+  - RNReanimated (4.3.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2406,11 +2406,11 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNReanimated/apple (= 4.3.0)
-    - RNReanimated/common (= 4.3.0)
+    - RNReanimated/apple (= 4.3.1)
+    - RNReanimated/common (= 4.3.1)
     - RNWorklets
     - Yoga
-  - RNReanimated/apple (4.3.0):
+  - RNReanimated/apple (4.3.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2434,7 +2434,7 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNReanimated/common (4.3.0):
+  - RNReanimated/common (4.3.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2550,7 +2550,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets (0.8.1):
+  - RNWorklets (0.8.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2572,10 +2572,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNWorklets/apple (= 0.8.1)
-    - RNWorklets/common (= 0.8.1)
+    - RNWorklets/apple (= 0.8.3)
+    - RNWorklets/common (= 0.8.3)
     - Yoga
-  - RNWorklets/apple (0.8.1):
+  - RNWorklets/apple (0.8.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2598,7 +2598,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets/common (0.8.1):
+  - RNWorklets/common (0.8.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3039,14 +3039,14 @@ SPEC CHECKSUMS:
   ExpoSymbols: 896159288ad708e1a32dc12c92fe5f90bff01126
   ExpoWebBrowser: b10b2e9f3552fe1c75aa2fa518f78ce8b213c439
   FBLazyVector: 061f518bbd81677ed8a8317e2ae60b8779495808
-  hermes-engine: 2f0d004f7ea59a531ab9a9087cf8663d386d3706
+  hermes-engine: 3001abebdc517c4409c390b10de5b777e0d41682
   iosMath: f7a6cbadf9d836d2149c2a84c435b1effc244cba
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   op-sqlite: 10397885c9f2d478a9d099d20e2a7915c5fda944
   opencv-rne: 2305807573b6e29c8c87e3416ab096d09047a7a0
-  Pdfium: f800387e18744bb2aa3a8054ee6d2f6c84e5e3fd
+  Pdfium: 4647abf0f19fd35adb7898911b72f59f31a74b69
   Pulsar: 9ec19a182a03d08ecefb47877e8de9e976c2a03c
   Pulsar-haptics: f795eaf55d8d0290148fd97c747dcc6689c3d079
   RCTDeprecation: 5045f20b2cc1239bf422764004338c720684a22f
@@ -3057,7 +3057,7 @@ SPEC CHECKSUMS:
   React: 3e14066ac707b3e369d09e2e923d8bee7f8c33ff
   React-callinvoker: bd7959a24564feaf5e4c8c11789e64884da13482
   React-Core: f060f4e14e9301685ce63ea65fbe903bf3397e45
-  React-Core-prebuilt: 3a1e334c56ae9652c0b9227176fe068e388bcea8
+  React-Core-prebuilt: 26830ab8901f602c7bf4e0331624831aae88c345
   React-CoreModules: 89a1a544297be88ca4cdff317423f9e0d0c192a4
   React-cxxreact: 81b1bfa305b1b759cc0fe18327644816216e5993
   React-debug: 234fddb309822e13b9b442ef1bdca8d2b8c3cbf2
@@ -3085,9 +3085,9 @@ SPEC CHECKSUMS:
   React-logger: d0632d799fbd3507cdd5406f72489a83ed5f9163
   React-Mapbuffer: 274cb203819492f7fb594bbb3a1f3f5061fa794d
   React-microtasksnativemodule: 563b4dcc8b8570814d6de4fc1196f48d2944acd4
-  react-native-executorch: c2ee5d2a9c6b7923585dc97ee63eb6f6b0558763
+  react-native-executorch: 27327ea825548e6ca831e57121d625f4bcb95a5c
   react-native-image-picker: 48d850454b4a389753053e1d7378b624d3b47d77
-  react-native-keyboard-controller: 6b4bc1ef1ad46ace3842f49ed03815a96a99b139
+  react-native-keyboard-controller: 915bcea56ada061f1c7d4b50162be64cb1cad9dc
   react-native-netinfo: f852c868bf5175e46165c7e4db48a204a95c3800
   react-native-safe-area-context: 37e680fc4cace3c0030ee46e8987d24f5d3bdab2
   react-native-webview: 3e303e80cadb5f17118c8c1502aa398e9287e415
@@ -3124,17 +3124,17 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 2b19d66e5ddfe8dc7afb6338a4626156cbf2bab1
   ReactCodegen: 43f0948182edee9407c7b977fb059455dfeb9361
   ReactCommon: c6e81cc1ae185fa84863f3ea1d58caac4be741d7
-  ReactNativeDependencies: a2f9f20c34689c0ea681da2ef0e17aed80df81cb
+  ReactNativeDependencies: be0d00208378743c177f0a12200d55703ba31856
   ReactNativeEnrichedMarkdown: 27a73f8df1bc304c35b7bd922c9885a4dfec3dc5
   ReactNativeFs: f2b571997aa8d6397850a6477e1c8f5823171e50
   RNAudioAPI: a2a67b86dbd376f391252f0e249aec34a6e1ae92
   RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
   RNDeviceInfo: 4c852998208b60dc192ae3529e5867817719ad1e
   RNGestureHandler: 0ea8153746a92b3744d4eaadade647debedf646e
-  RNReanimated: 992be09c2cb476a7ce23a4a71c865cc3a457b2e2
+  RNReanimated: b18b6df8643fd7a36791c908ba4900dad5ae2600
   RNScreens: 02e62f995ceb94ea465864b3bf4d4767b87f0362
   RNSVG: 0bd149b873018bc6e0e3321e2f6435bdba294460
-  RNWorklets: 9e58fb4eb675a5e582cb38aee96698ae86e905c9
+  RNWorklets: 8aae0363b180f9478a6269a1ea3522bdff6fac26
   SDWebImage: 1bb6a1b84b6fe87b972a102bdc77dd589df33477
   SDWebImageAVIFCoder: afe194a084e851f70228e4be35ef651df0fc5c57
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c


### PR DESCRIPTION
`main` currently ships an iOS lockfile that undoes the crash fix from #291.

#291 bumped `react-native-keyboard-controller` 1.21.1 → 1.22.3 to fix the SIGABRT that closed the app when switching between model variants. The web search merge (#320) brought a `Podfile.lock` generated against stale `node_modules`, which pinned the pre-fix versions back:

| pod | package.json | ios/Podfile.lock on main |
| --- | --- | --- |
| react-native-keyboard-controller | 1.22.3 | **1.21.1** |
| react-native-reanimated | 4.3.1 | **4.3.0** |
| react-native-worklets | 0.8.3 | **0.8.1** |

An iOS build cut from `main` today installs the version the crash fix replaced.

The lockfile is taken verbatim from `cr/phase1-security`, where the same restore already lives. The two files differ only in these version lines and the `hermes-engine` / `Pdfium` checksums that follow from them — 21 changed lines, one file, no source changes.

Split out of #321 so the crash fix can land independently of the version bump; the two branches touch disjoint files and can merge in either order.
